### PR TITLE
little typo fix for \gt

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -214,7 +214,7 @@ LatexCmds.asymp = LatexCmds.approx = bind(BinaryOperator,'\\approx ','&asymp;');
 
 LatexCmds.lt = bind(BinaryOperator,'<','&lt;');
 
-LatexCmds.gt = bind(BinaryOperator,'<','&gt;');
+LatexCmds.gt = bind(BinaryOperator,'>','&gt;');
 
 LatexCmds.le = LatexCmds.leq = bind(BinaryOperator,'\\le ','&le;');
 


### PR DESCRIPTION
this fixes a typo that was causing \gt to call < instead of > (the rendered html was ok, but the underlying representation was wrong)
