### PR TITLE
Fixed textInput() getting confused when quick typing

### DIFF
--- a/src/rootelements.js
+++ b/src/rootelements.js
@@ -52,7 +52,12 @@ function createRoot(jQ, root, textbox, editable) {
     var text = textarea.val();
     if (!text) return;
     textarea.val('');
-    cursor.parent.textInput(text);
+    // textarea can contain more than one character
+    // when typing quickly on slower platforms;
+    // so process each character separately
+    for (var i=0; i<text.length; i++) {
+        cursor.parent.textInput(text[i]);
+    }
   }
 
   var lastKeydn = {}; //see Wiki page "Keyboard Events"


### PR DESCRIPTION
This pull requests implements a fix for issue #30, see discussion there.
