### PR TITLE
more complete medium space (\:) support

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -554,7 +554,7 @@ _.keydown = function(e) {
   return this.parent.keydown(e);
 };
 _.textInput = function(ch) {
-  if (ch.match(/[a-z]/i)) {
+  if (ch.match(/[a-z:]/i)) {
     this.cursor.deleteSelection();
     this.cursor.insertNew(new VanillaSymbol(ch));
     return;

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -188,7 +188,7 @@ _.seek = function(target, pageX, pageY) {
 };
 _.writeLatex = function(latex) {
   this.deleteSelection();
-  latex = ( latex && latex.match(/\\text\{([^}]|\\\})*\}|\\[a-z]*|[^\s]/ig) ) || 0;
+  latex = ( latex && latex.match(/\\text\{([^}]|\\\})*\}|\\:|\\[a-z]*|[^\s]/ig) ) || 0;
   (function writeLatexBlock(cursor) {
     while (latex.length) {
       var token = latex.shift(); //pop first item
@@ -213,7 +213,7 @@ _.writeLatex = function(latex) {
         else //was an open-paren, hack to put the following latex
           latex.unshift('{'); //in the ParenBlock in the math DOM
       }
-      else if (/^\\[a-z]+$/i.test(token)) {
+      else if (/^\\[a-z:]+$/i.test(token)) {
         token = token.slice(1);
         var cmd = LatexCmds[token];
         if (cmd)

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -24,7 +24,7 @@ function VanillaSymbol(ch, html) {
 }
 VanillaSymbol.prototype = Symbol.prototype;
 
-CharCmds[' '] = bind(VanillaSymbol, '\\:', ' ');
+LatexCmds[':'] = CharCmds[' '] = bind(VanillaSymbol, '\\:', ' ');
 
 LatexCmds.prime = CharCmds["'"] = bind(VanillaSymbol, "'", '&prime;');
 


### PR DESCRIPTION
this change makes it so you can:
1. type \: and get a medium space (as a bare " " gives you now)
2. give mathquill latex with \: in it and have it render it correctly. previously it would display as "\:" instead of " ", since it wasn't a recognized command. this was annoying, as mathquill was unable to render latex it had previously generated

it seems like other whitespace commands could be implemented in a similar fashion. if there's a better approach, let me know.
