### PR TITLE
Fixes #65. Fixing android browser bug for backspace event. 

### DIFF
--- a/src/rootelements.js
+++ b/src/rootelements.js
@@ -275,7 +275,7 @@ _.renderLatex = function(latex) {
 _.keydown = function(e)
 {
   e.ctrlKey = e.ctrlKey || e.metaKey;
-  switch ((e.originalEvent && e.originalEvent.keyIdentifier) || e.which) {
+  switch (e.which) {
   case 8: //backspace
   case 'Backspace':
   case 'U+0008':
@@ -314,6 +314,7 @@ _.keydown = function(e)
     this.cursor.clearSelection();
     break;
   case 13: //enter
+  case 10: //iPhone safari enter.
   case 'Enter':
     break;
   case 35: //end


### PR DESCRIPTION
It does so by using only e.which for events, and having a special case for the iPhone which send
e.which = 10 for ENTER (instead of 13).
