### PR TITLE
minor change in order to be able to pass jslint

### DIFF
--- a/src/symbols.js
+++ b/src/symbols.js
@@ -269,7 +269,7 @@ BigSymbol.prototype = new Symbol; //so instanceof will work
 LatexCmds['∑'] = LatexCmds.sum = LatexCmds.summation = bind(BigSymbol,'\\sum ','&sum;');
 LatexCmds['∏'] = LatexCmds.prod = LatexCmds.product = bind(BigSymbol,'\\prod ','&prod;');
 LatexCmds.coprod = LatexCmds.coproduct = bind(BigSymbol,'\\coprod ','&#8720;');
-LatexCmds['∫'] = LatexCmds.int = LatexCmds.integral = bind(BigSymbol,'\\int ','&int;');
+LatexCmds['∫'] = LatexCmds['int'] = LatexCmds.integral = bind(BigSymbol,'\\int ','&int;');
 
 
 


### PR DESCRIPTION
jslint will choke on something line foo.int because `int` is 
a reserved future keyword. this little change just makes it 
so mathquill passes jslint
