### PR TITLE
`MathBlock::join()`

### DIFF
--- a/src/baseclasses.js
+++ b/src/baseclasses.js
@@ -215,9 +215,8 @@ var MathBlock = P(MathElement, function(_) {
   _.text = function() {
     return this.firstChild === this.lastChild ?
       this.firstChild.text() :
-      this.foldChildren('(', function(text, child) {
-        return text + child.text();
-      }) + ')';
+      '(' + this.join('text') + ')'
+    ;
   };
   _.isEmpty = function() {
     return this.firstChild === 0 && this.lastChild === 0;


### PR DESCRIPTION
This refactors common pattern on `MathBlock`s in math exports.

My intention is for this to become like `bubble`, and for `.latex()`, `.html()` to go the way of `.keydown()`, `.textInput()`, i.e. to completely replace all calls to `MathBlock::latex()` with `.join('latex')`.
