### PR TITLE
Refactor LaTeX parsers' names

### DIFF
--- a/src/latex.js
+++ b/src/latex.js
@@ -1,8 +1,8 @@
 // Parser MathCommand
-var VariableParser = LetterParser.then(Variable);
-var SymbolParser = CharParser(/[^{}]/).then(VanillaSymbol);
+var VariableParser = Parser('VariableParser').is(LetterParser).then(Variable);
+var SymbolParser = Parser('SymbolParser').is(CharParser(/[^{}]/)).then(VanillaSymbol);
 
-var SupSubParser = CharParser(/[_^]/).then(function(ch) {
+var SupSubParser = Parser('SupSubParser').is(CharParser(/[_^]/)).then(function(ch) {
   var cmd = LatexCmds[ch]();
 
   return BlockParser.then(function(block) {
@@ -12,8 +12,8 @@ var SupSubParser = CharParser(/[_^]/).then(function(ch) {
   });
 });
 
-var ControlSequenceParser =
-  CharParser('\\').then(
+var ControlSequenceParser = Parser('ControlSequenceParser')
+  .is(CharParser('\\')).then(
     LetterParser.many().after(WhiteSpaceParser)
     .or(WhiteSpaceParser.then(' '))
     .or(CharParser())
@@ -31,19 +31,19 @@ var ControlSequenceParser =
   })
 ;
 
-var CommandParser =
-  ControlSequenceParser
+var CommandParser = Parser('CommandParser')
+  .is(ControlSequenceParser)
   .or(SupSubParser)
   .or(VariableParser)
   .or(SymbolParser)
 ;
 
 // Parser [MathCommand]
-var GroupParser = CharParser('{').then(CommandParser.many()).after(CharParser('}'));
+var GroupParser = Parser('GroupParser').is(CharParser('{')).then(CommandParser.many()).after(CharParser('}'));
 
 // Parser MathBlock
-var BlockParser =
-  GroupParser
+var BlockParser = Parser('BlockParser')
+  .is(GroupParser)
   .or(CommandParser.then(function(x) { return [x]; }))
   .then(function(commands) {
     var block = MathBlock();
@@ -56,7 +56,7 @@ var BlockParser =
   })
 ;
 
-var RootParser = CommandParser.many().then(function(commands) {
+var RootParser = Parser('RootParser').is(CommandParser).many().then(function(commands) {
   var block = MathBlock();
 
   for (var i = 0; i < commands.length; i += 1) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -16,12 +16,14 @@ var Parser = P(function(_) {
   function ensureParser(x) {
     if (x instanceof Parser) return x;
 
-    return Parser(function(stream, success) {
+    return Parser('EnsuredParser', function(stream, success) {
       return success(stream, x);
     });
   }
 
-  _.init = function(body) { this._ = body; };
+  _.init = function(name, body) { this.name = name; this._ = body; };
+
+  _.is = function(parser) { this._ = parser._; return this; };
 
   _.parse = function(stream) {
     function success(stream, result) {
@@ -33,11 +35,11 @@ var Parser = P(function(_) {
     return this._(stream, success, parseError);
   };
 
-  // -*- primitive combinators -*- //
+  // -*- combinators -*- //
   _.or = function(two) {
     var one = this;
 
-    return Parser(function(stream, onSuccess, onFailure) {
+    return Parser(one.name, function(stream, onSuccess, onFailure) {
       return one._(stream, onSuccess, failure);
 
       function failure(newStream) {
@@ -50,7 +52,7 @@ var Parser = P(function(_) {
     var one = this;
     two = ensureFunction(two);
 
-    return Parser(function(stream, onSuccess, onFailure) {
+    return Parser(one.name, function(stream, onSuccess, onFailure) {
       return one._(stream, success, onFailure);
 
       function success(newStream, result) {
@@ -59,7 +61,6 @@ var Parser = P(function(_) {
     });
   };
 
-  // -*- higher-level combinators -*- //
   _.after = function(two) {
     var one = this;
     two = ensureFunction(two);
@@ -82,7 +83,9 @@ var Parser = P(function(_) {
   };
 });
 
-function CharParser(ch) {
+function CharParser(ch, name) {
+  if (!name) name = 'UnnamedParser :(';
+
   var cond;
   if (ch === undefined) {
     cond = function() { return true; };
@@ -97,7 +100,7 @@ function CharParser(ch) {
     cond = function(head) { return ch === head; };
   }
 
-  return Parser(function(stream, onSuccess, onFailure) {
+  return Parser(name, function(stream, onSuccess, onFailure) {
     if (!stream.length) return onFailure(stream);
 
     var head = stream.charAt(0);
@@ -110,5 +113,5 @@ function CharParser(ch) {
   });
 }
 
-var WhiteSpaceParser = CharParser(/\s/).many();
-var LetterParser = CharParser(/[a-z]/i);
+var WhiteSpaceParser = CharParser(/\s/, 'WhiteSpaceParser').many();
+var LetterParser = CharParser(/[a-z]/i, 'LetterParser');


### PR DESCRIPTION
Make `.name` essentially required on `Parser`s, defining parsers always start with `Parser('NamedParser').is(StartingParser).combinatorize(...)`
