### PR TITLE
Use Parser.string and Parser.regex instead of CharParser

### DIFF
--- a/src/latex.js
+++ b/src/latex.js
@@ -1,67 +1,76 @@
 // Parser MathCommand
-var VariableParser = LetterParser.then(Variable);
-var SymbolParser = CharParser(/[^{}]/).then(VanillaSymbol);
+var latexParser = (function() {
+  var string = Parser.string;
+  var regex = Parser.regex;
+  var letter = Parser.letter;
+  var any = Parser.any;
 
-var SupSubParser = CharParser(/[_^]/).then(function(ch) {
-  var cmd = LatexCmds[ch]();
+  var variable = letter.then(Variable);
+  var symbol = regex(/^[^{}]/).then(VanillaSymbol);
 
-  return BlockParser.then(function(block) {
-    block.adopt(cmd, 0, 0);
-
-    return cmd;
+  var supSub = regex(/^[_^]/).then(function(ch) {
+    return LatexCmds[ch]();
   });
-});
 
-var ControlSequenceParser =
-  CharParser('\\').then(
-    LetterParser.many().after(WhiteSpaceParser)
-    .or(WhiteSpaceParser.then(' '))
-    .or(CharParser())
-  ).then(function(ctrlSeq) {
-    var cmdKlass = LatexCmds[ctrlSeq];
+  var controlSequence =
+    string('\\').then(
+      regex(/^[a-z]+/i)
+      .or(regex(/^\s+/).then(' '))
+      .or(any)
+    ).then(function(ctrlSeq) {
+      var cmdKlass = LatexCmds[ctrlSeq];
 
-    if (cmdKlass) {
-      return cmdKlass(ctrlSeq);
-    }
-    else {
-      var textBlock = TextBlock();
-      textBlock.replaces(ctrlSeq);
-      return textBlock;
-    }
-  })
-;
+      if (cmdKlass) {
+        return cmdKlass(ctrlSeq);
+      }
+      else {
+        var textBlock = TextBlock();
+        textBlock.replaces(ctrlSeq);
+        return textBlock;
+      }
+    })
+  ;
 
-var CommandParser =
-  ControlSequenceParser
-  .or(SupSubParser)
-  .or(VariableParser)
-  .or(SymbolParser)
-;
+  var command =
+    controlSequence
+    .or(supSub)
+    .or(variable)
+    .or(symbol)
+  ;
 
-// Parser [MathCommand]
-var GroupParser = CharParser('{').then(CommandParser.many()).after(CharParser('}'));
+  // Parser [MathCommand]
+  var group =
+    string('{')
+    .then(command.many())
+    .after(string('}'))
+  ;
 
-// Parser MathBlock
-var BlockParser =
-  GroupParser
-  .or(CommandParser.then(function(x) { return [x]; }))
-  .then(function(commands) {
-    var block = MathBlock();
+  // Parser MathBlock
+  var block =
+    group.or(command.then(function(x) { return [x]; }))
+    .then(function(commands) {
+      var block = MathBlock();
 
-    for (var i = 0; i < commands.length; i += 1) {
-      commands[i].adopt(block, block.lastChild, 0);
-    }
+      for (var i = 0; i < commands.length; i += 1) {
+        commands[i].adopt(block, block.lastChild, 0);
+      }
 
-    return block;
-  })
-;
+      return block;
+    })
+  ;
 
-var RootParser = CommandParser.many().then(function(commands) {
-  var block = MathBlock();
+  var latex =
+    command.many().then(function(commands) {
+      var block = MathBlock();
 
-  for (var i = 0; i < commands.length; i += 1) {
-    commands[i].adopt(block, block.lastChild, 0);
-  }
+      for (var i = 0; i < commands.length; i += 1) {
+        commands[i].adopt(block, block.lastChild, 0);
+      }
 
-  return block;
-});
+      return block;
+    })
+  ;
+
+  return latex;
+
+})();

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -1,5 +1,5 @@
 suite('latex', function() {
-  function parseRoot(str) { return RootParser.parse(str); }
+  function parseRoot(str) { return latexParser.parse(str); }
 
   function assertParsesLatex(parser, str, latex) {
     if (!latex) latex = str;

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -1,21 +1,26 @@
 suite('parser', function() {
-  test('CharParser', function() {
-    var parser = CharParser('x');
+  var string = Parser.string;
+  var regex = Parser.regex;
+  var letter = Parser.letter;
+
+  test('Parser.string', function() {
+    var parser = string('x');
     assert.equal(parser.parse('x'), 'x');
     assert.throws(function() { parser.parse('y') })
   });
 
-  test('CharParser with a regex', function() {
-    var parser = CharParser(/[0-9]/);
+  test('Parser.regex', function() {
+    var parser = regex(/^[0-9]/);
 
     assert.equal(parser.parse('1'), '1');
     assert.equal(parser.parse('4'), '4');
     assert.throws(function() { parser.parse('x'); });
+    assert.throws(function() { regex(/./) }, 'must be anchored');
   });
 
   suite('then', function() {
     test('with a parser, uses the last return value', function() {
-      var parser = CharParser('x').then(CharParser('y'));
+      var parser = string('x').then(string('y'));
       assert.equal(parser.parse('xy'), 'y');
       assert.throws(function() { parser.parse('y'); });
       assert.throws(function() { parser.parse('xz'); });
@@ -24,7 +29,7 @@ suite('parser', function() {
     test('with a function, pipes the value in and uses that return value', function() {
       var piped;
 
-      var parser = CharParser('x').then(function(x) {
+      var parser = string('x').then(function(x) {
         piped = x;
         return 'y';
       });
@@ -34,8 +39,8 @@ suite('parser', function() {
     });
 
     test('with a function that returns a parser, continues with that parser', function() {
-      var parser = CharParser('x').then(function(x) {
-        return CharParser('y');
+      var parser = string('x').then(function(x) {
+        return string('y');
       });
 
       assert.equal(parser.parse('xy'), 'y');
@@ -45,14 +50,14 @@ suite('parser', function() {
 
   suite('after', function() {
     test('with a parser, uses the previous return value', function() {
-      var parser = CharParser('x').after(CharParser('y'));
+      var parser = string('x').after(string('y'));
 
       assert.equal(parser.parse('xy'), 'x');
       assert.throws(function() { parser.parse('x'); });
     });
 
     test('with a function, uses the previous return value', function() {
-      var parser = CharParser('x').after(function() { return 'y'; });
+      var parser = string('x').after(function() { return 'y'; });
 
       assert.equal(parser.parse('x'), 'x');
     });
@@ -61,9 +66,9 @@ suite('parser', function() {
          'uses the previous return value', function() {
       var piped;
 
-      var parser = CharParser('x').after(function(x) {
+      var parser = string('x').after(function(x) {
         piped = x;
-        return CharParser('y');
+        return string('y');
       });
 
       assert.equal(parser.parse('xy'), 'x');
@@ -73,7 +78,7 @@ suite('parser', function() {
 
   suite('or', function() {
     test('two parsers', function() {
-      var parser = CharParser('x').or(CharParser('y'));
+      var parser = string('x').or(string('y'));
 
       assert.equal(parser.parse('x'), 'x');
       assert.equal(parser.parse('y'), 'y');
@@ -81,10 +86,10 @@ suite('parser', function() {
     });
 
     test('with then', function() {
-      var parser = CharParser('\\')
+      var parser = string('\\')
         .then(function() {
-          return CharParser('y')
-        }).or(CharParser('z'));
+          return string('y')
+        }).or(string('z'));
 
       assert.equal(parser.parse('\\y'), 'y');
       assert.equal(parser.parse('z'), 'z');
@@ -98,7 +103,7 @@ suite('parser', function() {
 
   suite('many', function() {
     test('simple case', function() {
-      var letters = LetterParser.many();
+      var letters = letter.many();
 
       assertEqualArray(letters.parse('x'), ['x']);
       assertEqualArray(letters.parse('xyz'), ['x','y','z']);
@@ -108,7 +113,7 @@ suite('parser', function() {
     });
 
     test('followed by then', function() {
-      var parser = CharParser('x').many().then(CharParser('y'));
+      var parser = string('x').many().then(string('y'));
 
       assert.equal(parser.parse('y'), 'y');
       assert.equal(parser.parse('xy'), 'y');
@@ -118,14 +123,14 @@ suite('parser', function() {
 
   suite('times', function() {
     test('zero case', function() {
-      var zeroLetters = LetterParser.times(0);
+      var zeroLetters = letter.times(0);
 
       assertEqualArray(zeroLetters.parse(''), []);
       assert.throws(function() { zeroLetters.parse('x'); });
     });
 
     test('nonzero case', function() {
-      var threeLetters = LetterParser.times(3);
+      var threeLetters = letter.times(3);
 
       assertEqualArray(threeLetters.parse('xyz'), ['x', 'y', 'z']);
       assert.throws(function() { threeLetters.parse('xy'); });


### PR DESCRIPTION
Also I implemented `.times(n)` which repeats a parser `n` times and accumulates the results, just like `.many()`.  This could be used to parse out, for example `.numBlocks()` number of blocks after a command.
