### PR TITLE
Bugfix for iframes

### DIFF
--- a/src/rootelements.js
+++ b/src/rootelements.js
@@ -92,7 +92,7 @@ function createRoot(jQ, root, textbox, editable) {
 
       // delete the mouse handlers now that we're not dragging anymore
       jQ.unbind('mousemove', mousemove);
-      $(document).unbind('mousemove', docmousemove).unbind('mouseup', mouseup);
+      $(e.target.ownerDocument).unbind('mousemove', docmousemove).unbind('mouseup', mouseup);
     }
 
     setTimeout(function() { textarea.focus(); });
@@ -109,7 +109,7 @@ function createRoot(jQ, root, textbox, editable) {
     if (!editable) jQ.prepend(textareaSpan);
 
     jQ.mousemove(mousemove);
-    $(document).mousemove(docmousemove).mouseup(mouseup);
+    $(e.target.ownerDocument).mousemove(docmousemove).mouseup(mouseup);
 
     return false;
   });


### PR DESCRIPTION
Instead of binding mousemove and mouseup events to `document`, they are bound to `e.target.ownerDocument` so that mathquillified elements inside iframes display correct selection behavior.

This is the use case in which this fix is useful.
- document
  - mathquill.js
  - iframe
    - mathquill.css
    - elements to be mathquillified

The outer document uses the mathquill javascript and the mathquill functions are run in the context of the outer document. Elements inside the iframe can be mathquillified and rendered correctly as long as the iframe uses the css file. However, the mouseup event tied to the outer document is not triggered for mathquillified elements inside the iframe, resulting in weird selection behavior (once the mousedown event on the mathquillified element is triggered, the selection is always on because mouseup never gets triggered).
