### PR TITLE
Refactor Parser::many and friends to fold rather than yield arrays

### DIFF
--- a/src/latex.js
+++ b/src/latex.js
@@ -5,14 +5,9 @@ var latexMathParser = (function() {
     cmd.adopt(block, 0, 0);
     return block;
   }
-  function joinBlocks(blocks) {
-    var firstBlock = blocks[0] || MathBlock();
-
-    for (var i = 1; i < blocks.length; i += 1) {
-      blocks[i].children().adopt(firstBlock, firstBlock.lastChild, 0);
-    }
-
-    return firstBlock;
+  function foldBlocks(foldedBlock, block) {
+    block.children().adopt(foldedBlock, foldedBlock.lastChild, 0);
+    return foldedBlock;
   }
 
   var string = Parser.string;
@@ -54,14 +49,14 @@ var latexMathParser = (function() {
   // Parsers yielding MathBlocks
   var mathGroup = string('{').then(function() { return mathSequence; }).skip(string('}'));
   var mathBlock = optWhitespace.then(mathGroup.or(command.map(commandToBlock)));
-  var mathSequence = mathBlock.many().map(joinBlocks).skip(optWhitespace);
+  var mathSequence = mathBlock.many(MathBlock, foldBlocks).skip(optWhitespace);
 
   var optMathBlock =
     string('[').then(
       mathBlock.then(function(block) {
         return block.join('latex') !== ']' ? succeed(block) : fail();
       })
-      .many().map(joinBlocks).skip(optWhitespace)
+      .many(MathBlock, foldBlocks).skip(optWhitespace)
     ).skip(string(']'))
   ;
 

--- a/src/math.js
+++ b/src/math.js
@@ -116,16 +116,12 @@ var MathCommand = P(MathElement, function(_, _super) {
   _.parser = function() {
     var block = latexMathParser.block;
     var self = this;
+    var blocks = self.blocks = [];
 
-    return block.times(self.numBlocks()).map(function(blocks) {
-      self.blocks = blocks;
-
-      for (var i = 0; i < blocks.length; i += 1) {
-        blocks[i].adopt(self, self.lastChild, 0);
-      }
-
-      return self;
-    });
+    return block.times(self.numBlocks(), 0, function(i, block) {
+      blocks[i] = block.adopt(self, self.lastChild, 0);
+      return i + 1;
+    }).result(self);
   };
 
   // createBefore(cursor) and the methods it calls

--- a/src/math.js
+++ b/src/math.js
@@ -116,9 +116,10 @@ var MathCommand = P(MathElement, function(_, _super) {
   _.parser = function() {
     var block = latexMathParser.block;
     var self = this;
-    var blocks = self.blocks = [];
+    var numBlocks = self.numBlocks();
+    var blocks = self.blocks = Array(numBlocks)
 
-    return block.times(self.numBlocks(), 0, function(i, block) {
+    return block.times(numBlocks, 0, function(i, block) {
       blocks[i] = block.adopt(self, self.lastChild, 0);
       return i + 1;
     }).result(self);

--- a/src/rootelements.js
+++ b/src/rootelements.js
@@ -436,19 +436,16 @@ var RootTextBlock = P(MathBlock, function(_) {
 
     var escapedDollar = string('\\$').result('$');
     var textChar = escapedDollar.or(regex(/^[^$]/)).map(VanillaSymbol);
-    var latexText = mathMode.or(textChar).many();
-    var commands = latexText.skip(eof).or(all.result(false)).parse(latex);
+    var latexText = mathMode.or(textChar).many(0, function(prev, cmd) {
+      return cmd.adopt(self, prev, 0);
+    });
 
-    if (commands) {
-      for (var i = 0; i < commands.length; i += 1) {
-        commands[i].adopt(self, self.lastChild, 0);
-      }
+    latexText.skip(eof).or(all.result(false)).parse(latex);
 
-      var html = self.join('html');
-      MathElement.jQize(html).appendTo(self.jQ);
+    var html = self.join('html');
+    MathElement.jQize(html).appendTo(self.jQ);
 
-      this.finalizeInsert();
-    }
+    this.finalizeInsert();
   };
   _.onKey = RootMathBlock.prototype.onKey;
   _.onText = function(ch) {

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -113,17 +113,17 @@ suite('parser', function() {
 
   function assertParses(parser, str, expectedResult) {
     if (arguments.length < 3) expectedResult = str;
-    var result = parser.parse(str);
-    if (result instanceof Array) result = result.join('');
-    assert.equal(result, expectedResult);
+    assert.equal(parser.parse(str), expectedResult);
   }
   function assertDoesntParse(parser, str) {
     assert.throws(function() { parser.parse(str); });
   }
 
+  function cat(x, y) { return x + y; }
+
   suite('many', function() {
     test('simple case', function() {
-      var letters = letter.many();
+      var letters = letter.many('', cat);
 
       assertParses(letters, 'x');
       assertParses(letters, 'xyz');
@@ -133,7 +133,7 @@ suite('parser', function() {
     });
 
     test('followed by then', function() {
-      var parser = string('x').many().then(string('y'));
+      var parser = string('x').many('', cat).then(string('y'));
 
       assertParses(parser, 'y', 'y');
       assertParses(parser, 'xy', 'y');
@@ -146,14 +146,14 @@ suite('parser', function() {
 
   suite('times', function() {
     test('zero case', function() {
-      var zeroLetters = letter.times(0);
+      var zeroLetters = letter.times(0, '', cat);
 
       assertParses(zeroLetters, '');
       assertDoesntParse(zeroLetters, 'x');
     });
 
     test('nonzero case', function() {
-      var threeLetters = letter.times(3);
+      var threeLetters = letter.times(3, '', cat);
 
       assertParses(threeLetters, 'xyz');
       assertDoesntParse(threeLetters, 'xy');
@@ -168,7 +168,7 @@ suite('parser', function() {
     });
 
     test('with a min and max', function() {
-      var someLetters = letter.times(2, 4);
+      var someLetters = letter.times(2, 4, '', cat);
 
       assertParses(someLetters, 'xy');
       assertParses(someLetters, 'xyz');
@@ -188,7 +188,7 @@ suite('parser', function() {
     });
 
     test('atLeast', function() {
-      var atLeastTwo = letter.atLeast(2);
+      var atLeastTwo = letter.atLeast(2, '', cat);
 
       assertParses(atLeastTwo, 'xy');
       assertParses(atLeastTwo, 'xyzw');

--- a/test/unit/parser.test.js
+++ b/test/unit/parser.test.js
@@ -111,27 +111,36 @@ suite('parser', function() {
     });
   });
 
-  function assertEqualArray(arr1, arr2) {
-    assert.equal(arr1.join(), arr2.join());
+  function assertParses(parser, str, expectedResult) {
+    if (arguments.length < 3) expectedResult = str;
+    var result = parser.parse(str);
+    if (result instanceof Array) result = result.join('');
+    assert.equal(result, expectedResult);
+  }
+  function assertDoesntParse(parser, str) {
+    assert.throws(function() { parser.parse(str); });
   }
 
   suite('many', function() {
     test('simple case', function() {
       var letters = letter.many();
 
-      assertEqualArray(letters.parse('x'), ['x']);
-      assertEqualArray(letters.parse('xyz'), ['x','y','z']);
-      assertEqualArray(letters.parse(''), []);
-      assert.throws(function() { letters.parse('1'); });
-      assert.throws(function() { letters.parse('xyz1'); });
+      assertParses(letters, 'x');
+      assertParses(letters, 'xyz');
+      assertParses(letters, '');
+      assertDoesntParse(letters, '1');
+      assertDoesntParse(letters, 'xyz1');
     });
 
     test('followed by then', function() {
       var parser = string('x').many().then(string('y'));
 
-      assert.equal(parser.parse('y'), 'y');
-      assert.equal(parser.parse('xy'), 'y');
-      assert.equal(parser.parse('xxxxxy'), 'y');
+      assertParses(parser, 'y', 'y');
+      assertParses(parser, 'xy', 'y');
+      assertParses(parser, 'xxxxxy', 'y');
+      assertDoesntParse(parser, '');
+      assertDoesntParse(parser, 'x');
+      assertDoesntParse(parser, 'xyz');
     });
   });
 
@@ -139,49 +148,51 @@ suite('parser', function() {
     test('zero case', function() {
       var zeroLetters = letter.times(0);
 
-      assertEqualArray(zeroLetters.parse(''), []);
-      assert.throws(function() { zeroLetters.parse('x'); });
+      assertParses(zeroLetters, '');
+      assertDoesntParse(zeroLetters, 'x');
     });
 
     test('nonzero case', function() {
       var threeLetters = letter.times(3);
 
-      assertEqualArray(threeLetters.parse('xyz'), ['x', 'y', 'z']);
-      assert.throws(function() { threeLetters.parse('xy'); });
-      assert.throws(function() { threeLetters.parse('xyzw'); });
+      assertParses(threeLetters, 'xyz');
+      assertDoesntParse(threeLetters, 'xy');
+      assertDoesntParse(threeLetters, 'xyzw');
 
       var thenDigit = threeLetters.then(digit);
-      assert.equal(thenDigit.parse('xyz1'), '1');
-      assert.throws(function() { thenDigit.parse('xy1'); });
-      assert.throws(function() { thenDigit.parse('xyz'); });
-      assert.throws(function() { thenDigit.parse('xyzw'); });
+
+      assertParses(thenDigit, 'xyz1', '1');
+      assertDoesntParse(thenDigit, 'xy1');
+      assertDoesntParse(thenDigit, 'xyz');
+      assertDoesntParse(thenDigit, 'xyzw');
     });
 
     test('with a min and max', function() {
       var someLetters = letter.times(2, 4);
 
-      assertEqualArray(someLetters.parse('xy'), ['x', 'y']);
-      assertEqualArray(someLetters.parse('xyz'), ['x', 'y', 'z']);
-      assertEqualArray(someLetters.parse('xyzw'), ['x', 'y', 'z', 'w']);
-      assert.throws(function() { someLetters.parse('xyzwv'); });
-      assert.throws(function() { someLetters.parse('x'); });
+      assertParses(someLetters, 'xy');
+      assertParses(someLetters, 'xyz');
+      assertParses(someLetters, 'xyzw');
+      assertDoesntParse(someLetters, 'xyzwv');
+      assertDoesntParse(someLetters, 'x');
 
       var thenDigit = someLetters.then(digit);
-      assert.equal(thenDigit.parse('xy1'), '1');
-      assert.equal(thenDigit.parse('xyz1'), '1');
-      assert.equal(thenDigit.parse('xyzw1'), '1');
-      assert.throws(function() { thenDigit.parse('xy'); });
-      assert.throws(function() { thenDigit.parse('xyzw'); });
-      assert.throws(function() { thenDigit.parse('xyzwv1'); });
-      assert.throws(function() { thenDigit.parse('x1'); });
+
+      assertParses(thenDigit, 'xy1', '1');
+      assertParses(thenDigit, 'xyz1', '1');
+      assertParses(thenDigit, 'xyzw1', '1');
+      assertDoesntParse(thenDigit, 'xy');
+      assertDoesntParse(thenDigit, 'xyzw');
+      assertDoesntParse(thenDigit, 'xyzwv1');
+      assertDoesntParse(thenDigit, 'x1');
     });
 
     test('atLeast', function() {
       var atLeastTwo = letter.atLeast(2);
 
-      assertEqualArray(atLeastTwo.parse('xy'), ['x', 'y']);
-      assertEqualArray(atLeastTwo.parse('xyzw'), ['x', 'y', 'z', 'w']);
-      assert.throws(function() { atLeastTwo.parse('x'); });
+      assertParses(atLeastTwo, 'xy');
+      assertParses(atLeastTwo, 'xyzw');
+      assertDoesntParse(atLeastTwo, 'x');
     });
   });
 


### PR DESCRIPTION
Instead of yielding an array, `Parser::many`, `times`, `atLeast`, and `atMost` take in two additional arguments, the arguments that the `fold` or `reduce` HOF takes: an initial result-so-far (or a function returning one, if it's going to be mutated) and a function that takes in two arguments, the combined/folded/reduced-result-so-far, and the result of this iteration. The final result is the final result-so-far.

`mathSequence`, `MathCommand::parser`, `RootTextBlock::renderLatex`, and even `Parser::atMost` are all simplified by this, while `many` and `times` are just as simple.