### PR TITLE
TextPiece: override jQadd instead of finalizeTree

### DIFF
--- a/src/text.js
+++ b/src/text.js
@@ -18,6 +18,11 @@ var TextBlock = P(Node, function(_, _super) {
       this.replacedText = replacedText;
   };
 
+  _.jQadd = function(jQ) {
+    _super.jQadd.call(this, jQ);
+    this.ch[L].jQize(this.jQ[0].firstChild);
+  };
+
   _.createBefore = function(cursor) {
     var textBlock = this;
     _super.createBefore.call(this, cursor);
@@ -44,6 +49,10 @@ var TextBlock = P(Node, function(_, _super) {
     return optWhitespace
       .then(string('{')).then(regex(/^[^}]*/)).skip(string('}'))
       .map(function(text) {
+        // TODO: is this the correct behavior when parsing
+        // the latex \text{} ?  This violates the requirement that
+        // the text contents are always nonempty.  Should we just
+        // disown the parent node instead?
         TextPiece(text).adopt(textBlock, 0, 0);
         return textBlock;
       })
@@ -144,26 +153,9 @@ var TextPiece = P(Node, function(_, _super) {
   };
   // overriding .jQize because neither jQuery nor our html parsing
   // format like text nodes.
-  _.jQize = function() {
-    this.dom = document.createTextNode(this.text);
-    return this.jQ = $(this.dom);
-  };
-  // finalizeTree is for when we've parsed \text{abc}, created the dom,
-  // and need to link everything up
-  _.finalizeTree = function() {
-    var parentJQ = this.parent.jQ;
-    this.dom = parentJQ[0].childNodes[0];
-
-    // TODO: is this the correct behavior when parsing
-    // the latex \text{} ?  This violates the requirement that
-    // the text contents are always nonempty.  Should we just
-    // disown the parent node instead?
-    if (!this.dom) {
-      this.dom = document.createTextNode('');
-      parentJQ.append(this.dom);
-    }
-
-    this.text = this.dom.data;
+  _.jQize = function(dom) {
+    if (!dom) dom = document.createTextNode(this.text);
+    this.dom = dom;
     return this.jQ = $(this.dom);
   };
   _.appendText = function(text) {


### PR DESCRIPTION
...to set `.dom` and `.jQ`

note that the behavior on `\text{}` is the same because the way `TextBlock::parser` works, there'll be a `TextPiece` whose `.text === ''`, and on `TextBlock::jQadd` the span's .`firstChild` will be `null` and hence falsy and `TextPiece::jQize` will create an empty `DOMTextNode`.
