### PR TITLE
first successful fix for selecting in TextBlocks

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -49,11 +49,10 @@ var Cursor = P(Point, function(_) {
   };
 
   _.withDirInsertAt = function(dir, parent, withDir, oppDir) {
-    var oldParent = this.parent;
+    this.parent.blur(this);
     this.parent = parent;
     this[dir] = withDir;
     this[-dir] = oppDir;
-    oldParent.blur();
   };
   _.insertAdjacent = function(dir, el) {
     prayDirection(dir);


### PR DESCRIPTION
@jayferd, can you take a look? I'm sick of it and need a fresh set of eyes. It's pretty ugly, way too much checking of the `anticursor`.

Food for thought, `blur` is called on the `TextBlock` in 3 situations:
- clicking or keyboard-moving outside the `TextBlock`. We actually want to merge all `TextPiece`s in this case
- keyboard-selecting out of the `TextBlock` (which involves the `cursor` moving out of the `TextBlock`). We don't want to merge the `TextPiece`s around the `anticursor` in this case, and there shouldn't be anything else at all that needs merging (since to keyboard-select out of the `TextBlock`, the `cursor` must've been at the edge)
- mouse-selecting within or outside the `TextBlock`, `blur` is called **_twice_**, when `seek`ing and again after `select`ing. We want to merge the `TextPiece`s around where the `cursor` was but **_not_** around where the `anticursor` is

If we're pickier about when we try to merge, maybe we can be less worried about munging the `anticursor`'s surrounding `TextPiece`s.
