### PR TITLE
Add empty body to loops and ifs without body

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -377,7 +377,7 @@ var Cursor = P(function(_) {
     clearUpDownCache(this);
     this.show();
 
-    if (this.deleteSelection()); // pass
+    if (this.deleteSelection()) {} // pass
     else if (this.prev) {
       if (this.prev.isEmpty())
         this.prev = this.prev.remove().prev;
@@ -403,7 +403,7 @@ var Cursor = P(function(_) {
     clearUpDownCache(this);
     this.show();
 
-    if (this.deleteSelection()); // pass
+    if (this.deleteSelection()) {} // pass
     else if (this.next) {
       if (this.next.isEmpty())
         this.next = this.next.remove().next;

--- a/src/parser.js
+++ b/src/parser.js
@@ -60,7 +60,7 @@ var Parser = P(function(_, _super, Parser) {
 
     return Parser(function(stream, onSuccess, onFailure) {
       var xs = [];
-      while (self._(stream, success, failure));
+      while (self._(stream, success, failure)) {}
       return onSuccess(stream, xs);
 
       function success(newStream, x) {


### PR DESCRIPTION
Google Closure Compiler complains with this WARNING :
"If this if/for/while really shouldnt have a body, use {}"
