### PR TITLE
Implement \textcolor

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -102,7 +102,8 @@ var TextColor = LatexCmds.textcolor = P(MathCommand, function(_, _super) {
     var string = Parser.string;
     var regex = Parser.regex;
 
-    return string('{')
+    return optWhitespace
+      .then(string('{'))
       .then(regex(/^[^{}]*/))
       .skip(string('}'))
       .then(function(color) {

--- a/test/visual.html
+++ b/test/visual.html
@@ -158,7 +158,7 @@ button {
 <p>Colors should match their names:
 <span class="mathquill-embedded-latex">
   \textcolor{#0000FF}{blue} + \textcolor{red}{red}
-  = \textcolor{rgb(255, 0, 255)}{magenta}
+  = \textcolor { rgb(255, 0, 255) } {magenta}
 </span>
 </p>
 <p>Nested <code>\textcolor</code>: the 2 should be red, the "a+" green, the 4 blue, and the "+b" green again.


### PR DESCRIPTION
`\textcolor{color}{math}` will apply a color to the given math content.  `color` can be any valid CSS Color Value (see [SitePoint docs](http://reference.sitepoint.com/css/colorvalues) (recommended), [Mozilla docs](https://developer.mozilla.org/en-US/docs/CSS/color_value#Values), or [W3C spec](http://dev.w3.org/csswg/css3-color/#colorunits)).
