### PR TITLE
failed attempt to fix TextBlock mouse selection...

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -183,8 +183,8 @@ var Cursor = P(Point, function(_) {
       cached[R] ? self.insertBefore(cached[R]) : self.appendTo(cached.parent);
     }
     else {
-      var pageX = offset(self).left;
-      self.appendTo(to).seekHoriz(pageX, to);
+      var pageX = self.offset().left;
+      self.appendTo(to).seekHorizDir(L, pageX, to);
     }
   };
 
@@ -209,24 +209,24 @@ var Cursor = P(Point, function(_) {
 
     return cursor;
   };
-  _.seekHoriz = function(pageX, block) {
+  _.seekHorizDir = function(dir, pageX, block) {
     //move cursor to position closest to click
     var cursor = this;
-    var dist = offset(cursor).left - pageX;
+    var dist = dir*(pageX - cursor.offset().left);
     var prevDist;
 
     do {
-      cursor.moveLeftWithin(block);
+      cursor.moveDirWithin(dir, block);
       prevDist = dist;
-      dist = offset(cursor).left - pageX;
+      dist = dir*(pageX - cursor.offset().left);
     }
-    while (dist > 0 && (cursor[L] || cursor.parent !== block));
+    while (dist > 0 && (cursor[dir] || cursor.parent !== block));
 
-    if (-dist > prevDist) cursor.moveRightWithin(block);
+    if (-dist > prevDist) cursor.moveDirWithin(-dir, block);
 
     return cursor;
   };
-  function offset(self) {
+  _.offset = function() {
     //in Opera 11.62, .getBoundingClientRect() and hence jQuery::offset()
     //returns all 0's on inline elements with negative margin-right (like
     //the cursor) at the end of their parent, so temporarily remove the
@@ -234,10 +234,10 @@ var Cursor = P(Point, function(_) {
     //Opera bug DSK-360043
     //http://bugs.jquery.com/ticket/11523
     //https://github.com/jquery/jquery/pull/717
-    var offset = self.jQ.removeClass('cursor').offset();
+    var self = this, offset = self.jQ.removeClass('cursor').offset();
     self.jQ.addClass('cursor');
     return offset;
-  }
+  };
   _.writeLatex = function(latex) {
     var self = this;
     clearUpDownCache(self);

--- a/src/math.js
+++ b/src/math.js
@@ -113,7 +113,7 @@ var MathCommand = P(MathElement, function(_, _super) {
     cursor.selection = Selection(this);
   };
   _.seek = function(pageX, cursor) {
-    cursor.insertAfter(this).seekHoriz(pageX, this.parent);
+    cursor.insertAfter(this).seekHorizDir(L, pageX, this.parent);
   };
 
   // methods involved in creating and cross-linking with HTML DOM nodes
@@ -324,7 +324,7 @@ var MathBlock = P(MathElement, function(_) {
     cursor.selection = Selection(first, last);
   };
   _.seek = function(pageX, cursor) {
-    cursor.appendTo(this).seekHoriz(pageX, this);
+    cursor.appendTo(this).seekHorizDir(L, pageX, this);
   };
   _.write = function(cursor, ch, replacedFragment) {
     var cmd;

--- a/src/text.js
+++ b/src/text.js
@@ -123,9 +123,25 @@ var TextBlock = P(Node, function(_, _super) {
     return false;
   };
 
-  _.seek = function() {
+  _.seek = function(pageX, cursor) {
+    var anticursor = cursor.anticursor;
+    if (anticursor && anticursor.parent === this) {
+      var displacement = pageX - this.anticursorOffsetLeft;
+      console.log(displacement);
+      if (displacement) {
+        var dir = displacement < 0 ? L : R;
+        cursor.appendDir(dir, this);
+        cursor.seekHorizDir(-dir, pageX, this);
+      }
+      else {
+        if (anticursor[R]) cursor.insertBefore(anticursor[R]);
+        else cursor.appendTo(this);
+      }
+      return;
+    }
     consolidateChildren(this);
     MathBlock.prototype.seek.apply(this, arguments);
+    this.anticursorOffsetLeft = cursor.offset().left;
   };
 
   _.blur = function() {


### PR DESCRIPTION
by only selecting in the direction that the cursor is relative to the
anticursor.

This required directionalizing Cursor::seekHoriz; also, for
TextBlock::seek to determine which direction the cursor is relative to
the anticursor, had to expose Cursor::offset.

If you mouse select within a TextBlock _super fast_ then this will
mostly work... :D

This doesn't work because if the mouse is only one character away from
the anticursor, the cursor will go one character further than it ends
up (to test the distance), then when it moves back, a new TextPiece is
created that's different from what the anticursor points at. So if you
play around with it by selecting super fast, even when it doesn't error,
you might notice characters jiggling around.
