### PR TITLE
Add vector LaTeX command (\vec)

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -271,9 +271,7 @@ LatexCmds['√'] = P(MathCommand, function(_, _super) {
   };
 });
 
-var Vec =
-LatexCmds.vec =
-LatexCmds['vec'] = P(MathCommand, function(_, _super) {
+var Vec = LatexCmds.vec = P(MathCommand, function(_, _super) {
   _.ctrlSeq = '\\vec';
   _.htmlTemplate =
       '<span class="non-leaf">'
@@ -281,7 +279,7 @@ LatexCmds['vec'] = P(MathCommand, function(_, _super) {
     +   '<span class="vector-stem">&0</span>'
     + '</span>'
   ;
-  _.textTemplate = ['vec{', '}'];
+  _.textTemplate = ['vec(', ')'];
 });
 
 var NthRoot =

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -249,14 +249,11 @@
     text-align: center;
     line-height: .25em;
     margin-bottom: -.1em;
-	font-size: 0.75em;
+    font-size: 0.75em;
   }	
 
   .vector-stem {
     display: block;
-    text-align: center;
-    position: relative;
-    border-top: none;
   }
 
   &, .mathquill-editable {


### PR DESCRIPTION
The vector command places a right arrow above the text name of the vector.
This commit models the rendering of LaTeX where the arrow does not
extend to the full width of the vector name.
