### PR TITLE
added cssclass latex command

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -115,14 +115,14 @@ var TextColor = LatexCmds.textcolor = P(MathCommand, function(_, _super) {
 });
 
 // Very similar to the \textcolor command, but will add the given CSS class.
-// Usage: \class[classname]{math}
+// Usage: \class{classname}{math}
 var CssClass = LatexCmds['class'] = P(MathCommand, function(_, _super) {
   _.parser = function() {
     var self = this, string = Parser.string, regex = Parser.regex;
     return Parser.optWhitespace
-      .then(string('['))
-      .then(regex(/^[^\]]+/))
-      .skip(string(']'))
+      .then(string('{'))
+      .then(regex(/^[^{}]*/))
+      .skip(string('}'))
       .then(function(cls) {
         self.htmlTemplate = '<span class="mq-class '+cls+'">&0</span>';
         return _super.parser.call(self);

--- a/test/visual.html
+++ b/test/visual.html
@@ -173,7 +173,7 @@ e^{\textcolor{#FF0000}{2}}\sin(x^\textcolor{#00FF00}{{a+\textcolor{blue}{4}+b}})
 </style>
 <p>Second term should be styled like <span class='testclass'>this</span>:
   <span class="mathquill-embedded-latex">
-x+\class[testclass]{y}+z
+x+\class{testclass}{y}+z
 </span>
 </p>
 


### PR DESCRIPTION
This pull request rips off the recently added `textcolor` latex command to add a more general `cssclass` variant. Usage:

```
x+\cssclass{myclass}{y}+z
```

With this stylesheet definition of `.myclass`...

```
.myclass {
    background-color: #5A8;
    border-radius: 5px;
    padding: 4px;
    font-weight:bold;
    color:gold;
}
```

...that would output something like this:

![image](https://f.cloud.github.com/assets/249764/511182/531f8862-bdfb-11e2-9f95-ba2a86334d94.png)
