### PR TITLE
console.warn() in Quirks Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,13 @@ are all over the place.
 
 ## Usage
 
-(Note: Requires [jQuery 1.4.3+](http://jquery.com).
-[Google CDN-hosted copy](http://code.google.com/apis/libraries/devguide.html#jquery) recommended.)
+(Requires:
+* Standards Mode DOCTYPE and not [Quirks Mode][], `<!DOCTYPE html>` recommended
+* [jQuery 1.4.3+][jquery], [Google CDN-hosted copy][jquery cdn] recommended.)
+
+[Quirks Mode]: http://hsivonen.fi/doctype/
+[jquery]: http://jquery.com
+[jquery cdn]: http://code.google.com/apis/libraries/devguide.html#jquery
 
 To use MathQuill on your website, grab the latest tarball from the [downloads page][], and serve
 

--- a/src/intro.js
+++ b/src/intro.js
@@ -7,6 +7,13 @@
 
 (function() {
 
+if (!document.compatMode || document.compatMode === 'BackCompat') {
+  var msg = 'This document appears to be in Quirks Mode. Elements styled by '
+          +  'MathQuill may look wrong.';
+  if (window.console && console.warn) console.warn(msg);
+  else setTimeout(function() { throw msg; });
+}
+
 var jQuery = window.jQuery,
   undefined,
   _, //temp variable of prototypes


### PR DESCRIPTION
ehberger and I just spent an unfortunate amount of time re-discovering that MathQuill works poorly in Quirks Mode; among other things, subscripts are way too low, and empty `.mathquill-editable`s have no height.

It's documented in the README that MathQuill needs Standards Mode, but it's still easy to forget, it would be nice for MathQuill to check [`document.compatMode`](http://www.quirksmode.org/dom/w3c_html.html#t11) and like, [`console.warn()`](https://developer.mozilla.org/en-US/docs/Web/API/console.warn#Browser_compatibility) or something. (Where `console.warn()` isn't supported, `setTimeout(function() { throw 'message'; });` instead?)
