### PR TITLE
Fix #227 .less files not being auto-recompiled

### DIFF
--- a/script/test_server.js
+++ b/script/test_server.js
@@ -59,6 +59,7 @@ function recursivelyWatch(watchee, cb) {
           // filesNew - files = new files or dirs to watch
           filesNew.filter(function(file) { return files.indexOf(file) < 0; })
           .forEach(recurse);
+          files = filesNew;
         });
         cb();
       });


### PR DESCRIPTION
Quick googling turns up hundreds of wrappers around `fs.watch()` that watch recursively, as well as doing lots of unnecessary stuff like allowing globbing paths, all of which are also hundreds of lines long.

The `fs.readdir()` trick is from isaacs' filewatcherthing: https://github.com/isaacs/filewatcherthing/commit/740c76db4bcfd96bb087eca7f47d02828df2788d

I'm not sure why isaacs guarded against `.` and `..`, `fs.readdir()` supposedly (and empirically) excludes them: http://nodejs.org/api/fs.html#fs_fs_readdir_path_callback
