### PR TITLE
Change default spacebar behavior to type spaces

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -350,7 +350,8 @@ var MathBlock = P(MathElement, function(_, _super) {
   };
 
   _.keystroke = function(key, e, ctrlr) {
-    if (key === 'Spacebar' || key === 'Shift-Spacebar') {
+    if (ctrlr.spaceBehavesLikeTab
+        && (key === 'Spacebar' || key === 'Shift-Spacebar')) {
       e.preventDefault();
       ctrlr.escapeDir(key === 'Shift-Spacebar' ? L : R, key, e);
       return;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -170,6 +170,7 @@ setMathQuillDot('MathField', P(EditableField, function(_, _super) {
     var contents = this.initExtractContents(el);
     this.initRoot(RootMathBlock(), el);
     this.controller.root.setHandlers(opts && opts.handlers, this);
+    this.controller.spaceBehavesLikeTab = (opts && opts.spaceBehavesLikeTab);
     this.controller.renderLatexMath(contents);
     this.initEvents();
   };

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -89,4 +89,49 @@ suite('Public API', function() {
 
     $(mq.el()).remove();
   });
+
+  suite('spaceBehavesLikeTab', function() {
+    var mq, rootBlock, cursor;
+    test('space behaves like tab with default opts', function() {
+      mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+      rootBlock = mq.controller.root;
+      cursor = mq.controller.cursor;
+
+      mq.latex('\\sqrt{x}');
+      mq.keystroke('Left');
+
+      mq.keystroke('Spacebar');
+      mq.typedText(' ');
+      assert.equal(cursor[L].ctrlSeq, '\\:', 'left of the cursor is ' + cursor[L].ctrlSeq);
+      assert.equal(cursor[R], 0, 'right of the cursor is ' + cursor[R]);
+      mq.keystroke('Backspace');
+
+      mq.keystroke('Shift-Spacebar');
+      mq.typedText(' ');
+      assert.equal(cursor[L].ctrlSeq, '\\:', 'left of the cursor is ' + cursor[L].ctrlSeq);
+      assert.equal(cursor[R], 0, 'right of the cursor is ' + cursor[R]);
+
+      $(mq.el()).remove();
+    });
+    test('space behaves like tab when spaceBehavesLikeTab is true', function() {
+      var opts = { 'spaceBehavesLikeTab': true };
+      mq = MathQuill.MathField( $('<span></span>').appendTo('#mock')[0], opts)
+      rootBlock = mq.controller.root;
+      cursor = mq.controller.cursor;
+
+      mq.latex('\\sqrt{x}');
+
+      mq.keystroke('Left');
+      mq.keystroke('Spacebar');
+      assert.equal(cursor[L].parent, rootBlock, 'parent of the cursor is  ' + cursor[L].ctrlSeq);
+      assert.equal(cursor[R], 0, 'right cursor is ' + cursor[R]);
+
+      mq.keystroke('Left');
+      mq.keystroke('Shift-Spacebar');
+      assert.equal(cursor[L], 0, 'left cursor is ' + cursor[L]);
+      assert.equal(cursor[R], rootBlock.ends[L], 'parent of rootBlock is ' + cursor[R]);
+
+      $(mq.el()).remove();
+    });
+  });
 });


### PR DESCRIPTION
Add a flag for old behavior where spacebar behaves like tab and
escapes block.
