### PR TITLE
Further reduce running auto-unitalicization search

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -8,7 +8,7 @@
  * Both MathBlock's and MathCommand's descend from it.
  */
 var MathElement = P(Node, function(_, _super) {
-  _.finalizeInsert = function(cursor) {
+  _.finalizeInsert = function(origSiblings, cursor) {
     var self = this;
     self.postOrder('finalizeTree');
     self.postOrder('contactWeld', cursor);
@@ -20,8 +20,8 @@ var MathElement = P(Node, function(_, _super) {
     self.postOrder('blur');
 
     self.postOrder('edited');
-    if (self[R].siblingCreated) self[R].siblingCreated(L);
-    if (self[L].siblingCreated) self[L].siblingCreated(R);
+    if (self[R].siblingCreated) self[R].siblingCreated(L, origSiblings[L]);
+    if (self[L].siblingCreated) self[L].siblingCreated(R, origSiblings[R]);
     self.bubble('edited');
   };
 });
@@ -68,6 +68,7 @@ var MathCommand = P(MathElement, function(_, _super) {
 
   // createLeftOf(cursor) and the methods it calls
   _.createLeftOf = function(cursor) {
+    var origSiblings = Point.copy(cursor);
     var cmd = this;
     var replacedFragment = cmd.replacedFragment;
 
@@ -77,7 +78,7 @@ var MathCommand = P(MathElement, function(_, _super) {
       replacedFragment.adopt(cmd.ends[L], 0, 0);
       replacedFragment.jQ.appendTo(cmd.ends[L].jQ);
     }
-    cmd.finalizeInsert();
+    cmd.finalizeInsert(origSiblings);
     cmd.placeCursor(cursor);
   };
   _.createBlocks = function() {
@@ -312,6 +313,7 @@ var Symbol = P(MathCommand, function(_, _super) {
   };
   _.deleteTowards = function(dir, cursor) {
     cursor[dir] = this.remove()[dir];
+    return Fragment(this, this);
   };
   _.seek = function(pageX, cursor) {
     // insert at whichever side the click was closer to
@@ -370,6 +372,7 @@ var MathBlock = P(MathElement, function(_, _super) {
   };
   _.deleteOutOf = function(dir, cursor) {
     cursor.unwrapGramp();
+    return Fragment(this.parent, this.parent);
   };
   _.selectChildren = function(cursor, leftEnd, rightEnd) {
     cursor.selection = Selection(leftEnd, rightEnd);

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -2,13 +2,6 @@
  * Abstract classes of math blocks and commands.
  ************************************************/
 
-/**
- * Math tree node base class.
- * Some math-tree-specific extensions to Node.
- * Both MathBlock's and MathCommand's descend from it.
- */
-var MathElement = Node;
-
 // TODO: simplify inserting math
 function finalizeInsertingMath(frag, origSiblings, cursor) {
   frag.postOrder('finalizeTree');
@@ -31,7 +24,7 @@ function finalizeInsertingMath(frag, origSiblings, cursor) {
  * Commands and operators, like subscripts, exponents, or fractions.
  * Descendant commands are organized into blocks.
  */
-var MathCommand = P(MathElement, function(_, _super) {
+var MathCommand = P(Node, function(_, _super) {
   _.init = function(ctrlSeq, htmlTemplate, textTemplate) {
     var cmd = this;
     _super.init.call(cmd);
@@ -335,7 +328,7 @@ var Symbol = P(MathCommand, function(_, _super) {
  * symbols and operators that descend (in the Math DOM tree) from
  * ancestor operators.
  */
-var MathBlock = P(MathElement, function(_, _super) {
+var MathBlock = P(Node, function(_, _super) {
   _.join = function(methodName) {
     return this.foldChildren('', function(fold, child) {
       return fold + child[methodName]();

--- a/src/commands/math/symbols.js
+++ b/src/commands/math/symbols.js
@@ -248,15 +248,12 @@ LatexCmds.forall = P(VanillaSymbol, function(_, _super) {
 var LatexFragment = P(MathCommand, function(_) {
   _.init = function(latex) { this.latex = latex; };
   _.createLeftOf = function(cursor) {
-    var sibs = Point.copy(cursor);
+    var origSiblings = Point.copy(cursor);
     var block = latexMathParser.parse(this.latex);
     block.children().adopt(cursor.parent, cursor[L], cursor[R]);
     cursor[L] = block.ends[R];
     block.jQize().insertBefore(cursor.jQ);
-    block.finalizeInsert(0, cursor);
-    if (block.ends[R][R].siblingCreated) block.ends[R][R].siblingCreated(L, sibs[L]);
-    if (block.ends[L][L].siblingCreated) block.ends[L][L].siblingCreated(R, sibs[R]);
-    cursor.parent.bubble('edited');
+    finalizeInsertingMath(block.children(), origSiblings, cursor);
   };
   _.parser = function() {
     var frag = latexMathParser.parse(this.latex).children();

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -24,11 +24,12 @@ var TextBlock = P(Node, function(_, _super) {
   };
 
   _.createLeftOf = function(cursor) {
+    var origSibs = Point.copy(cursor);
     var textBlock = this;
     _super.createLeftOf.call(this, cursor);
 
-    if (textBlock[R].siblingCreated) textBlock[R].siblingCreated(L);
-    if (textBlock[L].siblingCreated) textBlock[L].siblingCreated(R);
+    if (textBlock[R].siblingCreated) textBlock[R].siblingCreated(L, origSibs[L]);
+    if (textBlock[L].siblingCreated) textBlock[L].siblingCreated(R, origSibs[R]);
     textBlock.bubble('edited');
 
     cursor.insAtRightEnd(textBlock);
@@ -90,7 +91,10 @@ var TextBlock = P(Node, function(_, _super) {
   };
   _.deleteOutOf = function(dir, cursor) {
     // backspace and delete at ends of block don't unwrap
-    if (this.isEmpty()) cursor.insRightOf(this);
+    if (this.isEmpty()) {
+      cursor.insRightOf(this);
+      return Fragment(this, this);
+    }
   };
   _.write = function(cursor, ch, replacedFragment) {
     if (replacedFragment) replacedFragment.remove();

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -165,9 +165,6 @@ var Cursor = P(Point, function(_) {
       this.insAtRightEnd(greatgramp);
 
     gramp.jQ.remove();
-
-    if (gramp[L].siblingDeleted) gramp[L].siblingDeleted(R);
-    if (gramp[R].siblingDeleted) gramp[R].siblingDeleted(L);
   };
   _.select = function() {
     var anticursor = this.anticursor;

--- a/src/services/keystroke.js
+++ b/src/services/keystroke.js
@@ -221,15 +221,17 @@ Controller.open(function(_) {
     prayDirection(dir);
     var cursor = this.cursor;
 
-    var hadSelection = cursor.selection;
+    var deletedFrag = cursor.selection;
     this.notify('edit'); // deletes selection if present
-    if (!hadSelection) {
-      if (cursor[dir]) cursor[dir].deleteTowards(dir, cursor);
-      else cursor.parent.deleteOutOf(dir, cursor);
+    if (!deletedFrag) {
+      deletedFrag = (cursor[dir] ? cursor[dir].deleteTowards(dir, cursor)
+                                 : cursor.parent.deleteOutOf(dir, cursor));
     }
 
-    if (cursor[L].siblingDeleted) cursor[L].siblingDeleted(R);
-    if (cursor[R].siblingDeleted) cursor[R].siblingDeleted(L);
+    if (deletedFrag) {
+      if (cursor[L].siblingDeleted) cursor[L].siblingDeleted(R, deletedFrag.ends[L]);
+      if (cursor[R].siblingDeleted) cursor[R].siblingDeleted(L, deletedFrag.ends[R]);
+    }
     cursor.parent.bubble('edited');
 
     return this;

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -85,13 +85,14 @@ Controller.open(function(_, _super) {
     var block = latexMathParser.skip(eof).or(all.result(false)).parse(latex);
 
     if (block) {
+      var sibs = Point.copy(cursor);
       block.children().adopt(cursor.parent, cursor[L], cursor[R]);
       var jQ = block.jQize();
       jQ.insertBefore(cursor.jQ);
       cursor[L] = block.ends[R];
-      block.finalizeInsert(cursor);
-      if (block.ends[R][R].siblingCreated) block.ends[R][R].siblingCreated(L);
-      if (block.ends[L][L].siblingCreated) block.ends[L][L].siblingCreated(R);
+      block.finalizeInsert(0, cursor);
+      if (block.ends[R][R].siblingCreated) block.ends[R][R].siblingCreated(L, sibs[L]);
+      if (block.ends[L][L].siblingCreated) block.ends[L][L].siblingCreated(R, sibs[R]);
       cursor.parent.bubble('edited');
     }
 

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -85,15 +85,12 @@ Controller.open(function(_, _super) {
     var block = latexMathParser.skip(eof).or(all.result(false)).parse(latex);
 
     if (block) {
-      var sibs = Point.copy(cursor);
+      var origSiblings = Point.copy(cursor);
       block.children().adopt(cursor.parent, cursor[L], cursor[R]);
       var jQ = block.jQize();
       jQ.insertBefore(cursor.jQ);
       cursor[L] = block.ends[R];
-      block.finalizeInsert(0, cursor);
-      if (block.ends[R][R].siblingCreated) block.ends[R][R].siblingCreated(L, sibs[L]);
-      if (block.ends[L][L].siblingCreated) block.ends[L][L].siblingCreated(R, sibs[R]);
-      cursor.parent.bubble('edited');
+      finalizeInsertingMath(block.children(), origSiblings, cursor);
     }
 
     return this;
@@ -119,7 +116,7 @@ Controller.open(function(_, _super) {
       var html = block.join('html');
       jQ.html(html);
       root.jQize(jQ.children());
-      root.finalizeInsert();
+      finalizeInsertingMath(Fragment(root, root));
     }
     else {
       jQ.empty();
@@ -171,7 +168,7 @@ Controller.open(function(_, _super) {
 
       root.jQize().appendTo(root.jQ);
 
-      root.finalizeInsert();
+      finalizeInsertingMath(Fragment(root, root));
     }
   };
 });

--- a/src/tree.js
+++ b/src/tree.js
@@ -158,8 +158,7 @@ var Node = P(function(_) {
   };
 
   _.eachChild = function() {
-    var children = this.children();
-    children.each.apply(children, arguments);
+    Fragment.prototype.each.apply(this.children(), arguments);
     return this;
   };
 

--- a/src/tree.js
+++ b/src/tree.js
@@ -140,15 +140,6 @@ var Node = P(function(_) {
     return this;
   });
 
-  _.postOrder = iterator(function(yield) {
-    (function recurse(descendant) {
-      descendant.eachChild(recurse);
-      yield(descendant);
-    })(this);
-
-    return this;
-  });
-
   _.isEmpty = function() {
     return this.ends[L] === 0 && this.ends[R] === 0;
   };
@@ -164,6 +155,11 @@ var Node = P(function(_) {
 
   _.foldChildren = function(fold, fn) {
     return this.children().fold(fold, fn);
+  };
+
+  _.postOrder = function() {
+    Fragment.prototype.postOrder.apply(this.children(), arguments);
+    return this;
   };
 
   _.adopt = function(parent, leftward, rightward) {
@@ -304,7 +300,7 @@ var Fragment = P(function(_) {
 
   _.remove = function() {
     this.jQ.remove();
-    this.each('postOrder', 'dispose');
+    this.postOrder('dispose');
     return this.disown();
   };
 
@@ -328,6 +324,13 @@ var Fragment = P(function(_) {
 
     return fold;
   };
+
+  _.postOrder = iterator(function(yield) {
+    return this.each(function recurse(descendant) {
+      descendant.eachChild(recurse);
+      yield(descendant);
+    });
+  });
 
   // create and return the Fragment between Point A and Point B, or if they
   // don't share a parent, between the ancestor of A and the ancestor of B

--- a/test/unit/unitalicized.test.js
+++ b/test/unit/unitalicized.test.js
@@ -46,7 +46,7 @@ suite('auto-unitalicized commands', function() {
     assertUnitalicizedCommandWorks('scscscscscsc', 's\\csc s\\csc s\\csc');
   });
 
-  test('deleting', function() {
+  test('deleting, typing in the middle', function() {
     var count = 0;
     var _autoUnItalicize = Letter.prototype.autoUnItalicize;
     Letter.prototype.autoUnItalicize = function() {
@@ -74,5 +74,26 @@ suite('auto-unitalicized commands', function() {
     mq.keystroke('Backspace');
     assertLatex('deleted plus', '\\csc s\\csc s\\csc sc');
     assert.equal(count, str.length + 5);
+  });
+
+  test('typing on either side', function() {
+    var count = 0;
+    var _autoUnItalicize = Letter.prototype.autoUnItalicize;
+    Letter.prototype.autoUnItalicize = function() {
+      count += 1;
+      return _autoUnItalicize.apply(this, arguments);
+    };
+
+    mq.latex('sin');
+    assertLatex('parsing \'sin\'', '\\sin');
+    assert.equal(count, 1);
+
+    mq.typedText('1');
+    assertLatex('typed \'1\' at the end', '\\sin1');
+    assert.equal(count, 1, 'typing at the end should not run autoUnItalicize');
+
+    mq.moveToLeftEnd().typedText('0');
+    assertLatex('typed \'0\' at the beginning', '0\\sin1');
+    assert.equal(count, 1, 'typing at the beginning should not run autoUnItalicize');
   });
 });

--- a/test/unit/unitalicized.test.js
+++ b/test/unit/unitalicized.test.js
@@ -14,14 +14,18 @@ suite('auto-unitalicized commands', function() {
     );
   }
 
+  function countAutoUnItalicizeCalls(incrementCount) {
+    var _autoUnItalicize = Letter.prototype.autoUnItalicize;
+    Letter.prototype.autoUnItalicize = function() {
+      incrementCount();
+      return _autoUnItalicize.apply(this, arguments);
+    };
+  }
+
   test('simple LaTeX parsing, typing', function() {
     function assertUnitalicizedCommandWorks(str, latex) {
       var count = 0;
-      var _autoUnItalicize = Letter.prototype.autoUnItalicize;
-      Letter.prototype.autoUnItalicize = function() {
-        count += 1;
-        return _autoUnItalicize.apply(this, arguments);
-      };
+      countAutoUnItalicizeCalls(function() { count += 1; });
 
       mq.latex(str);
       assertLatex('parsing \''+str+'\'', latex);
@@ -48,11 +52,7 @@ suite('auto-unitalicized commands', function() {
 
   test('deleting, typing in the middle', function() {
     var count = 0;
-    var _autoUnItalicize = Letter.prototype.autoUnItalicize;
-    Letter.prototype.autoUnItalicize = function() {
-      count += 1;
-      return _autoUnItalicize.apply(this, arguments);
-    };
+    countAutoUnItalicizeCalls(function() { count += 1; });
 
     var str = 'cscscscscscsc';
     for (var i = 0; i < str.length; i += 1) mq.typedText(str.charAt(i));
@@ -78,11 +78,7 @@ suite('auto-unitalicized commands', function() {
 
   test('typing on either side', function() {
     var count = 0;
-    var _autoUnItalicize = Letter.prototype.autoUnItalicize;
-    Letter.prototype.autoUnItalicize = function() {
-      count += 1;
-      return _autoUnItalicize.apply(this, arguments);
-    };
+    countAutoUnItalicizeCalls(function() { count += 1; });
 
     mq.latex('sin');
     assertLatex('parsing \'sin\'', '\\sin');


### PR DESCRIPTION
`.sibling{Created,Deleted}(dir{ => , origSibling})`

Add `origSibling` argument to `.sibling{Created,Deleted}()`, so that
`Letter`s can avoid running the auto-unitalicization algorithm in yet
another case: typing or deleting a non-`Letter` at the end of a sequence
of `Letter`s (when not breaking apart or joining together sequences).
`Letter`s now check that if the original and new sibling after the
sibling change are both non-`Letter`s, then no sequences of `Letter`s
could've changed.

For `.siblingCreated()`, this is straightforward, the nodes on either side
of the cursor before inserting stuff were the original siblings of each
other, so just copy the cursor before adopting stuff. (And add an
`origSiblings` argument to `MathElement::finalizeInsert`, and factor
that out as `finalizeInsertingMath()`.)

For `.siblingDeleted()`, this is less straightforward. `.siblingDeleted()`
should only be called by `Controller::deleteDir`, but `Controller::deleteDir`
delegates deleting to `.delete{Towards,OutOf}()` on the nodes themselves,
which may delete as much or as little as they desire, only the nodes
themselves easily know what the original siblings were on either side of
what they choose to delete. So, we now change the contract of
`.delete{Towards,OutOf}()` to, if anything is deleted that its siblings
might want to know about, return a `Fragment` of the disowned nodes.