### PR TITLE
Fix blue focus ring to only be around whole field

### DIFF
--- a/src/css/editable.less
+++ b/src/css/editable.less
@@ -22,16 +22,17 @@
     &, .mathquill-embedded-latex & {
       border: 1px solid gray;
       padding: 2px;
+
+      &.focused {
+        .box-shadow(~"#8bd 0 0 1px 2px, inset #6ae 0 0 2px 0");
+        border-color: #709AC0;
+        border-radius: 1px;
+      }
     }
   }
 // special styles for editables within static math
   .mathquill-embedded-latex & {
     margin: 1px;
-  }
-
-  // TODO: dasherize has-cursor
-  &.hasCursor, .hasCursor {
-    .box-shadow(#68B4DF 0 0 3px 2px);
   }
 
   ////

--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -3,6 +3,7 @@ Controller.open(function(_) {
     var ctrlr = this, root = ctrlr.root, cursor = ctrlr.cursor;
     ctrlr.textarea.focus(function() {
       ctrlr.blurred = false;
+      root.jQ.addClass('focused');
       if (!cursor.parent)
         cursor.insAtRightEnd(root);
       cursor.parent.jQ.addClass('hasCursor');
@@ -14,6 +15,7 @@ Controller.open(function(_) {
         cursor.show();
     }).blur(function() {
       ctrlr.blurred = true;
+      root.jQ.removeClass('focused');
       cursor.hide().parent.blur();
       if (cursor.selection)
         cursor.selection.jQ.addClass('blur');


### PR DESCRIPTION
...rather than individual blocks, which didn't make any sense, it's the
editable field as a whole that is supposed to be a fake textarea, so
it's the editable field as a whole that should be visibly focused.

Plus it was super distracting when working on parens auto-expanding.
