### PR TITLE
Handle intentional blur

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -577,7 +577,7 @@ var Bracket = P(MathCommand, function(_, _super) {
     };
     // FIXME HACK: after initial creation/insertion, finalizeTree would only be
     // called if the paren is selected and replaced, e.g. by LiveFraction
-    this.finalizeTree = function() {
+    this.finalizeTree = this.intentionalBlur = function() {
       this.bracketjQs.eq(this.side === L ? 1 : 0).removeClass('ghost');
       this.side = 0;
     };

--- a/src/services/focusBlur.js
+++ b/src/services/focusBlur.js
@@ -1,8 +1,10 @@
 Controller.open(function(_) {
   _.focusBlurEvents = function() {
     var ctrlr = this, root = ctrlr.root, cursor = ctrlr.cursor;
+    var blurTimeout;
     ctrlr.textarea.focus(function() {
       ctrlr.blurred = false;
+      clearTimeout(blurTimeout);
       root.jQ.addClass('focused');
       if (!cursor.parent)
         cursor.insAtRightEnd(root);
@@ -14,11 +16,23 @@ Controller.open(function(_) {
         cursor.show();
     }).blur(function() {
       ctrlr.blurred = true;
-      root.jQ.removeClass('focused');
-      cursor.hide().parent.blur();
-      if (cursor.selection)
-        cursor.selection.jQ.addClass('blur');
+      blurTimeout = setTimeout(function() { // wait for blur on window; if
+        root.postOrder('intentionalBlur'); // none, intentional blur: #264
+        cursor.clearSelection();
+        blur();
+      });
+      $(window).on('blur', windowBlur);
     }).blur();
+    function windowBlur() { // blur event also fired on window, just switching
+      clearTimeout(blurTimeout); // tabs/windows, not intentional blur
+      if (cursor.selection) cursor.selection.jQ.addClass('blur');
+      blur();
+    }
+    function blur() { // not directly in the textarea blur handler so as to be
+      cursor.hide().parent.blur(); // synchronous with/in the same frame as
+      root.jQ.removeClass('focused'); // clearing/blurring selection
+      $(window).off('blur', windowBlur);
+    }
   };
 });
 

--- a/test/visual.html
+++ b/test/visual.html
@@ -61,6 +61,8 @@ td {
 
 <h3>MathQuill Editables</h3>
 
+<p>In all editable fields, the selection should clear and ghost parens should solidify if you click outside, but not if you switch tabs/windows and switch back to this page.
+
 <table id="editables">
 <tr><th colspan=3>Initial LaTeX
 <tr>


### PR DESCRIPTION
That is, if the typist deliberately clicks outside an editable field, the selection should clear and any ghost parens should solidify; but if the typist switches tabs/windows and then switches back, nothing should change, which should be possible: http://www.one-tab.com/page/sLCTvblJSfqXEzZVL4Elmw

Previous discussion: https://github.com/mathquill/mathquill/pull/262#issuecomment-37904712
