### PR TITLE
Feature: substituteTextarea option

### DIFF
--- a/src/css/textarea.less
+++ b/src/css/textarea.less
@@ -8,7 +8,7 @@
     .user-select(text);
   }
 
-  .textarea textarea, .selectable {
+  .textarea *, .selectable {
     .user-select(text);
     // the only way to hide the textarea
     // *and the blinking insertion point* in IE

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -5,9 +5,9 @@
 
 Controller.open(function(_) {
   _.createTextarea = function() {
-    var textareaSpan = this.textareaSpan =
-        $('<span class="textarea"><textarea></textarea></span>'),
-      textarea = this.textarea = textareaSpan.children();
+    var textareaSpan = this.textareaSpan = $('<span class="textarea"></span>'),
+      fn = this.options.substituteTextarea, textarea = this.textarea =
+        $(fn ? fn() : '<textarea/>').appendTo(textareaSpan);
 
     //prevent native selection except in textarea
     this.container.bind('selectstart.mathquill', function(e) {

--- a/test/visual.html
+++ b/test/visual.html
@@ -175,6 +175,10 @@ x+\class{testclass}{y}+z
 </span>
 </p>
 
+<h3>substituteTextarea</h3>
+
+<p>In Safari on iOS, this should be focusable but not bring up the on-screen keyboard; to test, try focusing anything else and confirm this blurs: <span id="no-kbd-math"></span> (confirmed working on iOS 6.1.3)</p>
+
 </div>
 <script type="text/javascript">
 window.onerror = function() {
@@ -310,6 +314,12 @@ function timeAndLog(f) {
       .insertAfter('#html-render-perf');
   });
 }());
+
+MathQuill.MathField($('#no-kbd-math')[0], {
+  substituteTextarea: function() {
+    return $('<span tabindex=0 style="display:inline-block;width:1px;height:1px" />');
+  }
+});
 </script>
 </body>
 </html>


### PR DESCRIPTION
Add an API option to substitute something else focusable instead of the
hidden textarea.

This way, a web app using MathQuill with a custom touch keyboard for
math may disable the on-screen QWERTY touch keyboard on touch platforms,
by substituting a span with a non-negative `tab-index` attribute, which is
focusable but doesn't pull up the on-screen keyboard. Unfortunately,
[there's apparently no reliable way to detect a touchscreen](http://www.stucox.com/blog/you-cant-detect-a-touchscreen/). Desmos,
for example, User Agent sniffs for iOS and Android; this means that when
math fields are focused in iOS and Android, the on-screen keyboard won't
come up, but external keyboards won't work, either.

Also, in Android browsers where keyboard events are so unreliable that
even `saneKeyboardEvents.util.js` can't fix them, this lets you subsitute
an `input[type=password]` like in #115, which [potentially](https://github.com/mathquill/mathquill/pull/78#issuecomment-7362137) fixes typing in
some of them.
