### PR TITLE
Change license from LGPL to Mozilla Public License

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,8 @@ ready, finds and mathquill-ifies `.mathquill-editable` and so on elements.
 
 ## Open-Source License
 
-[GNU Lesser General Public License](http://www.gnu.org/licenses/lgpl.html)
+The Source Code Form of MathQuill is subject to the terms of the Mozilla Public
+License, v. 2.0: http://mozilla.org/MPL/2.0/
 
-Copyleft 2010-2012 [Han](http://github.com/laughinghan) and [Jay](http://github.com/jayferd)
+The quick-and-dirty is you can do whatever as long as modifications to MathQuill
+itself are in public GitHub forks.

--- a/src/css/main.less
+++ b/src/css/main.less
@@ -1,11 +1,11 @@
 /*
- * LaTeX Math in pure HTML and CSS -- No images whatsoever
- * v0.xa
- * by Jay and Han
- * Lesser GPL Licensed: http: //www.gnu.org/licenses/lgpl.html
+ * MathQuill: http://mathquill.com
+ * by Jay and Han (laughinghan@gmail.com)
  *
- * This file is automatically included by mathquill.js
- *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL
+ * was not distributed with this file, You can obtain
+ * one at http://mozilla.org/MPL/2.0/.
  */
 @import "./mixins/fonts";
 @import "./mixins/css3";

--- a/src/intro.js
+++ b/src/intro.js
@@ -1,8 +1,11 @@
 /**
- * Copyleft 2010-2011 Jay and Han (laughinghan@gmail.com)
- *   under the GNU Lesser General Public License
- *     http://www.gnu.org/licenses/lgpl.html
- * Project Website: http://mathquill.com
+ * MathQuill: http://mathquill.com
+ * by Jay and Han (laughinghan@gmail.com)
+ *
+ * This Source Code Form is subject to the terms of the
+ * Mozilla Public License, v. 2.0. If a copy of the MPL
+ * was not distributed with this file, You can obtain
+ * one at http://mozilla.org/MPL/2.0/.
  */
 
 (function() {


### PR DESCRIPTION
I technically wasn't complying with LGPL in the first place, since I
didn't include a complete copy of the license; MPL just requires I link
to it, as I do now.

Besides the pretty website, MPL is just shorter, simpler, and easier to
understand.

@jayferd: look good?
