### PR TITLE
Typing unicode characters doesn't work on demo.html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ clean:
 $(PJS_SRC): $(NODE_MODULES_INSTALLED)
 
 $(BUILD_JS): $(INTRO) $(SOURCES) $(OUTRO) $(BUILD_DIR_EXISTS)
-	cat $^ > $@
+	cat $^ | ./script/escape-non-ascii > $@
 
 $(UGLY_JS): $(BUILD_JS) $(NODE_MODULES_INSTALLED)
 	$(UGLIFY) $(UGLIFY_OPTS) < $< > $@

--- a/script/escape-non-ascii
+++ b/script/escape-non-ascii
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+
+// escape all non-ASCII characters with JS unicode escapes \u####, for #284
+
+process.stdin.setEncoding('utf8');
+
+process.stdin.on('data', function(data) {
+  process.stdout.write(data.replace(/[^\x00-\x7F]/g, function(c) {
+    return '\\u' + ('000' + c.charCodeAt(0).toString(16)).slice(-4);
+  }));
+});
+
+process.stdin.resume();


### PR DESCRIPTION
e.g. typing `√` doesn't type a square root, because the new local test server doesn't specify UTF-8 when serving the JS: http://speakingjs.com/es5/ch24.html#_javascript_source_code_and_unicode
