### PR TITLE
Fix backslashed commands like \sin()

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -663,7 +663,7 @@ CharCmds['\\'] = P(MathCommand, function(_, _super) {
 
       if (ch.match(/[a-z]/i)) VanillaSymbol(ch).createLeftOf(cursor);
       else {
-        this.parent.renderCommand();
+        this.parent.renderCommand(cursor);
         if (ch !== '\\' || !this.isEmpty()) this.parent.parent.write(cursor, ch);
       }
     };

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -36,6 +36,11 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+\\left(2+3\\right)+4');
       });
 
+      test('basic command', function () {
+        mq.typedText('\\sin(');
+        assertLatex('\\sin\\left(\\right)');
+      });
+
       test('wrapping things in parens', function() {
         mq.typedText('1+2+3+4');
         assertLatex('1+2+3+4');


### PR DESCRIPTION
There was a call to renderCommand that failed to pass the cursor.
