### PR TITLE
Assuage #293 Cmd-Left turns seln into typed text

### DIFF
--- a/test/unit/saneKeyboardEvents.test.js
+++ b/test/unit/saneKeyboardEvents.test.js
@@ -138,6 +138,14 @@ suite('key', function() {
       assert.equal(el.val(), 'foobar', 'it still has content');
     });
 
+    test('blur then empty selection', function() {
+      var shim = saneKeyboardEvents(el, { keystroke: noop });
+      shim.select('foobar');
+      el.blur();
+      shim.select('');
+      assert.ok(document.activeElement !== el[0], 'textarea remains blurred');
+    });
+
     suite('selected text after keypress or paste doesn\'t get mistaken' +
          ' for inputted text', function() {
       test('select() immediately after paste', function() {
@@ -240,6 +248,10 @@ suite('key', function() {
           el[0].selectionEnd = 0;
           el.trigger(Event('keyup', { which: 37, altKey: true }));
           assert.ok(el[0].selectionStart !== el[0].selectionEnd);
+
+          el.blur();
+          shim.select('');
+          assert.ok(document.activeElement !== el[0], 'textarea remains blurred');
         });
 
         test('with keypress, many characters selected', function() {
@@ -256,6 +268,10 @@ suite('key', function() {
 
           el.trigger('keyup');
           assert.ok(el[0].selectionStart !== el[0].selectionEnd);
+
+          el.blur();
+          shim.select('');
+          assert.ok(document.activeElement !== el[0], 'textarea remains blurred');
         });
 
         test('with keypress, only 1 character selected', function() {
@@ -280,6 +296,10 @@ suite('key', function() {
 
           el.trigger('keyup');
           assert.equal(count, 1);
+
+          el.blur();
+          shim.select('');
+          assert.ok(document.activeElement !== el[0], 'textarea remains blurred');
         });
       });
     });


### PR DESCRIPTION
First, fix in all browsers but Firefox (and Opera maybe? Not fixed in
browsers where arrow keys fire keypress) by always re-selecting the
textarea, in case an unrecognized key like Cmd-Left clears the
selection.

As for Firefox, "we just assume that if the text is 1 unselected
character then it must have been typed (no matter whether different from
or same as selection), the only bug will be that when exactly 1
character is selected, unrecognized keys in Firefox will clear the
selection":
https://github.com/mathquill/mathquill/issues/293#issuecomment-40997668
