### PR TITLE
More robust florin, without negative margin

### DIFF
--- a/src/commands/math/symbols.js
+++ b/src/commands/math/symbols.js
@@ -6,7 +6,7 @@ LatexCmds['∫'] =
 LatexCmds['int'] =
 LatexCmds.integral = bind(Symbol,'\\int ','<big>&int;</big>');
 
-LatexCmds.f = bind(Symbol, 'f', '<var class="florin">&fnof;</var><span style="display:inline-block;width:0">&nbsp;</span>');
+LatexCmds.f = bind(Symbol, 'f', '<var class="florin">&fnof;</var>');
 
 var Variable = P(Symbol, function(_, _super) {
   _.init = function(ch, html) {

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -61,7 +61,10 @@
   }
 
   var.florin {
-    margin: 0 -0.1em;
+    .inline-block;
+    width: .3em;
+    position: relative;
+    left: -.1em;
   }
 
   big {


### PR DESCRIPTION
Florin was introduced because the Times New Roman italic `f` extends
weirdly far on either side, whereas the Times New Roman italic florin
symbol is much more...reserved. Or something. I dunno, it looks bad.
Anyway, the thing with florin is it has tons of spacing on either side
for whatever reason, so we use a negative margin to get it to overlap
normally with adjacent characters.

Which seems pretty natural, but unfortunately keeps causing problems
(#61, #90, now #295):
https://github.com/mathquill/mathquill/issues?labels=Florin&state=closed

I suspect that negative margins on inline elements is uncommon, I don't
think the box model is really meant for inline elements, `width` and
`height` are even ignored on them. Instead, an `inline-block` with a fixed
width narrower than the florin symbol (the whole symbol is still visible
because it defaults `overflow:visible`) and `position:relative` (to overlap
on both sides, not just the right side) seems less likely to cause
layout quirks. Or at least, unique layout quirks, `inline-block`s cause
tons of layout quirks but MathQuill already works around them because
almost everything besides letters and digits are `inline-block`s, and
`position:relative` basically doesn't affect layout.
