### PR TITLE
Disable control sequences

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -651,18 +651,6 @@ LatexCmds.right = P(MathCommand, function(_) {
   };
 });
 
-MathQuill.disableControlSequences = function () {
-  delete CharCmds['\\'];
-  LatexCmds['\\'] = VanillaBackslash;
-};
-
-MathQuill.enableControlSequences = function () {
-  delete LatexCmds['\\'];
-  CharCmds['\\'] = LatexCommandInput;
-};
-
-var VanillaBackslash = bind(VanillaSymbol, '\\\\', '\\');
-
 // input box to type a variety of LaTeX commands beginning with a backslash
 var LatexCommandInput =
 CharCmds['\\'] = P(MathCommand, function(_, _super) {

--- a/src/commands/math/symbols.js
+++ b/src/commands/math/symbols.js
@@ -172,6 +172,16 @@ LatexCmds[' '] = LatexCmds.space = bind(VanillaSymbol, '\\ ', ' ');
 
 LatexCmds.prime = CharCmds["'"] = bind(VanillaSymbol, "'", '&prime;');
 
+var VanillaBackslash = bind(VanillaSymbol, '\\backslash', '\\');
+
+MathQuill.disableControlSequences = function () {
+  CharCmds['\\'] = VanillaBackslash;
+};
+
+MathQuill.enableControlSequences = function () {
+  CharCmds['\\'] = LatexCommandInput;
+};
+
 // does not use Symbola font
 var NonSymbolaSymbol = P(Symbol, function(_, _super) {
   _.init = function(ch, html) {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -786,7 +786,7 @@ suite('typing with auto-replaces', function() {
     test('Control Sequences Disabled', function () {
       MathQuill.disableControlSequences();
       mq.typedText('\\sin');
-      assertLatex('\\\\\\sin');
+      assertLatex('\\backslash\\sin');
     });
 
     test('Control Sequences Enabled', function () {


### PR DESCRIPTION
In practice, disabling control sequences means that typing `\` is interpreted as a literal `\` instead of the start of a control sequence.

From the new docs:
- `MathQuill.disableControlSequences()` affects what happens when a user types a `\` character. By default, a backslash is treated as the start of a control sequence. Disabling control sequences causes mathquill to typeset `\` as a literal backslash.
- `MathQuill.enableControlSequences()` reverts the effects of `MathQuill.disableControlSequences()`.
