### PR TITLE
Add support for \overarc

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -81,6 +81,7 @@ LatexCmds.mathtt = bind(Style, '\\mathtt', 'span', 'class="monospace font"');
 //text-decoration
 LatexCmds.underline = bind(Style, '\\underline', 'span', 'class="non-leaf underline"');
 LatexCmds.overline = LatexCmds.bar = bind(Style, '\\overline', 'span', 'class="non-leaf overline"');
+LatexCmds.overarc = bind(Style, '\\overarc', 'span', 'class="non-leaf overarc"');
 
 var SupSub = P(MathCommand, function(_, _super) {
   _.init = function(ctrlSeq, tag, text) {

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -85,6 +85,11 @@
     border-bottom: 1px solid black;
     margin-bottom: 1px;
   }
+  .overarc {
+    border-top: 1px solid black;
+    margin-top: 1px;
+    border-radius: 6px;
+  }
 
   ////
   // operators
@@ -250,7 +255,7 @@
     line-height: .25em;
     margin-bottom: -.1em;
     font-size: 0.75em;
-  }	
+  }
 
   .vector-stem {
     display: block;


### PR DESCRIPTION
Provides a curved equivalent to overline.

Couldn't find another way to do this. Please do let me know if there was already a way to achieve this.
