### PR TITLE
Rename .controller on API objects to .__controller

### DIFF
--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -369,10 +369,10 @@ MathQuill.TextField = APIFnFor(P(EditableField, function(_) {
   };
   _.latex = function(latex) {
     if (arguments.length > 0) {
-      this.controller.renderLatexText(latex);
-      if (this.controller.blurred) this.controller.cursor.hide().parent.blur();
+      this.__controller.renderLatexText(latex);
+      if (this.__controller.blurred) this.__controller.cursor.hide().parent.blur();
       return this;
     }
-    return this.controller.exportLatex();
+    return this.__controller.exportLatex();
   };
 }));

--- a/src/controller.js
+++ b/src/controller.js
@@ -12,7 +12,7 @@ var Controller = P(function(_) {
     this.root = root;
     this.container = container;
 
-    API.controller = root.controller = this;
+    API.__controller = root.controller = this;
 
     this.cursor = root.cursor = Cursor(root, API.__options);
     // TODO: stop depending on root.cursor, and rm it

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -73,25 +73,25 @@ var AbstractMathQuill = P(function(_) {
     }
     return this;
   };
-  _.el = function() { return this.controller.container[0]; };
-  _.text = function() { return this.controller.exportText(); };
+  _.el = function() { return this.__controller.container[0]; };
+  _.text = function() { return this.__controller.exportText(); };
   _.latex = function(latex) {
     if (arguments.length > 0) {
-      this.controller.renderLatexMath(latex);
-      if (this.controller.blurred) this.controller.cursor.hide().parent.blur();
+      this.__controller.renderLatexMath(latex);
+      if (this.__controller.blurred) this.__controller.cursor.hide().parent.blur();
       return this;
     }
-    return this.controller.exportLatex();
+    return this.__controller.exportLatex();
   };
   _.html = function() {
-    return this.controller.root.jQ.html()
+    return this.__controller.root.jQ.html()
       .replace(/ mathquill-(?:command|block)-id="?\d+"?/g, '')
       .replace(/<span class="?mq-cursor( mq-blink)?"?>.?<\/span>/i, '')
       .replace(/ mq-hasCursor|mq-hasCursor ?/, '')
       .replace(/ class=(""|(?= |>))/g, '');
   };
   _.reflow = function() {
-    this.controller.root.postOrder('reflow');
+    this.__controller.root.postOrder('reflow');
     return this;
   };
 });
@@ -100,13 +100,13 @@ MathQuill.prototype = AbstractMathQuill.prototype;
 MathQuill.StaticMath = APIFnFor(P(AbstractMathQuill, function(_, super_) {
   _.init = function(el) {
     this.initRoot(MathBlock(), el.addClass('mq-math-mode'));
-    this.controller.delegateMouseEvents();
-    this.controller.staticMathTextareaEvents();
+    this.__controller.delegateMouseEvents();
+    this.__controller.staticMathTextareaEvents();
   };
   _.latex = function() {
     var returned = super_.latex.apply(this, arguments);
     if (arguments.length > 0) {
-      this.controller.root.postOrder('registerInnerField', this.innerFields = []);
+      this.__controller.root.postOrder('registerInnerField', this.innerFields = []);
     }
     return returned;
   };
@@ -115,20 +115,20 @@ MathQuill.StaticMath = APIFnFor(P(AbstractMathQuill, function(_, super_) {
 var EditableField = MathQuill.EditableField = P(AbstractMathQuill, function(_) {
   _.initRootAndEvents = function(root, el, opts) {
     this.initRoot(root, el, opts);
-    this.controller.editable = true;
-    this.controller.delegateMouseEvents();
-    this.controller.editablesTextareaEvents();
+    this.__controller.editable = true;
+    this.__controller.delegateMouseEvents();
+    this.__controller.editablesTextareaEvents();
     root.setHandlers(this.__options.handlers, this);
   };
-  _.focus = function() { this.controller.textarea.focus(); return this; };
-  _.blur = function() { this.controller.textarea.blur(); return this; };
+  _.focus = function() { this.__controller.textarea.focus(); return this; };
+  _.blur = function() { this.__controller.textarea.blur(); return this; };
   _.write = function(latex) {
-    this.controller.writeLatex(latex);
-    if (this.controller.blurred) this.controller.cursor.hide().parent.blur();
+    this.__controller.writeLatex(latex);
+    if (this.__controller.blurred) this.__controller.cursor.hide().parent.blur();
     return this;
   };
   _.cmd = function(cmd) {
-    var ctrlr = this.controller.notify(), cursor = ctrlr.cursor.show();
+    var ctrlr = this.__controller.notify(), cursor = ctrlr.cursor.show();
     if (/^\\[a-z]+$/i.test(cmd)) {
       cmd = cmd.slice(1);
       var klass = LatexCmds[cmd];
@@ -144,18 +144,18 @@ var EditableField = MathQuill.EditableField = P(AbstractMathQuill, function(_) {
     return this;
   };
   _.select = function() {
-    var ctrlr = this.controller;
+    var ctrlr = this.__controller;
     ctrlr.notify('move').cursor.insAtRightEnd(ctrlr.root);
     while (ctrlr.cursor[L]) ctrlr.selectLeft();
     return this;
   };
   _.clearSelection = function() {
-    this.controller.cursor.clearSelection();
+    this.__controller.cursor.clearSelection();
     return this;
   };
 
   _.moveToDirEnd = function(dir) {
-    this.controller.notify('move').cursor.insAtDirEnd(dir, this.controller.root);
+    this.__controller.notify('move').cursor.insAtDirEnd(dir, this.__controller.root);
     return this;
   };
   _.moveToLeftEnd = function() { return this.moveToDirEnd(L); };
@@ -164,12 +164,12 @@ var EditableField = MathQuill.EditableField = P(AbstractMathQuill, function(_) {
   _.keystroke = function(keys) {
     var keys = keys.replace(/^\s+|\s+$/g, '').split(/\s+/);
     for (var i = 0; i < keys.length; i += 1) {
-      this.controller.keystroke(keys[i], { preventDefault: noop });
+      this.__controller.keystroke(keys[i], { preventDefault: noop });
     }
     return this;
   };
   _.typedText = function(text) {
-    for (var i = 0; i < text.length; i += 1) this.controller.typedText(text.charAt(i));
+    for (var i = 0; i < text.length; i += 1) this.__controller.typedText(text.charAt(i));
     return this;
   };
 });

--- a/test/unit/SupSub.test.js
+++ b/test/unit/SupSub.test.js
@@ -48,7 +48,7 @@ suite('SupSub', function() {
             doTo(mq, cmd);
             assert.equal(mq.latex().replace(/ /g, ''), expected);
 
-            prayWellFormedPoint(mq.controller.cursor);
+            prayWellFormedPoint(mq.__controller.cursor);
 
             mq.typedText('c');
             assert.equal(mq.latex().replace(/ /g, ''), expectedAfterC);
@@ -87,7 +87,7 @@ suite('SupSub', function() {
           doTo(mq);
           assert.equal(mq.latex().replace(/ /g, ''), expected);
 
-          prayWellFormedPoint(mq.controller.cursor);
+          prayWellFormedPoint(mq.__controller.cursor);
 
           mq.typedText('c');
           assert.equal(mq.latex().replace(/ /g, ''), expectedAfterC);

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -75,18 +75,18 @@ suite('Public API', function() {
 
     test('select, clearSelection', function() {
       mq.latex('n+\\frac{n}{2}');
-      assert.ok(!mq.controller.cursor.selection);
+      assert.ok(!mq.__controller.cursor.selection);
       mq.select();
-      assert.equal(mq.controller.cursor.selection.join('latex'), 'n+\\frac{n}{2}');
+      assert.equal(mq.__controller.cursor.selection.join('latex'), 'n+\\frac{n}{2}');
       mq.clearSelection();
-      assert.ok(!mq.controller.cursor.selection);
+      assert.ok(!mq.__controller.cursor.selection);
     });
 
     test('latex while there\'s a selection', function() {
       mq.latex('a');
       assert.equal(mq.latex(), 'a');
       mq.select();
-      assert.equal(mq.controller.cursor.selection.join('latex'), 'a');
+      assert.equal(mq.__controller.cursor.selection.join('latex'), 'a');
       mq.latex('b');
       assert.equal(mq.latex(), 'b');
       mq.typedText('c');
@@ -100,14 +100,14 @@ suite('Public API', function() {
 
     test('.moveToDirEnd(dir)', function() {
       mq.latex('a x^2 + b x + c = 0');
-      assert.equal(mq.controller.cursor[L].ctrlSeq, '0');
-      assert.equal(mq.controller.cursor[R], 0);
+      assert.equal(mq.__controller.cursor[L].ctrlSeq, '0');
+      assert.equal(mq.__controller.cursor[R], 0);
       mq.moveToLeftEnd();
-      assert.equal(mq.controller.cursor[L], 0);
-      assert.equal(mq.controller.cursor[R].ctrlSeq, 'a');
+      assert.equal(mq.__controller.cursor[L], 0);
+      assert.equal(mq.__controller.cursor[R].ctrlSeq, 'a');
       mq.moveToRightEnd();
-      assert.equal(mq.controller.cursor[L].ctrlSeq, '0');
-      assert.equal(mq.controller.cursor[R], 0);
+      assert.equal(mq.__controller.cursor[L].ctrlSeq, '0');
+      assert.equal(mq.__controller.cursor[R], 0);
     });
   });
 
@@ -218,8 +218,8 @@ suite('Public API', function() {
     var mq, rootBlock, cursor;
     test('space behaves like tab with default opts', function() {
       mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
-      rootBlock = mq.controller.root;
-      cursor = mq.controller.cursor;
+      rootBlock = mq.__controller.root;
+      cursor = mq.__controller.cursor;
 
       mq.latex('\\sqrt{x}');
       mq.keystroke('Left');
@@ -240,8 +240,8 @@ suite('Public API', function() {
     test('space behaves like tab when spaceBehavesLikeTab is true', function() {
       var opts = { 'spaceBehavesLikeTab': true };
       mq = MathQuill.MathField( $('<span></span>').appendTo('#mock')[0], opts)
-      rootBlock = mq.controller.root;
-      cursor = mq.controller.cursor;
+      rootBlock = mq.__controller.root;
+      cursor = mq.__controller.cursor;
 
       mq.latex('\\sqrt{x}');
 
@@ -261,8 +261,8 @@ suite('Public API', function() {
       MathQuill.config({ spaceBehavesLikeTab: true });
 
       mq = MathQuill.MathField( $('<span></span>').appendTo('#mock')[0]);
-      rootBlock = mq.controller.root;
-      cursor = mq.controller.cursor;
+      rootBlock = mq.__controller.root;
+      cursor = mq.__controller.cursor;
 
       mq.latex('\\sqrt{x}');
 

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -9,7 +9,7 @@ suite('typing with auto-replaces', function() {
 
   function prayWellFormedPoint(pt) { prayWellFormed(pt.parent, pt[L], pt[R]); }
   function assertLatex(latex) {
-    prayWellFormedPoint(mq.controller.cursor);
+    prayWellFormedPoint(mq.__controller.cursor);
     assert.equal(mq.latex(), latex);
   }
 

--- a/test/unit/updown.test.js
+++ b/test/unit/updown.test.js
@@ -2,8 +2,8 @@ suite('up/down', function() {
   var mq, rootBlock, controller, cursor;
   setup(function() {
     mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
-    rootBlock = mq.controller.root;
-    controller = mq.controller;
+    rootBlock = mq.__controller.root;
+    controller = mq.__controller;
     cursor = controller.cursor;
   });
   teardown(function() {
@@ -180,9 +180,9 @@ suite('up/down', function() {
     );
     var inner = MathQuill($(outer.el()).find('.mq-editable-field')[0]);
 
-    assert.equal(inner.controller.cursor.parent, inner.controller.root);
+    assert.equal(inner.__controller.cursor.parent, inner.__controller.root);
     inner.keystroke('Down');
-    assert.equal(inner.controller.cursor.parent, inner.controller.root);
+    assert.equal(inner.__controller.cursor.parent, inner.__controller.root);
 
     $(outer.el()).remove();
   });


### PR DESCRIPTION
This isn't part of the public API, it's only exposed because "we're all
consenting adults here", but it should be namespaced differently from
the public methods, especially seeing as our own README example suggests
adding extra properties to MathQuill API objects:
https://github.com/mathquill/mathquill/commit/6011db1ee9568f37e13eb3f2c6829f6f04939933#diff-04c6e90faac2675aa89e2176d2eec7d8R182

So, namespace by prefixing with two underscores, Python-style, like we
did with `.__options`:
https://github.com/mathquill/mathquill/commit/c60fa6cbe4c43a3ed8ef5bfdcee1cfb1d953648f#diff-9e90820baf0fc358322430e6d2b3beefR51
