### PR TITLE
Add bower.json to register mathquill on the bower registry

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,19 @@
+{
+  "name": "mathquill",
+  "version": "0.9.3",
+  "main": [
+    "build/mathquill.min.js",
+    "build/mathquill.css"
+  ],
+  "ignore": [
+    "test/**/*"
+  ],
+  "dependencies": {
+    "jquery": ">=1.4.3"
+  },
+  "keywords": [
+    "mathquill",
+    "math",
+    "latex"
+  ]
+}


### PR DESCRIPTION
bower is a registry for frontend packages. This bower.json makes it possible to add mathquill to bower using the simple instructions explained here:

http://bower.io/docs/creating-packages/

If the maintainers don't want to maintain the bower package, I can also do that.
