### PR TITLE
Fix .latex(undefined) throwing TypeError

### DIFF
--- a/src/services/parser.util.js
+++ b/src/services/parser.util.js
@@ -20,7 +20,7 @@ var Parser = P(function(_, super_, Parser) {
   _.init = function(body) { this._ = body; };
 
   _.parse = function(stream) {
-    return this.skip(eof)._(stream, success, parseError);
+    return this.skip(eof)._(''+stream, success, parseError);
 
     function success(stream, result) { return result; }
   };

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -112,28 +112,31 @@ suite('latex', function() {
     });
 
     suite('.latex(...)', function() {
+      function assertParsesLatex(str, latex) {
+        if (arguments.length < 2) latex = str;
+        mq.latex(str);
+        assert.equal(mq.latex(), latex);
+      }
+
       test('basic rendering', function() {
-        mq.latex('x = \\frac{ -b \\pm \\sqrt{ b^2 - 4ac } }{ 2a }');
-        assert.equal(mq.latex(), 'x=\\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}');
+        assertParsesLatex('x = \\frac{ -b \\pm \\sqrt{ b^2 - 4ac } }{ 2a }',
+                          'x=\\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}');
       });
 
       test('re-rendering', function() {
-        mq.latex('a x^2 + b x + c = 0');
-        assert.equal(mq.latex(), 'ax^2+bx+c=0');
-        mq.latex('x = \\frac{ -b \\pm \\sqrt{ b^2 - 4ac } }{ 2a }');
-        assert.equal(mq.latex(), 'x=\\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}');
+        assertParsesLatex('a x^2 + b x + c = 0', 'ax^2+bx+c=0');
+        assertParsesLatex('x = \\frac{ -b \\pm \\sqrt{ b^2 - 4ac } }{ 2a }',
+                          'x=\\frac{-b\\pm\\sqrt{b^2-4ac}}{2a}');
       });
 
       test('empty LaTeX', function () {
-        function assertParsesLatex(str, latex) {
-          if (arguments.length < 2) latex = str;
-          mq.latex(str);
-          assert.equal(mq.latex(), latex);
-        }
         assertParsesLatex('');
         assertParsesLatex(' ', '');
         assertParsesLatex('{}', '');
         assertParsesLatex('   {}{} {{{}}  }', '');
+      });
+
+      test('coerces to a string', function () {
       });
     });
 

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -137,6 +137,15 @@ suite('latex', function() {
       });
 
       test('coerces to a string', function () {
+        assertParsesLatex(undefined, 'undefined');
+        assertParsesLatex(null, 'null');
+        assertParsesLatex(0, '0');
+        assertParsesLatex(Infinity, 'Infinity');
+        assertParsesLatex(NaN, 'NaN');
+        assertParsesLatex(true, 'true');
+        assertParsesLatex(false, 'false');
+        assertParsesLatex({}, '[objectObject]'); // lol, the space gets ignored
+        assertParsesLatex({toString: function() { return 'thing'; }}, 'thing');
       });
     });
 


### PR DESCRIPTION
Or `.latex()` of anything besides a string, in fact. Now `.latex()` also
coerces to a string, Python-style.