### PR TITLE
[dev] Fractions in exponents too low in IE8-11

### DIFF
--- a/src/css/math.less
+++ b/src/css/math.less
@@ -122,7 +122,7 @@
 
       .mq-sup {
         display: inline-block;
-        vertical-align: bottom;
+        vertical-align: text-bottom;
       }
     }
 


### PR DESCRIPTION
...if there isn't also a subscript. Which is to say, the fraction in `x^{\frac{1}{2}}` is too low, but not the fraction in `x_1^{\frac{1}{2}}`. Also, I only tested IE8 and IE11, I didn't actually try the ones in between.

The bug only happens when there's no subscript because it's the `.mq-sup-only` CSS rules that exhibits this bug, which are different from the normal `.mq-sup-sub` CSS rules because they would require an empty subscript element to work, or something. I dunno, #246 was a while ago.

Anyway, I made a minimal test case, http://jsbin.com/miziqe/1, and reported it as an IE bug: https://connect.microsoft.com/IE/feedback/details/1076351