### PR TITLE
Fix fraction spacing

### DIFF
--- a/src/css/math.less
+++ b/src/css/math.less
@@ -239,14 +239,13 @@
 
   .mq-numerator {
     padding: 0 0.1em;
-    margin-bottom: -0.1em;
   }
 
   .mq-denominator {
     border-top: 1px solid;
     float: right; // take out of normal flow to manipulate baseline
     width: 100%;
-    padding: .1em .1em 0 .1em;
+    padding: .2em .1em 0 .1em;
     margin-right: -.1em;
     margin-left: -.1em;
   }

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -245,7 +245,7 @@
     border-top: 1px solid;
     float: right; // take out of normal flow to manipulate baseline
     width: 100%;
-    padding: .2em .1em 0 .1em;
+    padding: .15em .1em 0 .1em;
     margin-right: -.1em;
     margin-left: -.1em;
   }

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -148,14 +148,6 @@
       font-size: 70%;
       vertical-align: -0.4em;
     }
-
-    .mq-numerator {
-      padding-bottom: 0;
-    }
-
-    .mq-denominator {
-      padding-top: 0;
-    }
   }
 
   sup.mq-nthroot {


### PR DESCRIPTION
Fix fraction-related spacing stuff. The main thing is fixing numerators to not overlap with the fraction bar (which is espesh visible when selecting a numerator), but also slightly improving the spacing of denominators relative to the fraction bar, particularly in SupSubs.