### PR TITLE
Typing ~ should produce \sim

### DIFF
--- a/src/commands/math/advancedSymbols.js
+++ b/src/commands/math/advancedSymbols.js
@@ -3,7 +3,6 @@
  ***********************************/
 
 LatexCmds.notin =
-LatexCmds.sim =
 LatexCmds.cong =
 LatexCmds.equiv =
 LatexCmds.oplus =

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -446,3 +446,5 @@ LatexCmds.times = bind(BinaryOperator, '\\times ', '&times;', '[x]');
 
 LatexCmds['÷'] = LatexCmds.div = LatexCmds.divide = LatexCmds.divides =
   bind(BinaryOperator,'\\div ','&divide;', '[/]');
+
+CharCmds['~'] = LatexCmds.sim = bind(BinaryOperator, '\\sim ', '&sim;', '~');


### PR DESCRIPTION
Note that `~` is a special character in LaTeX, it's a non-breaking space
kinda like `&nbsp;`
http://tex.stackexchange.com/a/41268