### PR TITLE
Configure inner math field with options

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -357,9 +357,9 @@ var MathBlock = P(MathElement, function(_, super_) {
   _.html = function() { return this.join('html'); };
   _.latex = function() { return this.join('latex'); };
   _.text = function() {
-    return this.ends[L] === this.ends[R] ?
+    return (this.ends[L] === this.ends[R] && this.ends[L] !== 0) ?
       this.ends[L].text() :
-      '(' + this.join('text') + ')'
+      this.join('text')
     ;
   };
 

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -686,9 +686,10 @@ LatexCmds.choose = P(Binomial, function(_) {
 });
 
 var InnerMathField = P(MathQuill.MathField, function(_) {
-  _.init = function(root, container) {
+  _.init = function(root, container, options) {
     RootBlockMixin(root);
     this.__options = Options();
+    this.config(options);
     var ctrlr = Controller(this, root, container);
     ctrlr.editable = true;
     ctrlr.createTextarea();
@@ -710,7 +711,7 @@ LatexCmds.MathQuillMathField = P(MathCommand, function(_, super_) {
       .map(function(name) { self.name = name; }).or(succeed())
       .then(super_.parser.call(self));
   };
-  _.finalizeTree = function() { InnerMathField(this.ends[L], this.jQ); };
+  _.finalizeTree = function(options) { InnerMathField(this.ends[L], this.jQ, options); };
   _.registerInnerField = function(innerFields) {
     innerFields.push(innerFields[this.name] = this.ends[L].controller.API);
   };

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -15,7 +15,7 @@ var Cursor = P(Point, function(_) {
     this.parent = initParent;
     this.options = options;
 
-    var jQ = this.jQ = this._jQ = $('<span class="mq-cursor">&zwj;</span>');
+    var jQ = this.jQ = this._jQ = $('<span class="mq-cursor">&8203;</span>');
     //closured for setInterval
     this.blink = function(){ jQ.toggleClass('mq-blink'); };
 

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -97,6 +97,33 @@ suite('Public API', function() {
       mq.latex('x+y');
       assert.equal(mq.html(), '<var>x</var><span class="mq-binary-operator">+</span><var>y</var>');
     });
+    
+    test('.text() with incomplete commands', function() {
+      assert.equal(mq.text(), '');
+      mq.typedText('\\');
+      assert.equal(mq.text(), '\\');
+      mq.typedText('s');
+      assert.equal(mq.text(), '\\s');
+      mq.typedText('qrt');
+      assert.equal(mq.text(), '\\sqrt');
+    });
+    
+    test('.text() with complete commands', function() {
+      mq.latex('\\sqrt{}');
+      assert.equal(mq.text(), 'sqrt()');
+      mq.latex('\\nthroot[]{}');
+      assert.equal(mq.text(), 'sqrt[]()');
+      mq.latex('\\frac{}{}');
+      assert.equal(mq.text(), '(/)');
+      mq.latex('\\frac{3}{5}');
+      assert.equal(mq.text(), '(3/5)');
+      mq.latex('\\div');
+      assert.equal(mq.text(), '[/]');
+      mq.latex('^{}');
+      assert.equal(mq.text(), '**');
+      mq.latex('3^{4}');
+      assert.equal(mq.text(), '3**4');
+    });
 
     test('.moveToDirEnd(dir)', function() {
       mq.latex('a x^2 + b x + c = 0');


### PR DESCRIPTION
When finalizeTree() is called for inner math fields, it takes an
options object as a parameter. This object was not actually used to
configure the inner math field. This change ensures inner math fields
are configured correctly with the passed options.