### PR TITLE
Add 'autoSubscriptNumerals' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ var mathField = MathQuill.MathField(el[0], {
   sumStartsWithNEquals: true,
   supSubsRequireOperand: true,
   charsThatBreakOutOfSupSub: '+-=<>',
+  autoSubscriptNumerals: true,
   autoCommands: 'pi theta sqrt sum',
   autoOperatorNames: 'sin cos etc',
   substituteTextarea: function() {

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -396,7 +396,7 @@ var MathBlock = P(MathElement, function(_, super_) {
     while (pageX < node.jQ.offset().left) node = node[L];
     return node.seek(pageX, cursor);
   };
-  _.write = function(cursor, ch, replacedFragment) {
+  _.write = function(cursor, ch) {
     var cmd;
     if (ch.match(/^[a-eg-zA-Z]$/)) //exclude f because want florin
       cmd = Letter(ch);
@@ -405,7 +405,7 @@ var MathBlock = P(MathElement, function(_, super_) {
     else
       cmd = VanillaSymbol(ch);
 
-    if (replacedFragment) cmd.replaces(replacedFragment);
+    if (cursor.selection) cmd.replaces(cursor.replaceSelection());
 
     cmd.createLeftOf(cursor);
   };

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -396,18 +396,21 @@ var MathBlock = P(MathElement, function(_, super_) {
     while (pageX < node.jQ.offset().left) node = node[L];
     return node.seek(pageX, cursor);
   };
-  _.write = function(cursor, ch) {
-    var cmd;
+  _.chToCmd = function(ch) {
+    var cons;
     if (ch.match(/^[a-eg-zA-Z]$/)) //exclude f because want florin
-      cmd = Letter(ch);
-    else if (cmd = CharCmds[ch] || LatexCmds[ch])
-      cmd = cmd(ch);
+      return Letter(ch);
+    else if (/^\d$/.test(ch))
+      return Digit(ch);
+    else if (cons = CharCmds[ch] || LatexCmds[ch])
+      return cons(ch);
     else
-      cmd = VanillaSymbol(ch);
-
+      return VanillaSymbol(ch);
+  };
+  _.write = function(cursor, ch) {
+    var cmd = this.chToCmd(ch);
     if (cursor.selection) cmd.replaces(cursor.replaceSelection());
-
-    cmd.createLeftOf(cursor);
+    cmd.createLeftOf(cursor.show());
   };
 
   _.focus = function() {

--- a/src/commands/math/LatexCommandInput.js
+++ b/src/commands/math/LatexCommandInput.js
@@ -27,8 +27,8 @@ CharCmds['\\'] = P(MathCommand, function(_, super_) {
 
       return this;
     };
-    this.ends[L].write = function(cursor, ch, replacedFragment) {
-      if (replacedFragment) replacedFragment.remove();
+    this.ends[L].write = function(cursor, ch) {
+      cursor.show().deleteSelection();
 
       if (ch.match(/[a-z]/i)) VanillaSymbol(ch).createLeftOf(cursor);
       else {

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -2,6 +2,20 @@
  * Symbols for Basic Mathematics
  ********************************/
 
+var Digit = P(VanillaSymbol, function(_, super_) {
+  _.createLeftOf = function(cursor) {
+    if (cursor.options.autoSubscriptNumerals
+        && cursor.parent !== cursor.parent.parent.sub
+        && (cursor[L] instanceof Variable
+          || (cursor[L] instanceof SupSub && cursor[L][L] instanceof Variable))) {
+      LatexCmds._().createLeftOf(cursor);
+      super_.createLeftOf.call(this, cursor);
+      cursor.insRightOf(cursor.parent.parent);
+    }
+    else super_.createLeftOf.call(this, cursor);
+  };
+});
+
 var Variable = P(Symbol, function(_, super_) {
   _.init = function(ch, html) {
     super_.init.call(this, ch, '<var>'+(html || ch)+'</var>');

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -237,6 +237,51 @@ var SupSub = P(MathCommand, function(_, super_) {
   };
 });
 
+function insLeftOfMeUnlessAtEnd(cursor) {
+  // cursor.insLeftOf(cmd), unless cursor at the end of block, and every
+  // ancestor cmd is at the end of every ancestor block
+  var cmd = this.parent, ancestorCmd = cursor;
+  do {
+    if (ancestorCmd[R]) return cursor.insLeftOf(cmd);
+    ancestorCmd = ancestorCmd.parent.parent;
+  } while (ancestorCmd !== cmd);
+  cursor.insRightOf(cmd);
+}
+
+LatexCmds.subscript =
+LatexCmds._ = P(SupSub, function(_, super_) {
+  _.supsub = 'sub';
+  _.htmlTemplate =
+      '<span class="mq-supsub mq-non-leaf">'
+    +   '<span class="mq-sub">&0</span>'
+    +   '<span style="display:inline-block;width:0">&nbsp;</span>'
+    + '</span>'
+  ;
+  _.textTemplate = [ '_' ];
+  _.finalizeTree = function() {
+    this.downInto = this.sub = this.ends[L];
+    this.sub.upOutOf = insLeftOfMeUnlessAtEnd;
+    super_.finalizeTree.call(this);
+  };
+});
+
+LatexCmds.superscript =
+LatexCmds.supscript =
+LatexCmds['^'] = P(SupSub, function(_, super_) {
+  _.supsub = 'sup';
+  _.htmlTemplate =
+      '<span class="mq-supsub mq-non-leaf mq-sup-only">'
+    +   '<span class="mq-sup">&0</span>'
+    + '</span>'
+  ;
+  _.textTemplate = [ '**' ];
+  _.finalizeTree = function() {
+    this.upInto = this.sup = this.ends[R];
+    this.sup.downOutOf = insLeftOfMeUnlessAtEnd;
+    super_.finalizeTree.call(this);
+  };
+});
+
 var SummationNotation = P(MathCommand, function(_, super_) {
   _.init = function(ch, html) {
     var htmlTemplate =
@@ -300,53 +345,6 @@ LatexCmds.product = bind(SummationNotation,'\\prod ','&prod;');
 
 LatexCmds.coprod =
 LatexCmds.coproduct = bind(SummationNotation,'\\coprod ','&#8720;');
-
-
-
-function insLeftOfMeUnlessAtEnd(cursor) {
-  // cursor.insLeftOf(cmd), unless cursor at the end of block, and every
-  // ancestor cmd is at the end of every ancestor block
-  var cmd = this.parent, ancestorCmd = cursor;
-  do {
-    if (ancestorCmd[R]) return cursor.insLeftOf(cmd);
-    ancestorCmd = ancestorCmd.parent.parent;
-  } while (ancestorCmd !== cmd);
-  cursor.insRightOf(cmd);
-}
-
-LatexCmds.subscript =
-LatexCmds._ = P(SupSub, function(_, super_) {
-  _.supsub = 'sub';
-  _.htmlTemplate =
-      '<span class="mq-supsub mq-non-leaf">'
-    +   '<span class="mq-sub">&0</span>'
-    +   '<span style="display:inline-block;width:0">&nbsp;</span>'
-    + '</span>'
-  ;
-  _.textTemplate = [ '_' ];
-  _.finalizeTree = function() {
-    this.downInto = this.sub = this.ends[L];
-    this.sub.upOutOf = insLeftOfMeUnlessAtEnd;
-    super_.finalizeTree.call(this);
-  };
-});
-
-LatexCmds.superscript =
-LatexCmds.supscript =
-LatexCmds['^'] = P(SupSub, function(_, super_) {
-  _.supsub = 'sup';
-  _.htmlTemplate =
-      '<span class="mq-supsub mq-non-leaf mq-sup-only">'
-    +   '<span class="mq-sup">&0</span>'
-    + '</span>'
-  ;
-  _.textTemplate = [ '**' ];
-  _.finalizeTree = function() {
-    this.upInto = this.sup = this.ends[R];
-    this.sup.downOutOf = insLeftOfMeUnlessAtEnd;
-    super_.finalizeTree.call(this);
-  };
-});
 
 var Fraction =
 LatexCmds.frac =

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -91,8 +91,8 @@ var TextBlock = P(Node, function(_, super_) {
     // backspace and delete at ends of block don't unwrap
     if (this.isEmpty()) cursor.insRightOf(this);
   };
-  _.write = function(cursor, ch, replacedFragment) {
-    if (replacedFragment) replacedFragment.remove();
+  _.write = function(cursor, ch) {
+    cursor.show().deleteSelection();
 
     if (ch !== '$') {
       if (!cursor[L]) TextPiece(ch).createLeftOf(cursor);
@@ -324,9 +324,9 @@ var RootMathCommand = P(MathCommand, function(_, super_) {
     super_.createBlocks.call(this);
 
     this.ends[L].cursor = this.cursor;
-    this.ends[L].write = function(cursor, ch, replacedFragment) {
+    this.ends[L].write = function(cursor, ch) {
       if (ch !== '$')
-        MathBlock.prototype.write.call(this, cursor, ch, replacedFragment);
+        MathBlock.prototype.write.call(this, cursor, ch);
       else if (this.isEmpty()) {
         cursor.insRightOf(this.parent);
         this.parent.deleteTowards(dir, cursor);
@@ -337,7 +337,7 @@ var RootMathCommand = P(MathCommand, function(_, super_) {
       else if (!cursor[L])
         cursor.insLeftOf(this.parent);
       else
-        MathBlock.prototype.write.call(this, cursor, ch, replacedFragment);
+        MathBlock.prototype.write.call(this, cursor, ch);
     };
   };
   _.latex = function() {
@@ -350,8 +350,8 @@ var RootTextBlock = P(RootMathBlock, function(_, super_) {
     if (key === 'Spacebar' || key === 'Shift-Spacebar') return;
     return super_.keystroke.apply(this, arguments);
   };
-  _.write = function(cursor, ch, replacedFragment) {
-    if (replacedFragment) replacedFragment.remove();
+  _.write = function(cursor, ch) {
+    cursor.show().deleteSelection();
     if (ch === '$')
       RootMathCommand(cursor).createLeftOf(cursor);
     else {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -127,18 +127,18 @@ var EditableField = MathQuill.EditableField = P(AbstractMathQuill, function(_) {
     return this;
   };
   _.cmd = function(cmd) {
-    var ctrlr = this.__controller.notify(), cursor = ctrlr.cursor.show();
+    var ctrlr = this.__controller.notify(), cursor = ctrlr.cursor;
     if (/^\\[a-z]+$/i.test(cmd)) {
       cmd = cmd.slice(1);
       var klass = LatexCmds[cmd];
       if (klass) {
         cmd = klass(cmd);
         if (cursor.selection) cmd.replaces(cursor.replaceSelection());
-        cmd.createLeftOf(cursor);
+        cmd.createLeftOf(cursor.show());
       }
       else /* TODO: API needs better error reporting */;
     }
-    else cursor.parent.write(cursor, cmd, cursor.replaceSelection());
+    else cursor.parent.write(cursor, cmd);
     if (ctrlr.blurred) cursor.hide().parent.blur();
     return this;
   };

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -85,7 +85,7 @@ Controller.open(function(_) {
   _.typedText = function(ch) {
     if (ch === '\n') return this.handle('enter');
     var cursor = this.notify().cursor;
-    cursor.parent.write(cursor, ch, cursor.show().replaceSelection());
+    cursor.parent.write(cursor, ch);
     this.scrollHoriz();
   };
   _.paste = function(text) {

--- a/test/visual.html
+++ b/test/visual.html
@@ -114,6 +114,7 @@ $(function() {
     sumStartsWithNEquals: true,
     supSubsRequireOperand: true,
     charsThatBreakOutOfSupSub: '+-=<>',
+    autoSubscriptNumerals: true,
     autoCommands: 'pi theta sqrt sum',
     autoOperatorNames: 'only'
   });


### PR DESCRIPTION
When enabled, typing `x1` results in `x_1` with the cursor to the right
of the subscript. Typing more numerals extends the subscript without
putting the cursor inside the subscript (thanks `contactWeld`), and
backspacing "peels off" the last symbol in the subscript. Left and right
arrow keys go around the subscript, skipping its contents entirely. The
down arrow still goes into the subscript, but inside the subscript,
typing `_` is ignored, and typing anything other than a symbol (`^` or `/`)
pretends the cursor is to the right of the subscript.

@jwmerrill 