### PR TITLE
`OMIT_FONT_FACE=true make` omits @font-face{}

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ UGLIFY_OPTS ?= --mangle --compress hoist_vars=true
 
 LESSC ?= ./node_modules/.bin/lessc
 LESS_OPTS ?=
+ifdef OMIT_FONT_FACE
+  LESS_OPTS += --modify-var="omit-font-face=true"
+endif
 
 # Empty target files whose Last Modified timestamps are used to record when
 # something like `npm install` last happened (which, for example, would then be

--- a/src/css/font.less
+++ b/src/css/font.less
@@ -1,10 +1,14 @@
-@font-face {
-  font-family: Symbola;
-  .font-face();
+@omit-font-face:;
+.font-face;
+.font-face() when not (@omit-font-face) {
+  @font-face {
+    font-family: Symbola;
+    .font-srcs;
+  }
 }
 
 @basic:;
-.font-face() when not (@basic) {
+.font-srcs() when not (@basic) {
   src: url(font/Symbola.eot);
   src:
     local("Symbola Regular"),
@@ -14,7 +18,7 @@
     url(font/Symbola.svg#Symbola) format("svg")
   ;
 }
-.font-face() when (@basic) {
+.font-srcs() when (@basic) {
   src: url(font/Symbola-basic.eot);
   src:
     local("Symbola Regular"),


### PR DESCRIPTION
Any non-empty value for $OMIT_FONT_FACE works, e.g. OMIT_FONT_FACE=t or
OMIT_FONT_FACE=1 or OMIT_FONT_FACE=0 or OMIT_FONT_FACE=false.

Applies to any make target that compiles .less to .css, including
`OMIT_FONT_FACE=true make dev` and `OMIT_FONT_FACE=true make basic`.

--

This is an important feature because there's just too many approaches to
@font-face with too many different tradeoffs between performance and
compatibility, there's no one-size-fits-all that MathQuill can use.
Paul Irish maintains what is probably the most comprehensive and widely
cited reference on @font-face techniques, check out all the gotchas even
on the recommended technique among 7 alternatives:

http://www.paulirish.com/2009/bulletproof-font-face-implementation-syntax/

Let's not forget the follow-up post that exclusively lists more gotchas:

http://www.paulirish.com/2010/font-face-gotchas/

@jwmerrill 