### PR TITLE
Feature: restrictMismatchedBrackets

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ var el = $('<span>x^2</span>').appendTo('body');
 var mathField = MathQuill.MathField(el[0], {
   spaceBehavesLikeTab: true,
   leftRightIntoCmdGoes: 'up',
+  restrictMismatchedBrackets: true,
   sumStartsWithNEquals: true,
   supSubsRequireOperand: true,
   charsThatBreakOutOfSupSub: '+-=<>',
@@ -175,6 +176,11 @@ can't get to it with just Left and Right, you have to press Down); which is
 the same behavior as the Desmos calculator. `'down'` instead means it is the
 numerator that is always skipped, which is the same behavior as the Mac OS X
 built-in app Grapher.
+
+If `restrictMismatchedBrackets` is true then you can type [a,b) and [a,b), but
+if you try typing `[x}` or `\langle x|`, you'll get `[{x}]` or
+`\langle|x|\rangle` instead. This lets you type `(|x|+1)` normally; otherwise,
+you'd get `\left( \right| x \left| + 1 \right)`.
 
 If `sumStartsWithNEquals` is true then when you type `\sum`, `\prod`, or
 `\coprod`, the lower limit starts out with `n=`, e.g. you get the LaTeX

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -521,8 +521,8 @@ var Bracket = P(P(MathCommand, DelimsMixin), function(_, super_) {
     return '\\left'+this.sides[L].ctrlSeq+this.ends[L].latex()+'\\right'+this.sides[R].ctrlSeq;
   };
   _.oppBrack = function(node, expectedSide) {
-    // node must be 1-sided bracket of expected side (if any, may be undefined),
-    // and unless I'm a pipe, node and I must be opposite-facing sides
+    // return node iff it's a 1-sided bracket of expected side (if any, may be
+    // undefined), and of opposite side from me if I'm not a pipe
     return node instanceof Bracket && node.side && node.side !== -expectedSide
       && (this.sides[this.side].ch === '|' || node.side === -this.side) && node;
   };
@@ -535,6 +535,7 @@ var Bracket = P(P(MathCommand, DelimsMixin), function(_, super_) {
   _.createLeftOf = function(cursor) {
     if (!this.replacedFragment) { // unless wrapping seln in brackets,
         // check if next to or inside an opposing one-sided bracket
+        // (must check both sides 'cos I might be a pipe)
       var brack = this.oppBrack(cursor[L], L) || this.oppBrack(cursor[R], R)
                   || this.oppBrack(cursor.parent.parent);
     }

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -520,11 +520,14 @@ var Bracket = P(P(MathCommand, DelimsMixin), function(_, super_) {
   _.latex = function() {
     return '\\left'+this.sides[L].ctrlSeq+this.ends[L].latex()+'\\right'+this.sides[R].ctrlSeq;
   };
-  _.oppBrack = function(node, expectedSide) {
+  _.oppBrack = function(opts, node, expectedSide) {
     // return node iff it's a 1-sided bracket of expected side (if any, may be
     // undefined), and of opposite side from me if I'm not a pipe
     return node instanceof Bracket && node.side && node.side !== -expectedSide
-      && (this.sides[this.side].ch === '|' || node.side === -this.side) && node;
+      && (this.sides[this.side].ch === '|' || node.side === -this.side)
+      && (!opts.restrictMismatchedBrackets
+        || OPP_BRACKS[this.sides[this.side].ch] === node.sides[node.side].ch
+        || { '(': ']', '[': ')' }[this.sides[L].ch] === node.sides[R].ch) && node;
   };
   _.closeOpposing = function(brack) {
     brack.side = 0;
@@ -536,8 +539,10 @@ var Bracket = P(P(MathCommand, DelimsMixin), function(_, super_) {
     if (!this.replacedFragment) { // unless wrapping seln in brackets,
         // check if next to or inside an opposing one-sided bracket
         // (must check both sides 'cos I might be a pipe)
-      var brack = this.oppBrack(cursor[L], L) || this.oppBrack(cursor[R], R)
-                  || this.oppBrack(cursor.parent.parent);
+      var opts = cursor.options;
+      var brack = this.oppBrack(opts, cursor[L], L)
+                  || this.oppBrack(opts, cursor[R], R)
+                  || this.oppBrack(opts, cursor.parent.parent);
     }
     if (brack) {
       var side = this.side = -brack.side; // may be pipe with .side not yet set
@@ -576,18 +581,19 @@ var Bracket = P(P(MathCommand, DelimsMixin), function(_, super_) {
       return;
     }
 
+    var opts = cursor.options;
     this.side = -side;
-    // check if like deleting outer close-brace of [(1+2)+3} where inner open-
-    if (this.oppBrack(this.ends[L].ends[this.side], side)) { // paren is ghost,
-      this.closeOpposing(this.ends[L].ends[this.side]); // if so become [1+2)+3
+    // if deleting like, outer close-brace of [(1+2)+3} where inner open-paren
+    if (this.oppBrack(opts, this.ends[L].ends[this.side], side)) { // is ghost,
+      this.closeOpposing(this.ends[L].ends[this.side]); // then become [1+2)+3
       var origEnd = this.ends[L].ends[side];
       this.unwrap();
       if (origEnd.siblingCreated) origEnd.siblingCreated(cursor.options, side);
       sib ? cursor.insDirOf(-side, sib) : cursor.insAtDirEnd(side, parent);
     }
-    else { // check if like deleting inner close-brace of ([1+2}+3) where
-      if (this.oppBrack(this.parent.parent, side)) { // outer open-paren is
-        this.parent.parent.closeOpposing(this); // ghost, if so become [1+2+3)
+    else { // if deleting like, inner close-brace of ([1+2}+3) where outer
+      if (this.oppBrack(opts, this.parent.parent, side)) { // open-paren is
+        this.parent.parent.closeOpposing(this); // ghost, then become [1+2+3)
         this.parent.parent.unwrap();
       }
       else { // deleting one of a pair of brackets, become one-sided

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -529,7 +529,7 @@ var Bracket = P(P(MathCommand, DelimsMixin), function(_, super_) {
   _.closeOpposing = function(brack) {
     brack.side = 0;
     brack.sides[this.side] = this.sides[this.side]; // copy over my info (may be
-    brack.delimjQs.eq(this.side === L ? 0 : 1) // mis-matched, like [a, b))
+    brack.delimjQs.eq(this.side === L ? 0 : 1) // mismatched, like [a, b))
       .removeClass('mq-ghost').html(this.sides[this.side].ch);
   };
   _.createLeftOf = function(cursor) {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -736,7 +736,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('0+1+\\left|2+3\\right|+4');
         });
 
-        test('backspacing open-paren mismatched paren/pipe group inside a one-sided pipe 0+|1+(2+3|+4|', function() {
+        test('backspacing open-paren of mismatched paren/pipe group inside a one-sided pipe 0+|1+(2+3|+4|', function() {
           mq.latex('0+1+\\left(2+3\\right|+4');
           assertLatex('0+1+\\left(2+3\\right|+4');
           mq.keystroke('Home Right Right').typedText('|');

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -60,24 +60,24 @@ suite('typing with auto-replaces', function() {
 
   suite('auto-expanding parens', function() {
     suite('simple', function() {
-      test('empty parens', function() {
+      test('empty parens ()', function() {
         mq.typedText('(');
         assertLatex('\\left(\\right)');
         mq.typedText(')');
         assertLatex('\\left(\\right)');
       });
 
-      test('straight typing', function() {
+      test('straight typing 1+(2+3)+4', function() {
         mq.typedText('1+(2+3)+4');
         assertLatex('1+\\left(2+3\\right)+4');
       });
 
-      test('basic command', function () {
+      test('basic command \\sin(', function () {
         mq.typedText('\\sin(');
         assertLatex('\\sin\\left(\\right)');
       });
 
-      test('wrapping things in parens', function() {
+      test('wrapping things in parens 1+(2+3)+4', function() {
         mq.typedText('1+2+3+4');
         assertLatex('1+2+3+4');
         mq.keystroke('Left Left').typedText(')');
@@ -86,21 +86,21 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+\\left(2+3\\right)+4');
       });
 
-      test('nested parens', function() {
+      test('nested parens 1+(2+(3+4)+5)+6', function() {
         mq.typedText('1+(2+(3+4)+5)+6');
         assertLatex('1+\\left(2+\\left(3+4\\right)+5\\right)+6');
       });
     });
 
     suite('mismatched brackets', function() {
-      test('empty mismatched brackets', function() {
+      test('empty mismatched brackets (]', function() {
         mq.typedText('(');
         assertLatex('\\left(\\right)');
         mq.typedText(']');
         assertLatex('\\left(\\right]');
       });
 
-      test('typing mismatched brackets', function() {
+      test('typing mismatched brackets 1+(2+3]+4', function() {
         mq.typedText('1+');
         assertLatex('1+');
         mq.typedText('(');
@@ -111,7 +111,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+\\left(2+3\\right]+4');
       });
 
-      test('wrapping things in mismatched brackets', function() {
+      test('wrapping things in mismatched brackets 1+(2+3]+4', function() {
         mq.typedText('1+2+3+4');
         assertLatex('1+2+3+4');
         mq.keystroke('Left Left').typedText(']');
@@ -120,26 +120,26 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+\\left(2+3\\right]+4');
       });
 
-      test('nested mismatched brackets', function() {
+      test('nested mismatched brackets 1+(2+[3+4)+5]+6', function() {
         mq.typedText('1+(2+[3+4)+5]+6');
         assertLatex('1+\\left(2+\\left[3+4\\right)+5\\right]+6');
       });
     });
 
     suite('pipes', function() {
-      test('empty pipes', function() {
+      test('empty pipes ||', function() {
         mq.typedText('|');
         assertLatex('\\left|\\right|');
         mq.typedText('|');
         assertLatex('\\left|\\right|');
       });
 
-      test('straight typing', function() {
+      test('straight typing 1+|2+3|+4', function() {
         mq.typedText('1+|2+3|+4');
         assertLatex('1+\\left|2+3\\right|+4');
       });
 
-      test('wrapping things in pipes', function() {
+      test('wrapping things in pipes 1+|2+3|+4', function() {
         mq.typedText('1+2+3+4');
         assertLatex('1+2+3+4');
         mq.keystroke('Home Right Right').typedText('|');
@@ -329,7 +329,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('+4');
       });
 
-      test('rendering mismatched brackets from LaTeX then backspacing close-bracket then open-paren', function() {
+      test('rendering mismatched brackets 1+(2+3]+4 from LaTeX then backspacing close-bracket then open-paren', function() {
         mq.latex('1+\\left(2+3\\right]+4');
         assertLatex('1+\\left(2+3\\right]+4');
         mq.keystroke('Left Left Backspace');
@@ -338,7 +338,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('rendering mismatched brackets from LaTeX then backspacing open-paren then close-bracket', function() {
+      test('rendering mismatched brackets 1+(2+3]+4 from LaTeX then backspacing open-paren then close-bracket', function() {
         mq.latex('1+\\left(2+3\\right]+4');
         assertLatex('1+\\left(2+3\\right]+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
@@ -347,7 +347,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('rendering paren from LaTeX then backspacing close-paren then open-paren', function() {
+      test('rendering paren group 1+(2+3)+4 from LaTeX then backspacing close-paren then open-paren', function() {
         mq.latex('1+\\left(2+3\\right)+4');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Left Left Backspace');
@@ -356,7 +356,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('rendering paren from LaTeX then backspacing open-paren then close-paren', function() {
+      test('rendering paren group 1+(2+3)+4 from LaTeX then backspacing open-paren then close-paren', function() {
         mq.latex('1+\\left(2+3\\right)+4');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
@@ -365,7 +365,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('wrapping selection in parens then backspacing close-paren then open-paren', function() {
+      test('wrapping selection in parens 1+(2+3)+4 then backspacing close-paren then open-paren', function() {
         mq.typedText('1+2+3+4');
         assertLatex('1+2+3+4');
         mq.keystroke('Left Left Shift-Left Shift-Left Shift-Left').typedText(')');
@@ -376,7 +376,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('wrapping selection in parens then backspacing open-paren then close-paren', function() {
+      test('wrapping selection in parens 1+(2+3)+4 then backspacing open-paren then close-paren', function() {
         mq.typedText('1+2+3+4');
         assertLatex('1+2+3+4');
         mq.keystroke('Left Left Shift-Left Shift-Left Shift-Left').typedText('(');
@@ -405,7 +405,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+\\left[2+3\\right]+4');
       });
 
-      test('backspacing paren containing a one-sided paren', function() {
+      test('backspacing paren containing a one-sided paren 0+[(1+2)+3}+4', function() {
         mq.typedText('0+[1+2+3}+4');
         assertLatex('0+\\left[1+2+3\\right\\}+4');
         mq.keystroke('Left Left Left Left Left').typedText(')');
@@ -414,14 +414,14 @@ suite('typing with auto-replaces', function() {
         assertLatex('0+\\left[1+2\\right)+3+4');
       });
 
-      test('backspacing paren inside a one-sided paren', function() {
+      test('backspacing paren inside a one-sided paren (0+[1+2}+3)+4', function() {
         mq.typedText('0+[1+2}+3)+4');
         assertLatex('\\left(0+\\left[1+2\\right\\}+3\\right)+4');
         mq.keystroke('Left Left Left Left Left Backspace');
         assertLatex('0+\\left[1+2+3\\right)+4');
       });
 
-      test('backspacing paren containing and inside a one-sided paren', function() {
+      test('backspacing paren containing and inside a one-sided paren (([1+2]))', function() {
         mq.typedText('(1+2))');
         assertLatex('\\left(\\left(1+2\\right)\\right)');
         mq.keystroke('Left Left').typedText(']');
@@ -432,7 +432,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('\\left(1+2\\right)');
       });
 
-      test('auto-expanding calls .siblingCreated() on new siblings', function() {
+      test('auto-expanding calls .siblingCreated() on new siblings 1+((2+3))', function() {
         mq.typedText('1+((2+3))');
         assertLatex('1+\\left(\\left(2+3\\right)\\right)');
         mq.keystroke('Left Left Left Left Left Backspace');
@@ -444,7 +444,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+\\left(2+3\\right)');
       });
 
-      test('that unwrapping calls .siblingCreated() on new siblings', function() {
+      test('that unwrapping calls .siblingCreated() on new siblings ((1+2)+(3+4))+5', function() {
         mq.typedText('(1+2+3+4)+5');
         assertLatex('\\left(1+2+3+4\\right)+5');
         mq.keystroke('Home Right Right Right Right').typedText(')');
@@ -586,7 +586,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('+4');
         });
 
-        test('rendering pipe pair from LaTeX then backspacing close-pipe then open-pipe', function() {
+        test('rendering pipe pair 1+|2+3|+4 from LaTeX then backspacing close-pipe then open-pipe', function() {
           mq.latex('1+\\left|2+3\\right|+4');
           assertLatex('1+\\left|2+3\\right|+4');
           mq.keystroke('Left Left Backspace');
@@ -595,7 +595,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('rendering pipe pair from LaTeX then backspacing open-pipe then close-pipe', function() {
+        test('rendering pipe pair 1+|2+3|+4 from LaTeX then backspacing open-pipe then close-pipe', function() {
           mq.latex('1+\\left|2+3\\right|+4');
           assertLatex('1+\\left|2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
@@ -604,7 +604,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('rendering mismatched paren/pipe group from LaTeX then backspacing close-paren then open-pipe', function() {
+        test('rendering mismatched paren/pipe group 1+|2+3)+4 from LaTeX then backspacing close-paren then open-pipe', function() {
           mq.latex('1+\\left|2+3\\right)+4');
           assertLatex('1+\\left|2+3\\right)+4');
           mq.keystroke('Left Left Backspace');
@@ -613,7 +613,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('rendering mismatched paren/pipe group from LaTeX then backspacing open-pipe then close-paren', function() {
+        test('rendering mismatched paren/pipe group 1+|2+3)+4 from LaTeX then backspacing open-pipe then close-paren', function() {
           mq.latex('1+\\left|2+3\\right)+4');
           assertLatex('1+\\left|2+3\\right)+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
@@ -622,7 +622,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('rendering mismatched paren/pipe group from LaTeX then backspacing close-pipe then open-paren', function() {
+        test('rendering mismatched paren/pipe group 1+(2+3|+4 from LaTeX then backspacing close-pipe then open-paren', function() {
           mq.latex('1+\\left(2+3\\right|+4');
           assertLatex('1+\\left(2+3\\right|+4');
           mq.keystroke('Left Left Backspace');
@@ -631,7 +631,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('rendering mismatched paren/pipe group from LaTeX then backspacing open-paren then close-pipe', function() {
+        test('rendering mismatched paren/pipe group 1+(2+3|+4 from LaTeX then backspacing open-paren then close-pipe', function() {
           mq.latex('1+\\left(2+3\\right|+4');
           assertLatex('1+\\left(2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
@@ -640,7 +640,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('wrapping selection in pipes then backspacing open-pipe then close-pipe', function() {
+        test('wrapping selection in pipes 1+|2+3|+4 then backspacing open-pipe then close-pipe', function() {
           mq.typedText('1+2+3+4');
           assertLatex('1+2+3+4');
           mq.keystroke('Left Left Shift-Left Shift-Left Shift-Left').typedText('|');
@@ -651,7 +651,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('wrapping selection in pipes then backspacing close-pipe then open-pipe', function() {
+        test('wrapping selection in pipes 1+|2+3|+4 then backspacing close-pipe then open-pipe', function() {
           mq.typedText('1+2+3+4');
           assertLatex('1+2+3+4');
           mq.keystroke('Left Left Shift-Left Shift-Left Shift-Left').typedText('|');
@@ -680,7 +680,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+\\left|2+3\\right|+4');
         });
 
-        test('backspacing pipe containing a one-sided pipe', function() {
+        test('backspacing pipe containing a one-sided pipe 0+|1+|2+3||+4', function() {
           mq.typedText('0+|1+2+3|+4');
           assertLatex('0+\\left|1+2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left').typedText('|');
@@ -689,7 +689,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('0+1+\\left|2+3\\right|+4');
         });
 
-        test('backspacing pipe inside a one-sided pipe', function() {
+        test('backspacing pipe inside a one-sided pipe 0+|1+|2+3|+4|', function() {
           mq.typedText('0+1+|2+3|+4');
           assertLatex('0+1+\\left|2+3\\right|+4');
           mq.keystroke('Home Right Right').typedText('|');
@@ -698,7 +698,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('0+\\left|1+2+3\\right|+4');
         });
 
-        test('backspacing pipe containing and inside a one-sided pipe', function() {
+        test('backspacing pipe containing and inside a one-sided pipe |0+|1+|2+3||+4|', function() {
           mq.typedText('0+|1+2+3|+4');
           assertLatex('0+\\left|1+2+3\\right|+4');
           mq.keystroke('Home').typedText('|');
@@ -709,7 +709,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('\\left|0+1+\\left|2+3\\right|+4\\right|');
         });
 
-        test('backspacing pipe containing a one-sided pipe facing same way', function() {
+        test('backspacing pipe containing a one-sided pipe facing same way 0+||1+2||+3', function() {
           mq.typedText('0+|1+2|+3');
           assertLatex('0+\\left|1+2\\right|+3');
           mq.keystroke('Home Right Right Right').typedText('|');
@@ -718,7 +718,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('0+\\left|\\left|1+2\\right|+3\\right|');
         });
 
-        test('backspacing pipe inside a one-sided pipe facing same way', function() {
+        test('backspacing pipe inside a one-sided pipe facing same way 0+|1+|2+3|+4|', function() {
           mq.typedText('0+1+|2+3|+4');
           assertLatex('0+1+\\left|2+3\\right|+4');
           mq.keystroke('Home Right Right').typedText('|');
@@ -727,7 +727,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('0+\\left|1+\\left|2+3+4\\right|\\right|');
         });
 
-        test('backspacing open-paren of mismatched paren/pipe group containing a one-sided pipe', function() {
+        test('backspacing open-paren of mismatched paren/pipe group containing a one-sided pipe 0+(1+|2+3||+4', function() {
           mq.latex('0+\\left(1+2+3\\right|+4');
           assertLatex('0+\\left(1+2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left').typedText('|');
@@ -736,7 +736,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('0+1+\\left|2+3\\right|+4');
         });
 
-        test('backspacing open-paren mismatched paren/pipe group inside a one-sided pipe', function() {
+        test('backspacing open-paren mismatched paren/pipe group inside a one-sided pipe 0+|1+(2+3|+4|', function() {
           mq.latex('0+1+\\left(2+3\\right|+4');
           assertLatex('0+1+\\left(2+3\\right|+4');
           mq.keystroke('Home Right Right').typedText('|');
@@ -748,7 +748,7 @@ suite('typing with auto-replaces', function() {
     });
 
     suite('typing outside ghost paren', function() {
-      test('typing outside ghost paren solidifies ghost', function() {
+      test('typing outside ghost paren solidifies ghost 1+(2+3)', function() {
         mq.typedText('1+(2+3');
         assertLatex('1+\\left(2+3\\right)');
         mq.keystroke('Right').typedText('+4');
@@ -757,21 +757,21 @@ suite('typing with auto-replaces', function() {
         assertLatex('\\left(1+2+3\\right)+4');
       });
 
-      test('selected and replaced by LiveFraction solidifies ghosts', function() {
+      test('selected and replaced by LiveFraction solidifies ghosts (1+2)/( )', function() {
         mq.typedText('1+2)/');
         assertLatex('\\frac{\\left(1+2\\right)}{ }');
         mq.keystroke('Left Backspace');
         assertLatex('\\frac{\\left(1+2\\right)}{ }');
       });
 
-      test('close paren group by typing close-bracket outside ghost paren', function() {
+      test('close paren group by typing close-bracket outside ghost paren (1+2]', function() {
         mq.typedText('(1+2');
         assertLatex('\\left(1+2\\right)');
         mq.keystroke('Right').typedText(']');
         assertLatex('\\left(1+2\\right]');
       });
 
-      test('close adjacent paren group before containing paren group', function() {
+      test('close adjacent paren group before containing paren group (1+(2+3])', function() {
         mq.typedText('(1+(2+3');
         assertLatex('\\left(1+\\left(2+3\\right)\\right)');
         mq.keystroke('Right').typedText(']');
@@ -780,7 +780,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('\\left(1+\\left(2+3\\right]\\right]');
       });
 
-      test('can type close-bracket on solid side of one-sided paren', function() {
+      test('can type close-bracket on solid side of one-sided paren [](1+2)', function() {
         mq.typedText('(1+2');
         assertLatex('\\left(1+2\\right)');
         mq.moveToLeftEnd().typedText(']');
@@ -788,7 +788,7 @@ suite('typing with auto-replaces', function() {
       });
 
       suite('pipes', function() {
-        test('close pipe pair from outside to the right', function() {
+        test('close pipe pair from outside to the right |1+2|', function() {
           mq.typedText('|1+2');
           assertLatex('\\left|1+2\\right|');
           mq.keystroke('Right').typedText('|');
@@ -797,7 +797,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('\\left|1+2\\right|');
         });
 
-        test('close pipe pair from outside to the left', function() {
+        test('close pipe pair from outside to the left |1+2|', function() {
           mq.typedText('|1+2|');
           assertLatex('\\left|1+2\\right|');
           mq.keystroke('Home Del');
@@ -808,7 +808,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('\\left|1+2\\right|');
         });
 
-        test('can type pipe on solid side of one-sided pipe', function() {
+        test('can type pipe on solid side of one-sided pipe ||||', function() {
           mq.typedText('|');
           assertLatex('\\left|\\right|');
           mq.moveToLeftEnd().typedText('|');

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -92,15 +92,15 @@ suite('typing with auto-replaces', function() {
       });
     });
 
-    suite('mis-matched brackets', function() {
-      test('empty mis-matched brackets', function() {
+    suite('mismatched brackets', function() {
+      test('empty mismatched brackets', function() {
         mq.typedText('(');
         assertLatex('\\left(\\right)');
         mq.typedText(']');
         assertLatex('\\left(\\right]');
       });
 
-      test('typing mis-matched brackets', function() {
+      test('typing mismatched brackets', function() {
         mq.typedText('1+');
         assertLatex('1+');
         mq.typedText('(');
@@ -111,7 +111,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+\\left(2+3\\right]+4');
       });
 
-      test('wrapping things in mis-matched brackets', function() {
+      test('wrapping things in mismatched brackets', function() {
         mq.typedText('1+2+3+4');
         assertLatex('1+2+3+4');
         mq.keystroke('Left Left').typedText(']');
@@ -120,7 +120,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+\\left(2+3\\right]+4');
       });
 
-      test('nested mis-matched brackets', function() {
+      test('nested mismatched brackets', function() {
         mq.typedText('1+(2+[3+4)+5]+6');
         assertLatex('1+\\left(2+\\left[3+4\\right)+5\\right]+6');
       });
@@ -148,7 +148,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+\\left|2+3\\right|+4');
       });
 
-      suite('can type mis-matched paren/pipe group from any side', function() {
+      suite('can type mismatched paren/pipe group from any side', function() {
         suite('straight typing', function() {
           test('|)', function() {
             mq.typedText('|)');
@@ -329,7 +329,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('+4');
       });
 
-      test('rendering mis-matched brackets from LaTeX then backspacing close-bracket then open-paren', function() {
+      test('rendering mismatched brackets from LaTeX then backspacing close-bracket then open-paren', function() {
         mq.latex('1+\\left(2+3\\right]+4');
         assertLatex('1+\\left(2+3\\right]+4');
         mq.keystroke('Left Left Backspace');
@@ -338,7 +338,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('rendering mis-matched brackets from LaTeX then backspacing open-paren then close-bracket', function() {
+      test('rendering mismatched brackets from LaTeX then backspacing open-paren then close-bracket', function() {
         mq.latex('1+\\left(2+3\\right]+4');
         assertLatex('1+\\left(2+3\\right]+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
@@ -604,7 +604,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('rendering mis-matched paren/pipe group from LaTeX then backspacing close-paren then open-pipe', function() {
+        test('rendering mismatched paren/pipe group from LaTeX then backspacing close-paren then open-pipe', function() {
           mq.latex('1+\\left|2+3\\right)+4');
           assertLatex('1+\\left|2+3\\right)+4');
           mq.keystroke('Left Left Backspace');
@@ -613,7 +613,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('rendering mis-matched paren/pipe group from LaTeX then backspacing open-pipe then close-paren', function() {
+        test('rendering mismatched paren/pipe group from LaTeX then backspacing open-pipe then close-paren', function() {
           mq.latex('1+\\left|2+3\\right)+4');
           assertLatex('1+\\left|2+3\\right)+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
@@ -622,7 +622,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('rendering mis-matched paren/pipe group from LaTeX then backspacing close-pipe then open-paren', function() {
+        test('rendering mismatched paren/pipe group from LaTeX then backspacing close-pipe then open-paren', function() {
           mq.latex('1+\\left(2+3\\right|+4');
           assertLatex('1+\\left(2+3\\right|+4');
           mq.keystroke('Left Left Backspace');
@@ -631,7 +631,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('rendering mis-matched paren/pipe group from LaTeX then backspacing open-paren then close-pipe', function() {
+        test('rendering mismatched paren/pipe group from LaTeX then backspacing open-paren then close-pipe', function() {
           mq.latex('1+\\left(2+3\\right|+4');
           assertLatex('1+\\left(2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
@@ -727,7 +727,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('0+\\left|1+\\left|2+3+4\\right|\\right|');
         });
 
-        test('backspacing open-paren of mis-matched paren/pipe group containing a one-sided pipe', function() {
+        test('backspacing open-paren of mismatched paren/pipe group containing a one-sided pipe', function() {
           mq.latex('0+\\left(1+2+3\\right|+4');
           assertLatex('0+\\left(1+2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left').typedText('|');
@@ -736,7 +736,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('0+1+\\left|2+3\\right|+4');
         });
 
-        test('backspacing open-paren mis-matched paren/pipe group inside a one-sided pipe', function() {
+        test('backspacing open-paren mismatched paren/pipe group inside a one-sided pipe', function() {
           mq.latex('0+1+\\left(2+3\\right|+4');
           assertLatex('0+1+\\left(2+3\\right|+4');
           mq.keystroke('Home Right Right').typedText('|');

--- a/test/visual.html
+++ b/test/visual.html
@@ -111,6 +111,7 @@ $(function() {
   MathQuill.MathField($('#custom-behavior')[0], {
     spaceBehavesLikeTab: true,
     leftRightIntoCmdGoes: 'up',
+    restrictMismatchedBrackets: true,
     sumStartsWithNEquals: true,
     supSubsRequireOperand: true,
     charsThatBreakOutOfSupSub: '+-=<>',


### PR DESCRIPTION
Say you want to type "(|x|+1)", LaTeX: `\left( \left|x\right| + 1 \right)`
(whitespace added for clarity).

With the current auto-expanding parens behavior (#262 and #281), if you
tried to type that directly, you'd get: `\left(\right| x \left|+1\right)`
(whitespace added for clarity).

This is unintuitive partly because in practice you almost never actually
want mismatched brackets, you actually almost always want pairs of them
to be matching. In fact, usually the only mismatched pairs you want are
like [a,b) and (a,b].

The `restrictMismatchedBrackets` option restricts the mismatched pairs
that may be typed using auto-expanding parens and ghosts to just those
two, otherwise you can only close an auto-expanded pair/solidify a ghost
paren by typing the opposing delimiter.