### PR TITLE
Stop using florin, and just special case spacing of the f character

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -398,7 +398,8 @@ var MathBlock = P(MathElement, function(_, super_) {
   };
   _.chToCmd = function(ch) {
     var cons;
-    if (ch.match(/^[a-eg-zA-Z]$/)) //exclude f because want florin
+    // exclude f because it gets a dedicated command with more spacing
+    if (ch.match(/^[a-eg-zA-Z]$/))
       return Letter(ch);
     else if (/^\d$/.test(ch))
       return Digit(ch);

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -204,10 +204,10 @@ LatexCmds.operatorname = P(MathCommand, function(_) {
 
 LatexCmds.f = P(Letter, function(_, super_) {
   _.init = function() {
-    Symbol.p.init.call(this, this.letter = 'f', '<var class="mq-florin">&fnof;</var>');
+    Symbol.p.init.call(this, this.letter = 'f', '<var class="mq-florin">f</var>');
   };
   _.italicize = function(bool) {
-    this.jQ.html(bool ? '&fnof;' : 'f').toggleClass('mq-florin', bool);
+    this.jQ.html(bool ? 'f' : 'f').toggleClass('mq-florin', bool);
     return super_.italicize.apply(this, arguments);
   };
 });

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -204,10 +204,10 @@ LatexCmds.operatorname = P(MathCommand, function(_) {
 
 LatexCmds.f = P(Letter, function(_, super_) {
   _.init = function() {
-    Symbol.p.init.call(this, this.letter = 'f', '<var class="mq-florin">f</var>');
+    Symbol.p.init.call(this, this.letter = 'f', '<var class="mq-f">f</var>');
   };
   _.italicize = function(bool) {
-    this.jQ.html(bool ? 'f' : 'f').toggleClass('mq-florin', bool);
+    this.jQ.html('f').toggleClass('mq-f', bool);
     return super_.italicize.apply(this, arguments);
   };
 });

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -60,14 +60,14 @@
     font-style: italic;
   }
 
-  var.mq-florin {
+  var.mq-f {
     .inline-block;
     width: 0.5em;
     position: relative;
     left: 0.1em;
   }
 
-  .mq-roman var.mq-florin {
+  .mq-roman var.mq-f {
     display: inline;
     position: static;
   }

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -62,9 +62,14 @@
 
   var.mq-florin {
     .inline-block;
-    width: .3em;
+    width: 0.5em;
     position: relative;
-    left: -.1em;
+    left: 0.1em;
+  }
+
+  .mq-roman var.mq-florin {
+    display: inline;
+    position: static;
   }
 
   big {


### PR DESCRIPTION
Mathquill has been rewriting italicized f's to florin characters because italicized f's take up a lot of horizontal space and collide with parens if you don't treat them specially. This PR switches back to using f's, but gives them a little bit of extra horizontal space to avoid collisions.

The rendering in this branch is actually closer to the way that italic f's are rendered in latex computer modern. Compare:

Florins (mathquill's current strategy):
![image](https://cloud.githubusercontent.com/assets/48409/7596505/fc929c8e-f8a2-11e4-97b7-2a2382bc3700.png)

F's with no special case spacing:
![image](https://cloud.githubusercontent.com/assets/48409/7596521/126ec4ec-f8a3-11e4-9ff7-5f688221e2a9.png)

F's with special case spacing (this PR):
![image](https://cloud.githubusercontent.com/assets/48409/7596538/3318cea4-f8a3-11e4-9e95-0f0f5e42fcb1.png)

Latex with computer modern:
![image](https://cloud.githubusercontent.com/assets/48409/7596601/b2b9db58-f8a3-11e4-9377-fa1cb7522946.png)

For comparison, here are a few h's in a row in latex (notice the relatively tighter spacing):
![image](https://cloud.githubusercontent.com/assets/48409/7596644/225982b0-f8a4-11e4-9b90-06e49f3f099d.png)

My proximate motivation for doing this is that I want f's to not show up italicized in mathrm mode, and this PR also solves that problem, but I think it's a good idea independent of that issue.