### PR TITLE
rm bad denominator rules

### DIFF
--- a/src/css/math.less
+++ b/src/css/math.less
@@ -236,9 +236,7 @@
     border-top: 1px solid;
     float: right; // take out of normal flow to manipulate baseline
     width: 100%;
-    padding: .15em .1em 0 .1em;
-    margin-right: -.1em;
-    margin-left: -.1em;
+    padding: .1em 0;
   }
 
   ////


### PR DESCRIPTION
negative margin here was causing denominators to be offset. we also need more padding in the denominator to keep the bottom of tall fractions from being cut off.

Before: 
![screen shot 2015-05-15 at 4 31 13 pm](https://cloud.githubusercontent.com/assets/478331/7663498/0a7e4a26-fb20-11e4-8e51-4aa9fc1cd39e.png)

After: 
![screen shot 2015-05-15 at 4 31 50 pm](https://cloud.githubusercontent.com/assets/478331/7663499/0f40a9b4-fb20-11e4-9be5-44e80af903c5.png)

