### PR TITLE
Delete both parens when they match and are both hardened

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -575,7 +575,14 @@ var Bracket = P(P(MathCommand, DelimsMixin), function(_, super_) {
   _.deleteSide = function(side, outward, cursor) {
     var parent = this.parent, sib = this[side], farEnd = parent.ends[side];
 
-    if (side === this.side) { // deleting non-ghost of one-sided bracket, unwrap
+    if (
+      //unwrap if deleting either...
+      side === this.side || //the solid side with a ghost pair
+      (
+        this.side === 0 && //or one side of matched parens
+        this.sides[-side].ch === OPP_BRACKS[this.sides[side].ch]
+      )
+    ) {
       this.unwrap();
       sib ? cursor.insDirOf(-side, sib) : cursor.insAtDirEnd(side, parent);
       return;

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -199,9 +199,9 @@ suite('typing with auto-replaces', function() {
             mq.typedText('||');
             assertLatex('\\left|\\right|');
             mq.keystroke('Left Backspace');
-            assertLatex('\\left|\\right|');
+            assertLatex('');
             mq.typedText('(');
-            assertLatex('\\left(\\right|');
+            assertLatex('\\left(\\right)');
           });
         });
       });
@@ -227,21 +227,17 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('backspacing close-paren then open-paren of 1+(2+3)+4', function() {
+      test('backspacing close-paren of 1+(2+3)+4', function() {
         mq.typedText('1+(2+3)+4');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Left Left Backspace');
-        assertLatex('1+\\left(2+3+4\\right)');
-        mq.keystroke('Left Left Left Backspace');
         assertLatex('1+2+3+4');
       });
 
-      test('backspacing open-paren then close-paren of 1+(2+3)+4', function() {
+      test('backspacing open-paren of 1+(2+3)+4', function() {
         mq.typedText('1+(2+3)+4');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
-        assertLatex('\\left(1+2+3\\right)+4');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3+4');
       });
 
@@ -383,43 +379,35 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('rendering paren group 1+(2+3)+4 from LaTeX then backspacing close-paren then open-paren', function() {
+      test('rendering paren group 1+(2+3)+4 from LaTeX then backspacing close-paren', function() {
         mq.latex('1+\\left(2+3\\right)+4');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Left Left Backspace');
-        assertLatex('1+\\left(2+3+4\\right)');
-        mq.keystroke('Left Left Left Backspace');
         assertLatex('1+2+3+4');
       });
 
-      test('rendering paren group 1+(2+3)+4 from LaTeX then backspacing open-paren then close-paren', function() {
+      test('rendering paren group 1+(2+3)+4 from LaTeX then backspacing open-paren', function() {
         mq.latex('1+\\left(2+3\\right)+4');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
-        assertLatex('\\left(1+2+3\\right)+4');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3+4');
       });
 
-      test('wrapping selection in parens 1+(2+3)+4 then backspacing close-paren then open-paren', function() {
+      test('wrapping selection in parens 1+(2+3)+4 then backspacing close-paren', function() {
         mq.typedText('1+2+3+4');
         assertLatex('1+2+3+4');
         mq.keystroke('Left Left Shift-Left Shift-Left Shift-Left').typedText(')');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Backspace');
-        assertLatex('1+\\left(2+3+4\\right)');
-        mq.keystroke('Left Left Left Backspace');
         assertLatex('1+2+3+4');
       });
 
-      test('wrapping selection in parens 1+(2+3)+4 then backspacing open-paren then close-paren', function() {
+      test('wrapping selection in parens 1+(2+3)+4 then backspacing open-paren', function() {
         mq.typedText('1+2+3+4');
         assertLatex('1+2+3+4');
         mq.keystroke('Left Left Shift-Left Shift-Left Shift-Left').typedText('(');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Backspace');
-        assertLatex('\\left(1+2+3\\right)+4');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3+4');
       });
 
@@ -441,20 +429,11 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+\\left[2+3\\right]+4');
       });
 
-      test('backspacing paren containing a one-sided paren 0+[(1+2)+3]+4', function() {
-        mq.typedText('0+[1+2+3]+4');
-        assertLatex('0+\\left[1+2+3\\right]+4');
-        mq.keystroke('Left Left Left Left Left').typedText(')');
-        assertLatex('0+\\left[\\left(1+2\\right)+3\\right]+4');
-        mq.keystroke('Right Right Right Backspace');
-        assertLatex('0+\\left[1+2\\right)+3+4');
-      });
-
       test('backspacing paren inside a one-sided paren (0+[1+2]+3)+4', function() {
         mq.typedText('0+[1+2]+3)+4');
         assertLatex('\\left(0+\\left[1+2\\right]+3\\right)+4');
         mq.keystroke('Left Left Left Left Left Backspace');
-        assertLatex('0+\\left[1+2+3\\right)+4');
+        assertLatex('\\left(0+1+2+3\\right)+4');
       });
 
       test('backspacing paren containing and inside a one-sided paren (([1+2]))', function() {
@@ -463,7 +442,7 @@ suite('typing with auto-replaces', function() {
         mq.keystroke('Left Left').typedText(']');
         assertLatex('\\left(\\left(\\left[1+2\\right]\\right)\\right)');
         mq.keystroke('Right Backspace');
-        assertLatex('\\left(\\left(1+2\\right]\\right)');
+        assertLatex('\\left(\\left[1+2\\right]\\right)');
         mq.keystroke('Backspace');
         assertLatex('\\left(1+2\\right)');
       });
@@ -472,11 +451,6 @@ suite('typing with auto-replaces', function() {
         mq.typedText('1+((2+3))');
         assertLatex('1+\\left(\\left(2+3\\right)\\right)');
         mq.keystroke('Left Left Left Left Left Backspace');
-        assertLatex('1+\\left(\\left(2+3\\right)\\right)');
-        mq.keystroke('Backspace');
-        assertLatex('\\left(1+\\left(2+3\\right)\\right)');
-        // now check that the inner open-paren isn't still a ghost
-        mq.keystroke('Right Right Right Right Del');
         assertLatex('1+\\left(2+3\\right)');
       });
 
@@ -490,7 +464,7 @@ suite('typing with auto-replaces', function() {
         mq.keystroke('Right Right Right Right Right Backspace');
         assertLatex('\\left(1+2\\right)+\\left(3+4\\right)+5');
         mq.keystroke('Left Left Left Left Backspace');
-        assertLatex('\\left(\\left(1+2\\right)+3+4\\right)+5');
+        assertLatex('\\left(1+2\\right)+3+4+5');
       });
 
       suite('pipes', function() {
@@ -503,57 +477,45 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('backspacing close-pipe then open-pipe of 1+|2+3|+4', function() {
+        test('backspacing close-pipe of 1+|2+3|+4', function() {
           mq.typedText('1+|2+3|+4');
           assertLatex('1+\\left|2+3\\right|+4');
           mq.keystroke('Left Left Backspace');
-          assertLatex('1+\\left|2+3+4\\right|');
-          mq.keystroke('Left Left Left Backspace');
           assertLatex('1+2+3+4');
         });
 
-        test('backspacing open-pipe then close-pipe of 1+|2+3|+4', function() {
+        test('backspacing open-pipe of 1+|2+3|+4', function() {
           mq.typedText('1+|2+3|+4');
           assertLatex('1+\\left|2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
-          assertLatex('\\left|1+2+3\\right|+4');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3+4');
         });
 
-        test('backspacing close-pipe then open-pipe of 1+|2+3| (nothing after pipe pair)', function() {
+        test('backspacing close-pipe of 1+|2+3| (nothing after pipe pair)', function() {
           mq.typedText('1+|2+3|');
           assertLatex('1+\\left|2+3\\right|');
           mq.keystroke('Backspace');
-          assertLatex('1+\\left|2+3\\right|');
-          mq.keystroke('Left Left Left Backspace');
           assertLatex('1+2+3');
         });
 
-        test('backspacing open-pipe then close-pipe of 1+|2+3| (nothing after pipe pair)', function() {
+        test('backspacing open-pipe of 1+|2+3| (nothing after pipe pair)', function() {
           mq.typedText('1+|2+3|');
           assertLatex('1+\\left|2+3\\right|');
           mq.keystroke('Left Left Left Left Backspace');
-          assertLatex('\\left|1+2+3\\right|');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3');
         });
 
-        test('backspacing close-pipe then open-pipe of |2+3|+4 (nothing before pipe pair)', function() {
+        test('backspacing close-pipe of |2+3|+4 (nothing before pipe pair)', function() {
           mq.typedText('|2+3|+4');
           assertLatex('\\left|2+3\\right|+4');
           mq.keystroke('Left Left Backspace');
-          assertLatex('\\left|2+3+4\\right|');
-          mq.keystroke('Left Left Left Backspace');
           assertLatex('2+3+4');
         });
 
-        test('backspacing open-pipe then close-pipe of |2+3|+4 (nothing before pipe pair)', function() {
+        test('backspacing open-pipe of |2+3|+4 (nothing before pipe pair)', function() {
           mq.typedText('|2+3|+4');
           assertLatex('\\left|2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
-          assertLatex('\\left|2+3\\right|+4');
-          mq.keystroke('Right Right Right Right Right Backspace');
           assertLatex('2+3+4');
         });
 
@@ -564,79 +526,59 @@ suite('typing with auto-replaces', function() {
                     'paren block auto-expanded, should no longer be gray');
         }
 
-        test('backspacing close-pipe then open-pipe of 1+||+4 (empty pipe pair)', function() {
+        test('backspacing close-pipe of 1+||+4 (empty pipe pair)', function() {
           mq.typedText('1+||+4');
           assertLatex('1+\\left|\\right|+4');
           mq.keystroke('Left Left Backspace');
-          assertLatex('1+\\left|+4\\right|');
-          assertParenBlockNonEmpty();
-          mq.keystroke('Backspace');
           assertLatex('1++4');
         });
 
-        test('backspacing open-pipe then close-pipe of 1+||+4 (empty pipe pair)', function() {
+        test('backspacing open-pipe of 1+||+4 (empty pipe pair)', function() {
           mq.typedText('1+||+4');
           assertLatex('1+\\left|\\right|+4');
           mq.keystroke('Left Left Left Backspace');
-          assertLatex('\\left|1+\\right|+4');
-          assertParenBlockNonEmpty();
-          mq.keystroke('Right Backspace');
           assertLatex('1++4');
         });
 
-        test('backspacing close-pipe then open-pipe of 1+|| (empty pipe pair, nothing after)', function() {
+        test('backspacing close-pipe of 1+|| (empty pipe pair, nothing after)', function() {
           mq.typedText('1+||');
-          assertLatex('1+\\left|\\right|');
-          mq.keystroke('Backspace');
           assertLatex('1+\\left|\\right|');
           mq.keystroke('Backspace');
           assertLatex('1+');
         });
 
-        test('backspacing open-pipe then close-pipe of 1+|| (empty pipe pair, nothing after)', function() {
+        test('backspacing open-pipe of 1+|| (empty pipe pair, nothing after)', function() {
           mq.typedText('1+||');
           assertLatex('1+\\left|\\right|');
           mq.keystroke('Left Backspace');
-          assertLatex('\\left|1+\\right|');
-          assertParenBlockNonEmpty();
-          mq.keystroke('Right Right Backspace');
           assertLatex('1+');
         });
 
-        test('backspacing close-pipe then open-pipe of ||+4 (empty pipe pair, nothing before)', function() {
+        test('backspacing close-pipe of ||+4 (empty pipe pair, nothing before)', function() {
           mq.typedText('||+4');
           assertLatex('\\left|\\right|+4');
           mq.keystroke('Left Left Backspace');
-          assertLatex('\\left|+4\\right|');
-          assertParenBlockNonEmpty();
-          mq.keystroke('Backspace');
           assertLatex('+4');
         });
 
-        test('backspacing open-pipe then close-pipe of ||+4 (empty pipe pair, nothing before)', function() {
+        test('backspacing open-pipe of ||+4 (empty pipe pair, nothing before)', function() {
           mq.typedText('||+4');
           assertLatex('\\left|\\right|+4');
           mq.keystroke('Left Left Left Backspace');
-          assertLatex('\\left|\\right|+4');
-          mq.keystroke('Right Right Backspace');
           assertLatex('+4');
         });
 
-        test('rendering pipe pair 1+|2+3|+4 from LaTeX then backspacing close-pipe then open-pipe', function() {
+        test('rendering pipe pair 1+|2+3|+4 from LaTeX then backspacing close-pipe', function() {
           mq.latex('1+\\left|2+3\\right|+4');
           assertLatex('1+\\left|2+3\\right|+4');
           mq.keystroke('Left Left Backspace');
-          assertLatex('1+\\left|2+3+4\\right|');
-          mq.keystroke('Left Left Left Backspace');
           assertLatex('1+2+3+4');
         });
 
-        test('rendering pipe pair 1+|2+3|+4 from LaTeX then backspacing open-pipe then close-pipe', function() {
+        test('rendering pipe pair 1+|2+3|+4 from LaTeX then backspacing open-pipe', function() {
           mq.latex('1+\\left|2+3\\right|+4');
           assertLatex('1+\\left|2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
-          assertLatex('\\left|1+2+3\\right|+4');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3+4');
         });
 
@@ -676,25 +618,21 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('wrapping selection in pipes 1+|2+3|+4 then backspacing open-pipe then close-pipe', function() {
+        test('wrapping selection in pipes 1+|2+3|+4 then backspacing open-pipe', function() {
           mq.typedText('1+2+3+4');
           assertLatex('1+2+3+4');
           mq.keystroke('Left Left Shift-Left Shift-Left Shift-Left').typedText('|');
           assertLatex('1+\\left|2+3\\right|+4');
           mq.keystroke('Backspace');
-          assertLatex('\\left|1+2+3\\right|+4');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3+4');
         });
 
-        test('wrapping selection in pipes 1+|2+3|+4 then backspacing close-pipe then open-pipe', function() {
+        test('wrapping selection in pipes 1+|2+3|+4 then backspacing close-pipe', function() {
           mq.typedText('1+2+3+4');
           assertLatex('1+2+3+4');
           mq.keystroke('Left Left Shift-Left Shift-Left Shift-Left').typedText('|');
           assertLatex('1+\\left|2+3\\right|+4');
           mq.keystroke('Tab Backspace');
-          assertLatex('1+\\left|2+3+4\\right|');
-          mq.keystroke('Left Left Left Backspace');
           assertLatex('1+2+3+4');
         });
 
@@ -702,18 +640,18 @@ suite('typing with auto-replaces', function() {
           mq.typedText('1+|2+3|');
           assertLatex('1+\\left|2+3\\right|');
           mq.keystroke('Backspace');
-          assertLatex('1+\\left|2+3\\right|');
+          assertLatex('1+2+3');
           mq.typedText('+4');
-          assertLatex('1+\\left|2+3+4\\right|');
+          assertLatex('1+2+3+4');
         });
 
         test('backspacing open-pipe of |2+3|+4 (nothing before) then typing', function() {
           mq.typedText('|2+3|+4');
           assertLatex('\\left|2+3\\right|+4');
           mq.keystroke('Home Right Backspace');
-          assertLatex('\\left|2+3\\right|+4');
+          assertLatex('2+3+4');
           mq.typedText('1+');
-          assertLatex('1+\\left|2+3\\right|+4');
+          assertLatex('1+2+3+4');
         });
 
         test('backspacing pipe containing a one-sided pipe 0+|1+|2+3||+4', function() {
@@ -731,7 +669,7 @@ suite('typing with auto-replaces', function() {
           mq.keystroke('Home Right Right').typedText('|');
           assertLatex('0+\\left|1+\\left|2+3\\right|+4\\right|');
           mq.keystroke('Right Right Del');
-          assertLatex('0+\\left|1+2+3\\right|+4');
+          assertLatex('0+\\left|1+2+3+4\\right|');
         });
 
         test('backspacing pipe containing and inside a one-sided pipe |0+|1+|2+3||+4|', function() {
@@ -751,7 +689,7 @@ suite('typing with auto-replaces', function() {
           mq.keystroke('Home Right Right Right').typedText('|');
           assertLatex('0+\\left|\\left|1+2\\right|\\right|+3');
           mq.keystroke('Tab Del');
-          assertLatex('0+\\left|\\left|1+2\\right|+3\\right|');
+          assertLatex('0+\\left|1+2\\right|+3');
         });
 
         test('backspacing pipe inside a one-sided pipe facing same way 0+|1+|2+3|+4|', function() {
@@ -760,7 +698,7 @@ suite('typing with auto-replaces', function() {
           mq.keystroke('Home Right Right').typedText('|');
           assertLatex('0+\\left|1+\\left|2+3\\right|+4\\right|');
           mq.keystroke('Right Right Right Right Right Right Del');
-          assertLatex('0+\\left|1+\\left|2+3+4\\right|\\right|');
+          assertLatex('0+\\left|1+2+3+4\\right|');
         });
 
         test('backspacing open-paren of mismatched paren/pipe group containing a one-sided pipe 0+(1+|2+3||+4', function() {
@@ -790,14 +728,14 @@ suite('typing with auto-replaces', function() {
         mq.keystroke('Right').typedText('+4');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
-        assertLatex('\\left(1+2+3\\right)+4');
+        assertLatex('1+2+3+4');
       });
 
       test('selected and replaced by LiveFraction solidifies ghosts (1+2)/( )', function() {
         mq.typedText('1+2)/');
         assertLatex('\\frac{\\left(1+2\\right)}{ }');
         mq.keystroke('Left Backspace');
-        assertLatex('\\frac{\\left(1+2\\right)}{ }');
+        assertLatex('\\frac{1+2}{ }');
       });
 
       test('close paren group by typing close-bracket outside ghost paren (1+2]', function() {
@@ -830,18 +768,14 @@ suite('typing with auto-replaces', function() {
           mq.keystroke('Right').typedText('|');
           assertLatex('\\left|1+2\\right|');
           mq.keystroke('Home Del');
-          assertLatex('\\left|1+2\\right|');
+          assertLatex('1+2');
         });
 
         test('close pipe pair from outside to the left |1+2|', function() {
           mq.typedText('|1+2|');
           assertLatex('\\left|1+2\\right|');
-          mq.keystroke('Home Del');
-          assertLatex('\\left|1+2\\right|');
-          mq.keystroke('Left').typedText('|');
-          assertLatex('\\left|1+2\\right|');
           mq.keystroke('Ctrl-End Backspace');
-          assertLatex('\\left|1+2\\right|');
+          assertLatex('1+2');
         });
 
         test('can type pipe on solid side of one-sided pipe ||||', function() {


### PR DESCRIPTION
Proposed solution for #396 

Leaves current behavior for mismatched parens (power user stuff in there). Leaves current behavior if either is a ghost.

Note: @laughinghan paren behavior is absurdly well tested. well-done / holy crap.