### PR TITLE
Unwrap parens when you delete the left paren

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -578,11 +578,7 @@ var Bracket = P(P(MathCommand, DelimsMixin), function(_, super_) {
     if (
       //unwrap if deleting either...
       side === this.side || //the solid side with a ghost pair
-      (
-        this.side === 0 && //or one side of matched parens
-        side === -1 &&
-        this.sides[1].ch === OPP_BRACKS[this.sides[-1].ch]
-      )
+      (this.side === 0 && side === -1) //opening paren
     ) {
       this.unwrap();
       sib ? cursor.insDirOf(-side, sib) : cursor.insAtDirEnd(side, parent);

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -575,7 +575,15 @@ var Bracket = P(P(MathCommand, DelimsMixin), function(_, super_) {
   _.deleteSide = function(side, outward, cursor) {
     var parent = this.parent, sib = this[side], farEnd = parent.ends[side];
 
-    if (side === this.side) { // deleting non-ghost of one-sided bracket, unwrap
+    if (
+      //unwrap if deleting either...
+      side === this.side || //the solid side with a ghost pair
+      (
+        this.side === 0 && //or one side of matched parens
+        side === -1 &&
+        this.sides[1].ch === OPP_BRACKS[this.sides[-1].ch]
+      )
+    ) {
       this.unwrap();
       sib ? cursor.insDirOf(-side, sib) : cursor.insAtDirEnd(side, parent);
       return;

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -256,8 +256,6 @@ suite('typing with auto-replaces', function() {
         mq.typedText('1+(2+3]+4');
         assertLatex('1+\\left(2+3\\right]+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
-        assertLatex('\\left[1+2+3\\right]+4');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3+4');
       });
 
@@ -275,8 +273,6 @@ suite('typing with auto-replaces', function() {
         mq.typedText('1+(2+3]');
         assertLatex('1+\\left(2+3\\right]');
         mq.keystroke('Left Left Left Left Backspace');
-        assertLatex('\\left[1+2+3\\right]');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3');
       });
 
@@ -293,8 +289,6 @@ suite('typing with auto-replaces', function() {
         mq.typedText('(2+3]+4');
         assertLatex('\\left(2+3\\right]+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
-        assertLatex('\\left[2+3\\right]+4');
-        mq.keystroke('Right Right Right Right Right Backspace');
         assertLatex('2+3+4');
       });
 
@@ -319,9 +313,6 @@ suite('typing with auto-replaces', function() {
         mq.typedText('1+(]+4');
         assertLatex('1+\\left(\\right]+4');
         mq.keystroke('Left Left Left Backspace');
-        assertLatex('\\left[1+\\right]+4');
-        assertParenBlockNonEmpty();
-        mq.keystroke('Right Backspace');
         assertLatex('1++4');
       });
 
@@ -338,9 +329,6 @@ suite('typing with auto-replaces', function() {
         mq.typedText('1+(]');
         assertLatex('1+\\left(\\right]');
         mq.keystroke('Left Backspace');
-        assertLatex('\\left[1+\\right]');
-        assertParenBlockNonEmpty();
-        mq.keystroke('Right Right Backspace');
         assertLatex('1+');
       });
 
@@ -358,8 +346,6 @@ suite('typing with auto-replaces', function() {
         mq.typedText('(]+4');
         assertLatex('\\left(\\right]+4');
         mq.keystroke('Left Left Left Backspace');
-        assertLatex('\\left[\\right]+4');
-        mq.keystroke('Right Right Backspace');
         assertLatex('+4');
       });
 
@@ -376,8 +362,6 @@ suite('typing with auto-replaces', function() {
         mq.latex('1+\\left(2+3\\right]+4');
         assertLatex('1+\\left(2+3\\right]+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
-        assertLatex('\\left[1+2+3\\right]+4');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3+4');
       });
 
@@ -430,9 +414,7 @@ suite('typing with auto-replaces', function() {
         mq.typedText('(2+3]+4');
         assertLatex('\\left(2+3\\right]+4');
         mq.keystroke('Home Right Backspace');
-        assertLatex('\\left[2+3\\right]+4');
-        mq.typedText('1+');
-        assertLatex('1+\\left[2+3\\right]+4');
+        assertLatex('2+3+4');
       });
 
       test('backspacing paren containing a one-sided paren 0+[(1+2)+3]+4', function() {
@@ -626,8 +608,6 @@ suite('typing with auto-replaces', function() {
           mq.latex('1+\\left|2+3\\right)+4');
           assertLatex('1+\\left|2+3\\right)+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
-          assertLatex('\\left(1+2+3\\right)+4');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3+4');
         });
 
@@ -644,8 +624,6 @@ suite('typing with auto-replaces', function() {
           mq.latex('1+\\left(2+3\\right|+4');
           assertLatex('1+\\left(2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
-          assertLatex('\\left|1+2+3\\right|+4');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3+4');
         });
 
@@ -749,7 +727,7 @@ suite('typing with auto-replaces', function() {
           mq.keystroke('Home Right Right').typedText('|');
           assertLatex('0+\\left|1+\\left(2+3\\right|+4\\right|');
           mq.keystroke('Right Right Del');
-          assertLatex('0+\\left|1+2+3\\right|+4');
+          assertLatex('0+\\left|1+2+3+4\\right|');
         });
       });
     }

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -199,9 +199,9 @@ suite('typing with auto-replaces', function() {
             mq.typedText('||');
             assertLatex('\\left|\\right|');
             mq.keystroke('Left Backspace');
-            assertLatex('\\left|\\right|');
+            assertLatex('');
             mq.typedText('(');
-            assertLatex('\\left(\\right|');
+            assertLatex('\\left(\\right)');
           });
         });
       });
@@ -236,12 +236,10 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('backspacing open-paren then close-paren of 1+(2+3)+4', function() {
+      test('backspacing open-paren of 1+(2+3)+4', function() {
         mq.typedText('1+(2+3)+4');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
-        assertLatex('\\left(1+2+3\\right)+4');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3+4');
       });
 
@@ -392,12 +390,10 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('rendering paren group 1+(2+3)+4 from LaTeX then backspacing open-paren then close-paren', function() {
+      test('rendering paren group 1+(2+3)+4 from LaTeX then backspacing open-paren', function() {
         mq.latex('1+\\left(2+3\\right)+4');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
-        assertLatex('\\left(1+2+3\\right)+4');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3+4');
       });
 
@@ -412,14 +408,12 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('wrapping selection in parens 1+(2+3)+4 then backspacing open-paren then close-paren', function() {
+      test('wrapping selection in parens 1+(2+3)+4 then backspacing open-paren', function() {
         mq.typedText('1+2+3+4');
         assertLatex('1+2+3+4');
         mq.keystroke('Left Left Shift-Left Shift-Left Shift-Left').typedText('(');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Backspace');
-        assertLatex('\\left(1+2+3\\right)+4');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3+4');
       });
 
@@ -472,11 +466,6 @@ suite('typing with auto-replaces', function() {
         mq.typedText('1+((2+3))');
         assertLatex('1+\\left(\\left(2+3\\right)\\right)');
         mq.keystroke('Left Left Left Left Left Backspace');
-        assertLatex('1+\\left(\\left(2+3\\right)\\right)');
-        mq.keystroke('Backspace');
-        assertLatex('\\left(1+\\left(2+3\\right)\\right)');
-        // now check that the inner open-paren isn't still a ghost
-        mq.keystroke('Right Right Right Right Del');
         assertLatex('1+\\left(2+3\\right)');
       });
 
@@ -490,7 +479,7 @@ suite('typing with auto-replaces', function() {
         mq.keystroke('Right Right Right Right Right Backspace');
         assertLatex('\\left(1+2\\right)+\\left(3+4\\right)+5');
         mq.keystroke('Left Left Left Left Backspace');
-        assertLatex('\\left(\\left(1+2\\right)+3+4\\right)+5');
+        assertLatex('\\left(1+2\\right)+3+4+5');
       });
 
       suite('pipes', function() {
@@ -512,12 +501,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('backspacing open-pipe then close-pipe of 1+|2+3|+4', function() {
+        test('backspacing open-pipe of 1+|2+3|+4', function() {
           mq.typedText('1+|2+3|+4');
           assertLatex('1+\\left|2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
-          assertLatex('\\left|1+2+3\\right|+4');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3+4');
         });
 
@@ -530,12 +517,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3');
         });
 
-        test('backspacing open-pipe then close-pipe of 1+|2+3| (nothing after pipe pair)', function() {
+        test('backspacing open-pipe of 1+|2+3| (nothing after pipe pair)', function() {
           mq.typedText('1+|2+3|');
           assertLatex('1+\\left|2+3\\right|');
           mq.keystroke('Left Left Left Left Backspace');
-          assertLatex('\\left|1+2+3\\right|');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3');
         });
 
@@ -548,12 +533,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('2+3+4');
         });
 
-        test('backspacing open-pipe then close-pipe of |2+3|+4 (nothing before pipe pair)', function() {
+        test('backspacing open-pipe of |2+3|+4 (nothing before pipe pair)', function() {
           mq.typedText('|2+3|+4');
           assertLatex('\\left|2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
-          assertLatex('\\left|2+3\\right|+4');
-          mq.keystroke('Right Right Right Right Right Backspace');
           assertLatex('2+3+4');
         });
 
@@ -574,13 +557,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('1++4');
         });
 
-        test('backspacing open-pipe then close-pipe of 1+||+4 (empty pipe pair)', function() {
+        test('backspacing open-pipe of 1+||+4 (empty pipe pair)', function() {
           mq.typedText('1+||+4');
           assertLatex('1+\\left|\\right|+4');
           mq.keystroke('Left Left Left Backspace');
-          assertLatex('\\left|1+\\right|+4');
-          assertParenBlockNonEmpty();
-          mq.keystroke('Right Backspace');
           assertLatex('1++4');
         });
 
@@ -593,13 +573,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+');
         });
 
-        test('backspacing open-pipe then close-pipe of 1+|| (empty pipe pair, nothing after)', function() {
+        test('backspacing open-pipe of 1+|| (empty pipe pair, nothing after)', function() {
           mq.typedText('1+||');
           assertLatex('1+\\left|\\right|');
           mq.keystroke('Left Backspace');
-          assertLatex('\\left|1+\\right|');
-          assertParenBlockNonEmpty();
-          mq.keystroke('Right Right Backspace');
           assertLatex('1+');
         });
 
@@ -613,12 +590,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('+4');
         });
 
-        test('backspacing open-pipe then close-pipe of ||+4 (empty pipe pair, nothing before)', function() {
+        test('backspacing open-pipe of ||+4 (empty pipe pair, nothing before)', function() {
           mq.typedText('||+4');
           assertLatex('\\left|\\right|+4');
           mq.keystroke('Left Left Left Backspace');
-          assertLatex('\\left|\\right|+4');
-          mq.keystroke('Right Right Backspace');
           assertLatex('+4');
         });
 
@@ -631,12 +606,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('rendering pipe pair 1+|2+3|+4 from LaTeX then backspacing open-pipe then close-pipe', function() {
+        test('rendering pipe pair 1+|2+3|+4 from LaTeX then backspacing open-pipe', function() {
           mq.latex('1+\\left|2+3\\right|+4');
           assertLatex('1+\\left|2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
-          assertLatex('\\left|1+2+3\\right|+4');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3+4');
         });
 
@@ -676,14 +649,12 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('wrapping selection in pipes 1+|2+3|+4 then backspacing open-pipe then close-pipe', function() {
+        test('wrapping selection in pipes 1+|2+3|+4 then backspacing open-pipe', function() {
           mq.typedText('1+2+3+4');
           assertLatex('1+2+3+4');
           mq.keystroke('Left Left Shift-Left Shift-Left Shift-Left').typedText('|');
           assertLatex('1+\\left|2+3\\right|+4');
           mq.keystroke('Backspace');
-          assertLatex('\\left|1+2+3\\right|+4');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3+4');
         });
 
@@ -698,22 +669,22 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('backspacing close-pipe of 1+|2+3| (nothing after) then typing', function() {
+        test('backspacing close-pipe then open-pipe of 1+|2+3| (nothing after pipe pair)', function() {
           mq.typedText('1+|2+3|');
           assertLatex('1+\\left|2+3\\right|');
           mq.keystroke('Backspace');
           assertLatex('1+\\left|2+3\\right|');
-          mq.typedText('+4');
-          assertLatex('1+\\left|2+3+4\\right|');
+          mq.keystroke('Left Left Left Backspace');
+          assertLatex('1+2+3');
         });
 
         test('backspacing open-pipe of |2+3|+4 (nothing before) then typing', function() {
           mq.typedText('|2+3|+4');
           assertLatex('\\left|2+3\\right|+4');
           mq.keystroke('Home Right Backspace');
-          assertLatex('\\left|2+3\\right|+4');
+          assertLatex('2+3+4');
           mq.typedText('1+');
-          assertLatex('1+\\left|2+3\\right|+4');
+          assertLatex('1+2+3+4');
         });
 
         test('backspacing pipe containing a one-sided pipe 0+|1+|2+3||+4', function() {
@@ -731,7 +702,7 @@ suite('typing with auto-replaces', function() {
           mq.keystroke('Home Right Right').typedText('|');
           assertLatex('0+\\left|1+\\left|2+3\\right|+4\\right|');
           mq.keystroke('Right Right Del');
-          assertLatex('0+\\left|1+2+3\\right|+4');
+          assertLatex('0+\\left|1+2+3+4\\right|');
         });
 
         test('backspacing pipe containing and inside a one-sided pipe |0+|1+|2+3||+4|', function() {
@@ -790,7 +761,7 @@ suite('typing with auto-replaces', function() {
         mq.keystroke('Right').typedText('+4');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
-        assertLatex('\\left(1+2+3\\right)+4');
+        assertLatex('1+2+3+4');
       });
 
       test('selected and replaced by LiveFraction solidifies ghosts (1+2)/( )', function() {
@@ -830,14 +801,14 @@ suite('typing with auto-replaces', function() {
           mq.keystroke('Right').typedText('|');
           assertLatex('\\left|1+2\\right|');
           mq.keystroke('Home Del');
-          assertLatex('\\left|1+2\\right|');
+          assertLatex('1+2');
         });
 
         test('close pipe pair from outside to the left |1+2|', function() {
           mq.typedText('|1+2|');
           assertLatex('\\left|1+2\\right|');
           mq.keystroke('Home Del');
-          assertLatex('\\left|1+2\\right|');
+          assertLatex('1+2');
           mq.keystroke('Left').typedText('|');
           assertLatex('\\left|1+2\\right|');
           mq.keystroke('Ctrl-End Backspace');


### PR DESCRIPTION
Alternative to #399 
Fixes #396 

Tried out deleting both when you delete either, but that doesn't actually feel quite right. Realized that a possible general principle is: actions shouldn't cause non-local changes to the left of the cursor whenever possible. That's what feels weird to me.

Note: this still doesn't help with the case of using parentheses to form a complex fraction. Making a ticket about that one separately.