### PR TITLE
Denominators should have same padding as numerators

### DIFF
--- a/src/css/math.less
+++ b/src/css/math.less
@@ -236,7 +236,9 @@
     border-top: 1px solid;
     float: right; // take out of normal flow to manipulate baseline
     width: 100%;
-    padding: .1em 0;
+    padding: .1em;
+    position: relative;
+    left: .1em;
   }
 
   ////


### PR DESCRIPTION
Before:
![image](http://i.imgur.com/5ldcpuq.gif)
After:
![image](http://i.imgur.com/NVzlW7L.gif)

Numerators have a .1em padding on the left and right, but it was removed
from denominators in #397 because the negative margin was causing
problems. Well, florin doesn't use negative margins anymore and neither
should denominators.