### PR TITLE
Unary operators shouldn't break out of exponents.

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ the LaTeX `x^{2n+y}`, you have to hit Down or Tab (or Space if
 the LaTeX `x^{2n}+y`; this option makes `+` "break out" of the exponent and
 type what you expect. Problem is, now you can't just type `x^n+m` to get the
 LaTeX `x^{n+m}`, you have to type `x^(n+m` and delete the paren or something.
+(Doesn't apply to the first character in a superscript or subscript, so typing
+`x^-6` still results in `x^{-6}`.)
 
 `autoCommands`, a space-delimited list of LaTeX control words (no backslash,
 letters only, min length 2), defines the (default empty) set of "auto-commands",

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -191,12 +191,8 @@ var SupSub = P(MathCommand, function(_, super_) {
         else cursor.clearSelection().insRightOf(this.parent);
         return cmd.createLeftOf(cursor.show());
       }
-      if (
-        cursor.options.charsThatBreakOutOfSupSub.indexOf(ch) > -1 &&
-        // Unary operators never break out of exponents, so that it's easy to
-        // write negative exponents.
-        cursor[L] !== 0
-      ) {
+      if (cursor[L] // doesn't apply to 1st char, in case of negative exponents
+          && cursor.options.charsThatBreakOutOfSupSub.indexOf(ch) > -1) {
         cursor.insRightOf(this.parent);
       }
       MathBlock.p.write.apply(this, arguments);

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -191,7 +191,12 @@ var SupSub = P(MathCommand, function(_, super_) {
         else cursor.clearSelection().insRightOf(this.parent);
         return cmd.createLeftOf(cursor.show());
       }
-      if (cursor.options.charsThatBreakOutOfSupSub.indexOf(ch) > -1) {
+      if (
+        cursor.options.charsThatBreakOutOfSupSub.indexOf(ch) > -1 &&
+        // Unary operators never break out of exponents, so that it's easy to
+        // write negative exponents.
+        cursor[L] !== 0
+      ) {
         cursor.insRightOf(this.parent);
       }
       MathBlock.p.write.apply(this, arguments);

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1026,11 +1026,25 @@ suite('typing with auto-replaces', function() {
   suite('SupSub behavior options', function() {
     test('charsThatBreakOutOfSupSub', function() {
       assert.equal(mq.typedText('x^2n+y').latex(), 'x^{2n+y}');
-
       mq.latex('');
+      assert.equal(mq.typedText('x^+2n').latex(), 'x^{+2n}');
+      mq.latex('');
+      assert.equal(mq.typedText('x^-2n').latex(), 'x^{-2n}');
+      mq.latex('');
+      assert.equal(mq.typedText('x^=2n').latex(), 'x^{=2n}');
+      mq.latex('');
+
       MathQuill.config({ charsThatBreakOutOfSupSub: '+-=<>' });
 
       assert.equal(mq.typedText('x^2n+y').latex(), 'x^{2n}+y');
+      mq.latex('');
+      // Unary operators never break out of exponents.
+      assert.equal(mq.typedText('x^+2n').latex(), 'x^{+2n}');
+      mq.latex('');
+      assert.equal(mq.typedText('x^-2n').latex(), 'x^{-2n}');
+      mq.latex('');
+      assert.equal(mq.typedText('x^=2n').latex(), 'x^{=2n}');
+      mq.latex('');
     });
     test('supSubsRequireOperand', function() {
       assert.equal(mq.typedText('^').latex(), '^{ }');


### PR DESCRIPTION
The point of this is to make it so that even with `charsThatBreakOutOfSupSub = '+-'`, typing `10^-7` still gives you `10^{-7}`.