### PR TITLE
Replace zero width joiner with zero width space.

### DIFF
--- a/src/cursor.js
+++ b/src/cursor.js
@@ -15,7 +15,7 @@ var Cursor = P(Point, function(_) {
     this.parent = initParent;
     this.options = options;
 
-    var jQ = this.jQ = this._jQ = $('<span class="mq-cursor">&zwj;</span>');
+    var jQ = this.jQ = this._jQ = $('<span class="mq-cursor">&#8203;</span>');
     //closured for setInterval
     this.blink = function(){ jQ.toggleClass('mq-blink'); };
 


### PR DESCRIPTION
`&#8203` is the zero width space character. We replaced most other uses of the zero width joiner with a zero width space because of a font rendering bug in Chrome. For whatever reason, this particular example doesn't visually exhibit the bug, but I think it makes sense to replace zwj here for consistency, and because a zero width space makes more semantic sense.