### PR TITLE
Simplify backspace behavior

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -108,9 +108,7 @@ var MathCommand = P(MathElement, function(_, super_) {
     cursor.insAtDirEnd(-dir, updownInto || this.ends[-dir]);
   };
   _.deleteTowards = function(dir, cursor) {
-    cursor.startSelection();
-    this.selectTowards(dir, cursor);
-    cursor.select();
+    this.moveTowards(dir, cursor, null);
   };
   _.selectTowards = function(dir, cursor) {
     cursor[-dir] = this;

--- a/test/unit/autosubscript.test.js
+++ b/test/unit/autosubscript.test.js
@@ -2,6 +2,9 @@ suite('autoSubscript', function() {
   var mq;
   setup(function() {
     mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0], {autoSubscriptNumerals: true});
+    rootBlock = mq.__controller.root;
+    controller = mq.__controller;
+    cursor = controller.cursor;
   });
   teardown(function() {
     $(mq.el()).remove();
@@ -46,4 +49,58 @@ suite('autoSubscript', function() {
   });
 
 
+  test('backspace through compound subscript', function() {
+    mq.latex('x_{2_2}');
+
+    //first backspace moves to cursor in subscript and peels it off
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_2');
+
+    //second backspace clears out remaining subscript
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_{ }');
+
+    //unpeel subscript
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x');
+  });
+
+  test('backspace through simple subscript', function() {
+    mq.latex('x_{2+3}');
+
+    assert.equal(cursor.parent, rootBlock, 'start in the root block');
+
+    //backspace peels off subscripts but stays at the root block level
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_{2+}');
+    assert.equal(cursor.parent, rootBlock, 'backspace keeps us in the root block');
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_2');
+    assert.equal(cursor.parent, rootBlock, 'backspace keeps us in the root block');
+
+    //second backspace clears out remaining subscript and unpeels
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x');
+  });
+
+  test('backspace through subscript & superscript with autosubscripting on', function() {
+    mq.latex('x_2^{32}');
+
+    //first backspace peels off the subscript
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x^{32}');
+
+    //second backspace goes into the exponent
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x^{32}');
+
+    //clear out exponent
+    mq.keystroke('Backspace');
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x^{ }');
+
+    //unpeel exponent
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x');
+  });
 });

--- a/test/unit/backspace.test.js
+++ b/test/unit/backspace.test.js
@@ -1,0 +1,187 @@
+suite('backspace', function() {
+  var mq, rootBlock, controller, cursor;
+  setup(function() {
+    mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+    rootBlock = mq.__controller.root;
+    controller = mq.__controller;
+    cursor = controller.cursor;
+  });
+  teardown(function() {
+    $(mq.el()).remove();
+  });
+
+  function prayWellFormedPoint(pt) { prayWellFormed(pt.parent, pt[L], pt[R]); }
+  function assertLatex(latex) {
+    prayWellFormedPoint(mq.__controller.cursor);
+    assert.equal(mq.latex(), latex);
+  }
+
+  test('backspace through exponent', function() {
+    controller.renderLatexMath('x^{nm}');
+    var exp = rootBlock.ends[R],
+      expBlock = exp.ends[L];
+    assert.equal(exp.latex(), '^{nm}', 'right end el is exponent');
+    assert.equal(cursor.parent, rootBlock, 'cursor is in root block');
+    assert.equal(cursor[L], exp, 'cursor is at the end of root block');
+
+    mq.keystroke('Backspace');
+    assert.equal(cursor.parent, expBlock, 'cursor up goes into exponent on backspace');
+    assertLatex('x^{nm}');
+
+    mq.keystroke('Backspace');
+    assert.equal(cursor.parent, expBlock, 'cursor still in exponent');
+    assertLatex('x^n');
+
+    mq.keystroke('Backspace');
+    assert.equal(cursor.parent, expBlock, 'still in exponent, but it is empty');
+    assertLatex('x^{ }');
+
+    mq.keystroke('Backspace');
+    assert.equal(cursor.parent, rootBlock, 'backspace tears down exponent');
+    assertLatex('x');
+  });
+
+  test('backspace through complex fraction', function() {
+    controller.renderLatexMath('1+\\frac{1}{\\frac{1}{2}+\\frac{2}{3}}');
+
+    //first backspace moves to denominator
+    mq.keystroke('Backspace');
+    assertLatex('1+\\frac{1}{\\frac{1}{2}+\\frac{2}{3}}');
+
+    //first backspace moves to denominator in denominator
+    mq.keystroke('Backspace');
+    assertLatex('1+\\frac{1}{\\frac{1}{2}+\\frac{2}{3}}');
+
+    //finally delete a character
+    mq.keystroke('Backspace');
+    assertLatex('1+\\frac{1}{\\frac{1}{2}+\\frac{2}{ }}');
+
+    //destroy fraction
+    mq.keystroke('Backspace');
+    assertLatex('1+\\frac{1}{\\frac{1}{2}+2}');
+
+    mq.keystroke('Backspace');
+    mq.keystroke('Backspace');
+    assertLatex('1+\\frac{1}{\\frac{1}{2}}');
+
+    mq.keystroke('Backspace');
+    mq.keystroke('Backspace');
+    assertLatex('1+\\frac{1}{\\frac{1}{ }}');
+
+    mq.keystroke('Backspace');
+    assertLatex('1+\\frac{1}{1}');
+
+    mq.keystroke('Backspace');
+    assertLatex('1+\\frac{1}{ }');
+
+    mq.keystroke('Backspace');
+    assertLatex('1+1');
+  });
+
+
+
+  test('backspace through compound subscript', function() {
+    mq.latex('x_{2_2}');
+
+    //first backspace goes into the subscript
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_{2_2}');
+
+    //second one goes into the subscripts' subscript
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_{2_2}');
+
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_{2_{ }}');
+
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_2');
+
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_{ }');
+
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x');
+  });
+
+  test('backspace through simple subscript', function() {
+    mq.latex('x_{2+3}');
+
+    assert.equal(cursor.parent, rootBlock, 'start in the root block');
+
+    //backspace goes down
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_{2+3}');
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_{2+}');
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_2');
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_{ }');
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x');
+  });
+
+  test('backspace through subscript & superscript', function() {
+    mq.latex('x_2^{32}');
+
+    //first backspace takes us into the exponent
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_2^{32}');
+
+    //second backspace goes into the exponent
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_2^3');
+
+    //clear out exponent
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_2^{ }');
+
+    //unpeel exponent
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'x_2');
+
+    //(slightly weird behavior), next backspace is at the baseline and removes the x
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'_2');
+  });
+
+  test('backspace through nthroot', function() {
+    mq.latex('\\sqrt[3]{x}');
+
+    //first backspace takes us inside the nthroot
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'\\sqrt[3]{x}');
+
+    //second backspace removes the x
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'\\sqrt[3]{}');
+
+    //third one destroys the cube root, but leaves behind the 3
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'3');
+
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'');
+  });
+
+  test('backspace through large operator', function() {
+    mq.latex('\\sum_{n=1}^3x');
+
+    //first backspace takes out the argument
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'\\sum_{n=1}^3');
+
+    //up into the superscript
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'\\sum_{n=1}^3');
+
+    //up into the superscript
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'\\sum_{n=1}^{ }');
+
+    //destroy the sum, preserve the subscript (a little surprising)
+    mq.keystroke('Backspace');
+    assert.equal(mq.latex(),'n=1');
+  });
+});

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -863,22 +863,22 @@ suite('typing with auto-replaces', function() {
       mq.typedText('sum' + 'n=0');
       mq.keystroke('Up').typedText('100').keystroke('Right');
       assertLatex('\\sum_{n=0}^{100}');
-      mq.keystroke('Backspace');
+      mq.keystroke('Ctrl-Backspace').keystroke('Backspace').keystroke('Ctrl-Backspace');
 
       mq.typedText('prod');
       mq.typedText('n=0').keystroke('Up').typedText('100').keystroke('Right');
       assertLatex('\\prod_{n=0}^{100}');
-      mq.keystroke('Backspace');
+      mq.keystroke('Ctrl-Backspace').keystroke('Backspace').keystroke('Ctrl-Backspace');
 
       mq.typedText('sqrt');
       mq.typedText('100').keystroke('Right');
       assertLatex('\\sqrt{100}');
-      mq.keystroke('Backspace').keystroke('Backspace');
+      mq.keystroke('Ctrl-Backspace').keystroke('Backspace');
 
       mq.typedText('nthroot');
       mq.typedText('n').keystroke('Right').typedText('100').keystroke('Right');
       assertLatex('\\sqrt[n]{100}');
-      mq.keystroke('Backspace').keystroke('Backspace');
+      mq.keystroke('Ctrl-Backspace').keystroke('Backspace').keystroke('Backspace');
 
       mq.typedText('pi');
       assertLatex('\\pi');


### PR DESCRIPTION
On this branch, backspace into a complex element (fraction, exponent, etc) behaves like a left arrow instead of selecting.

to me, it's a little more intuitive. A few edge cases feel a little off, but the whole thing feels more intuitive to me. @laughinghan, what do you think?

Also adding a bunch of backspace tests -- backspace felt pretty untested