### PR TITLE
fix chrome display bug

### DIFF
--- a/src/css/textarea.less
+++ b/src/css/textarea.less
@@ -6,6 +6,9 @@
 
     // TODO: why is this here?
     .user-select(text);
+
+    //fixes chrome 43 bug where the left side of 'f' could get cut off. discovered by @ctlusto
+    border: 1px solid transparent;
   }
 
   .mq-textarea *, .mq-selectable {


### PR DESCRIPTION
could only repro when 'f' is the first character in the desmos calculator,
and only in chrome canary. seems like a non-destructive fix.