### PR TITLE
Fix chrome & ipad display bugs

### DIFF
--- a/src/css/textarea.less
+++ b/src/css/textarea.less
@@ -13,8 +13,13 @@
     position: absolute; // the only way to hide the textarea *and* the
     clip: rect(1em 1em 1em 1em); // blinking insertion point in IE
     resize: none; // hotfix: https://code.google.com/p/chromium/issues/detail?id=355199#c1
-
   }
+
+  //remove system cursor on iPad
+  .mq-textarea textarea:focus {
+    text-indent: -9999em;
+  }
+
   .mq-selectable {
     width: 1px; // don't "stick out" invisibly from a math field,
     height: 1px; // can affect ancestor's .scroll{Width,Height}

--- a/src/css/textarea.less
+++ b/src/css/textarea.less
@@ -10,12 +10,12 @@
 
   .mq-textarea *, .mq-selectable {
     .user-select(text);
-
     position: absolute; // the only way to hide the textarea *and* the
     clip: rect(1em 1em 1em 1em); // blinking insertion point in IE
-
     resize: none; // hotfix: https://code.google.com/p/chromium/issues/detail?id=355199#c1
 
+  }
+  .mq-selectable {
     width: 1px; // don't "stick out" invisibly from a math field,
     height: 1px; // can affect ancestor's .scroll{Width,Height}
   }


### PR DESCRIPTION
Fix #1: get rid of weird white cover that shows up in chrome 43 in desmos tables.

Before:
![screen shot 2015-06-09 at 2 35 35 pm](https://cloud.githubusercontent.com/assets/478331/8070883/c6073490-0eb9-11e5-93e3-6923868b5bfc.png)

After:
![screen shot 2015-06-09 at 3 09 30 pm](https://cloud.githubusercontent.com/assets/478331/8070881/c24c95e8-0eb9-11e5-9b10-a5e60ed4b05a.png)

Fix #2:
make sure a second cursor doesn't show up on iPad when using a real textarea. Fix from here:
