### PR TITLE
Fix TextBlock cursor movement bug

### DIFF
--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -170,7 +170,7 @@ var TextBlock = P(Node, function(_, super_) {
   function fuseChildren(self) {
     self.jQ[0].normalize();
 
-    var textPcDom = self.jQ[0].firstChild;
+    var textPcDom = self.jQ.contents().filter(function (i, el) { return el.nodeType === 3; })[0]
     var textPc = TextPiece(textPcDom.data);
     textPc.jQadd(textPcDom);
 

--- a/test/unit/text.test.js
+++ b/test/unit/text.test.js
@@ -53,4 +53,16 @@ suite('text', function() {
     ctrlr.moveRight();
     assertSplit(cursor.jQ, 'abc', null);
   });
+
+  test('does not change latex as the cursor moves around', function() {
+    var block = fromLatex('\\text{x}');
+    var ctrlr = Controller({ __options: 0 }, block);
+    var cursor = ctrlr.cursor.insAtRightEnd(block);
+
+    ctrlr.moveLeft();
+    ctrlr.moveLeft();
+    ctrlr.moveLeft();
+
+    assert.equal(block.latex(), '\\text{x}');
+  });
 });


### PR DESCRIPTION
When the cursor is in a certain position, firstChild picks up the .mq-cursor span rather than the text node, causing [issue 429](https://github.com/mathquill/mathquill/issues/429).

My code will still throw an error on line 174 if there's no textNode child. I think that's ok as we already make the assumption elsewhere that TextBlock always has content.

Sorry about the magic number for textNode - maybe there's a better way to filter this?