### PR TITLE
Enforce sub-then-sup order when deleting SupSub blocks

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -246,12 +246,13 @@ var SupSub = P(MathCommand, function(_, super_) {
     // like 'sub sup'.split(' ').forEach(function(supsub) { ... });
     for (var i = 0; i < 2; i += 1) (function(cmd, supsub, oppositeSupsub, updown) {
       cmd[supsub].deleteOutOf = function(dir, cursor) {
-        cursor.insDirOf(dir, this.parent);
+        cursor.insDirOf((this[dir] ? -dir : dir), this.parent);
         if (!this.isEmpty()) {
-          cursor[-dir] = this.ends[dir];
+          var end = this.ends[dir];
           this.children().disown()
-            .withDirAdopt(dir, cursor.parent, cursor[dir], this.parent)
-            .jQ.insDirOf(dir, this.parent.jQ);
+            .withDirAdopt(dir, cursor.parent, cursor[dir], cursor[-dir])
+            .jQ.insDirOf(-dir, cursor.jQ);
+          cursor[-dir] = end;
         }
         cmd.supsub = oppositeSupsub;
         delete cmd[supsub];

--- a/test/unit/SupSub.test.js
+++ b/test/unit/SupSub.test.js
@@ -158,10 +158,10 @@ suite('SupSub', function() {
       assert.equal(mq.latex(), 'x_a^b');
 
       mq.keystroke('Left Backspace');
-      assert.equal(mq.latex(), 'xb_a');
+      assert.equal(mq.latex(), 'x_ab');
 
       mq.typedText('c');
-      assert.equal(mq.latex(), 'xcb_a');
+      assert.equal(mq.latex(), 'x_acb');
     });
   });
 });


### PR DESCRIPTION
Say you've got

    x_{sub}^{|sup}

where the | is the cursor. If you hit backspace, what should you get?

    x_{sub}|sup

right?

Well, prior to this commit, you'd get

    x|sup_{sub}

which maybe would make sense if subscripts and superscripts were
semantically on equal footing (e.g. Einstein notation or chemical
symbols symbol), but usually subscripts are part of a variable's name
(e.g. the index), whereas superscripts are exponents.

We already enforce the subscript-then-superscript ordering when
exporting LaTeX and when moving the cursor around with the left and
right arrow keys (when `leftRightIntoCmdGoes` isn't set), so it makes
sense to be consistent with that when deleting.