### PR TITLE
Backspacing open-paren unwraps paren-pair

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -583,7 +583,7 @@ var Bracket = P(P(MathCommand, DelimsMixin), function(_, super_) {
       return;
     }
 
-    var opts = cursor.options;
+    var opts = cursor.options, wasSolid = !this.side;
     this.side = -side;
     // if deleting like, outer close-brace of [(1+2)+3} where inner open-paren
     if (this.oppBrack(opts, this.ends[L].ends[this.side], side)) { // is ghost,
@@ -597,8 +597,13 @@ var Bracket = P(P(MathCommand, DelimsMixin), function(_, super_) {
       if (this.oppBrack(opts, this.parent.parent, side)) { // open-paren is
         this.parent.parent.closeOpposing(this); // ghost, then become [1+2+3)
         this.parent.parent.unwrap();
+      } // else if deleting outward from a solid pair, unwrap
+      else if (outward && wasSolid) {
+        this.unwrap();
+        sib ? cursor.insDirOf(-side, sib) : cursor.insAtDirEnd(side, parent);
+        return;
       }
-      else { // deleting one of a pair of brackets, become one-sided
+      else { // else deleting just one of a pair of brackets, become one-sided
         this.sides[side] = { ch: OPP_BRACKS[this.sides[this.side].ch],
                              ctrlSeq: OPP_BRACKS[this.sides[this.side].ctrlSeq] };
         this.delimjQs.removeClass('mq-ghost')

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -198,7 +198,7 @@ suite('typing with auto-replaces', function() {
           test('(|', function() {
             mq.typedText('||');
             assertLatex('\\left|\\right|');
-            mq.keystroke('Left Backspace');
+            mq.keystroke('Left Left Del');
             assertLatex('\\left|\\right|');
             mq.typedText('(');
             assertLatex('\\left(\\right|');
@@ -236,12 +236,10 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('backspacing open-paren then close-paren of 1+(2+3)+4', function() {
+      test('backspacing open-paren of 1+(2+3)+4', function() {
         mq.typedText('1+(2+3)+4');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
-        assertLatex('\\left(1+2+3\\right)+4');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3+4');
       });
 
@@ -254,12 +252,10 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('backspacing open-paren then close-bracket of 1+(2+3]+4', function() {
+      test('backspacing open-paren of 1+(2+3]+4', function() {
         mq.typedText('1+(2+3]+4');
         assertLatex('1+\\left(2+3\\right]+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
-        assertLatex('\\left[1+2+3\\right]+4');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3+4');
       });
 
@@ -273,12 +269,10 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3');
       });
 
-      test('backspacing open-paren then close-bracket of 1+(2+3] (nothing after paren group)', function() {
+      test('backspacing open-paren of 1+(2+3] (nothing after paren group)', function() {
         mq.typedText('1+(2+3]');
         assertLatex('1+\\left(2+3\\right]');
         mq.keystroke('Left Left Left Left Backspace');
-        assertLatex('\\left[1+2+3\\right]');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3');
       });
 
@@ -291,12 +285,10 @@ suite('typing with auto-replaces', function() {
         assertLatex('2+3+4');
       });
 
-      test('backspacing open-paren then close-bracket of (2+3]+4 (nothing before paren group)', function() {
+      test('backspacing open-paren of (2+3]+4 (nothing before paren group)', function() {
         mq.typedText('(2+3]+4');
         assertLatex('\\left(2+3\\right]+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
-        assertLatex('\\left[2+3\\right]+4');
-        mq.keystroke('Right Right Right Right Right Backspace');
         assertLatex('2+3+4');
       });
 
@@ -317,13 +309,10 @@ suite('typing with auto-replaces', function() {
         assertLatex('1++4');
       });
 
-      test('backspacing open-paren then close-bracket of 1+(]+4 (empty paren group)', function() {
+      test('backspacing open-paren of 1+(]+4 (empty paren group)', function() {
         mq.typedText('1+(]+4');
         assertLatex('1+\\left(\\right]+4');
         mq.keystroke('Left Left Left Backspace');
-        assertLatex('\\left[1+\\right]+4');
-        assertParenBlockNonEmpty();
-        mq.keystroke('Right Backspace');
         assertLatex('1++4');
       });
 
@@ -336,13 +325,10 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+');
       });
 
-      test('backspacing open-paren then close-bracket of 1+(] (empty paren group, nothing after)', function() {
+      test('backspacing open-paren of 1+(] (empty paren group, nothing after)', function() {
         mq.typedText('1+(]');
         assertLatex('1+\\left(\\right]');
         mq.keystroke('Left Backspace');
-        assertLatex('\\left[1+\\right]');
-        assertParenBlockNonEmpty();
-        mq.keystroke('Right Right Backspace');
         assertLatex('1+');
       });
 
@@ -356,12 +342,10 @@ suite('typing with auto-replaces', function() {
         assertLatex('+4');
       });
 
-      test('backspacing open-paren then close-bracket of (]+4 (empty paren group, nothing before)', function() {
+      test('backspacing open-paren of (]+4 (empty paren group, nothing before)', function() {
         mq.typedText('(]+4');
         assertLatex('\\left(\\right]+4');
         mq.keystroke('Left Left Left Backspace');
-        assertLatex('\\left[\\right]+4');
-        mq.keystroke('Right Right Backspace');
         assertLatex('+4');
       });
 
@@ -374,12 +358,10 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('rendering mismatched brackets 1+(2+3]+4 from LaTeX then backspacing open-paren then close-bracket', function() {
+      test('rendering mismatched brackets 1+(2+3]+4 from LaTeX then backspacing open-paren', function() {
         mq.latex('1+\\left(2+3\\right]+4');
         assertLatex('1+\\left(2+3\\right]+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
-        assertLatex('\\left[1+2+3\\right]+4');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3+4');
       });
 
@@ -392,12 +374,10 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('rendering paren group 1+(2+3)+4 from LaTeX then backspacing open-paren then close-paren', function() {
+      test('rendering paren group 1+(2+3)+4 from LaTeX then backspacing open-paren', function() {
         mq.latex('1+\\left(2+3\\right)+4');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Left Left Left Left Left Left Backspace');
-        assertLatex('\\left(1+2+3\\right)+4');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3+4');
       });
 
@@ -412,14 +392,12 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+2+3+4');
       });
 
-      test('wrapping selection in parens 1+(2+3)+4 then backspacing open-paren then close-paren', function() {
+      test('wrapping selection in parens 1+(2+3)+4 then backspacing open-paren', function() {
         mq.typedText('1+2+3+4');
         assertLatex('1+2+3+4');
         mq.keystroke('Left Left Shift-Left Shift-Left Shift-Left').typedText('(');
         assertLatex('1+\\left(2+3\\right)+4');
         mq.keystroke('Backspace');
-        assertLatex('\\left(1+2+3\\right)+4');
-        mq.keystroke('Right Right Right Right Backspace');
         assertLatex('1+2+3+4');
       });
 
@@ -436,9 +414,9 @@ suite('typing with auto-replaces', function() {
         mq.typedText('(2+3]+4');
         assertLatex('\\left(2+3\\right]+4');
         mq.keystroke('Home Right Backspace');
-        assertLatex('\\left[2+3\\right]+4');
+        assertLatex('2+3+4');
         mq.typedText('1+');
-        assertLatex('1+\\left[2+3\\right]+4');
+        assertLatex('1+2+3+4');
       });
 
       test('backspacing paren containing a one-sided paren 0+[(1+2)+3]+4', function() {
@@ -471,9 +449,9 @@ suite('typing with auto-replaces', function() {
       test('auto-expanding calls .siblingCreated() on new siblings 1+((2+3))', function() {
         mq.typedText('1+((2+3))');
         assertLatex('1+\\left(\\left(2+3\\right)\\right)');
-        mq.keystroke('Left Left Left Left Left Backspace');
+        mq.keystroke('Left Left Left Left Left Left Del');
         assertLatex('1+\\left(\\left(2+3\\right)\\right)');
-        mq.keystroke('Backspace');
+        mq.keystroke('Left Left Del');
         assertLatex('\\left(1+\\left(2+3\\right)\\right)');
         // now check that the inner open-paren isn't still a ghost
         mq.keystroke('Right Right Right Right Del');
@@ -490,7 +468,7 @@ suite('typing with auto-replaces', function() {
         mq.keystroke('Right Right Right Right Right Backspace');
         assertLatex('\\left(1+2\\right)+\\left(3+4\\right)+5');
         mq.keystroke('Left Left Left Left Backspace');
-        assertLatex('\\left(\\left(1+2\\right)+3+4\\right)+5');
+        assertLatex('\\left(1+2\\right)+3+4+5');
       });
 
       suite('pipes', function() {
@@ -512,12 +490,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('backspacing open-pipe then close-pipe of 1+|2+3|+4', function() {
+        test('backspacing open-pipe of 1+|2+3|+4', function() {
           mq.typedText('1+|2+3|+4');
           assertLatex('1+\\left|2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
-          assertLatex('\\left|1+2+3\\right|+4');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3+4');
         });
 
@@ -530,12 +506,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3');
         });
 
-        test('backspacing open-pipe then close-pipe of 1+|2+3| (nothing after pipe pair)', function() {
+        test('backspacing open-pipe of 1+|2+3| (nothing after pipe pair)', function() {
           mq.typedText('1+|2+3|');
           assertLatex('1+\\left|2+3\\right|');
           mq.keystroke('Left Left Left Left Backspace');
-          assertLatex('\\left|1+2+3\\right|');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3');
         });
 
@@ -548,12 +522,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('2+3+4');
         });
 
-        test('backspacing open-pipe then close-pipe of |2+3|+4 (nothing before pipe pair)', function() {
+        test('backspacing open-pipe of |2+3|+4 (nothing before pipe pair)', function() {
           mq.typedText('|2+3|+4');
           assertLatex('\\left|2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
-          assertLatex('\\left|2+3\\right|+4');
-          mq.keystroke('Right Right Right Right Right Backspace');
           assertLatex('2+3+4');
         });
 
@@ -574,13 +546,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('1++4');
         });
 
-        test('backspacing open-pipe then close-pipe of 1+||+4 (empty pipe pair)', function() {
+        test('backspacing open-pipe of 1+||+4 (empty pipe pair)', function() {
           mq.typedText('1+||+4');
           assertLatex('1+\\left|\\right|+4');
           mq.keystroke('Left Left Left Backspace');
-          assertLatex('\\left|1+\\right|+4');
-          assertParenBlockNonEmpty();
-          mq.keystroke('Right Backspace');
           assertLatex('1++4');
         });
 
@@ -593,13 +562,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+');
         });
 
-        test('backspacing open-pipe then close-pipe of 1+|| (empty pipe pair, nothing after)', function() {
+        test('backspacing open-pipe of 1+|| (empty pipe pair, nothing after)', function() {
           mq.typedText('1+||');
           assertLatex('1+\\left|\\right|');
           mq.keystroke('Left Backspace');
-          assertLatex('\\left|1+\\right|');
-          assertParenBlockNonEmpty();
-          mq.keystroke('Right Right Backspace');
           assertLatex('1+');
         });
 
@@ -613,12 +579,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('+4');
         });
 
-        test('backspacing open-pipe then close-pipe of ||+4 (empty pipe pair, nothing before)', function() {
+        test('backspacing open-pipe of ||+4 (empty pipe pair, nothing before)', function() {
           mq.typedText('||+4');
           assertLatex('\\left|\\right|+4');
           mq.keystroke('Left Left Left Backspace');
-          assertLatex('\\left|\\right|+4');
-          mq.keystroke('Right Right Backspace');
           assertLatex('+4');
         });
 
@@ -631,12 +595,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('rendering pipe pair 1+|2+3|+4 from LaTeX then backspacing open-pipe then close-pipe', function() {
+        test('rendering pipe pair 1+|2+3|+4 from LaTeX then backspacing open-pipe', function() {
           mq.latex('1+\\left|2+3\\right|+4');
           assertLatex('1+\\left|2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
-          assertLatex('\\left|1+2+3\\right|+4');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3+4');
         });
 
@@ -649,12 +611,10 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('rendering mismatched paren/pipe group 1+|2+3)+4 from LaTeX then backspacing open-pipe then close-paren', function() {
+        test('rendering mismatched paren/pipe group 1+|2+3)+4 from LaTeX then backspacing open-pipe', function() {
           mq.latex('1+\\left|2+3\\right)+4');
           assertLatex('1+\\left|2+3\\right)+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
-          assertLatex('\\left(1+2+3\\right)+4');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3+4');
         });
 
@@ -667,23 +627,19 @@ suite('typing with auto-replaces', function() {
           assertLatex('1+2+3+4');
         });
 
-        test('rendering mismatched paren/pipe group 1+(2+3|+4 from LaTeX then backspacing open-paren then close-pipe', function() {
+        test('rendering mismatched paren/pipe group 1+(2+3|+4 from LaTeX then backspacing open-paren', function() {
           mq.latex('1+\\left(2+3\\right|+4');
           assertLatex('1+\\left(2+3\\right|+4');
           mq.keystroke('Left Left Left Left Left Left Backspace');
-          assertLatex('\\left|1+2+3\\right|+4');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3+4');
         });
 
-        test('wrapping selection in pipes 1+|2+3|+4 then backspacing open-pipe then close-pipe', function() {
+        test('wrapping selection in pipes 1+|2+3|+4 then backspacing open-pipe', function() {
           mq.typedText('1+2+3+4');
           assertLatex('1+2+3+4');
           mq.keystroke('Left Left Shift-Left Shift-Left Shift-Left').typedText('|');
           assertLatex('1+\\left|2+3\\right|+4');
           mq.keystroke('Backspace');
-          assertLatex('\\left|1+2+3\\right|+4');
-          mq.keystroke('Right Right Right Right Backspace');
           assertLatex('1+2+3+4');
         });
 
@@ -711,9 +667,9 @@ suite('typing with auto-replaces', function() {
           mq.typedText('|2+3|+4');
           assertLatex('\\left|2+3\\right|+4');
           mq.keystroke('Home Right Backspace');
-          assertLatex('\\left|2+3\\right|+4');
+          assertLatex('2+3+4');
           mq.typedText('1+');
-          assertLatex('1+\\left|2+3\\right|+4');
+          assertLatex('1+2+3+4');
         });
 
         test('backspacing pipe containing a one-sided pipe 0+|1+|2+3||+4', function() {
@@ -750,7 +706,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('0+\\left|1+2\\right|+3');
           mq.keystroke('Home Right Right Right').typedText('|');
           assertLatex('0+\\left|\\left|1+2\\right|\\right|+3');
-          mq.keystroke('Tab Del');
+          mq.keystroke('Tab Tab Backspace');
           assertLatex('0+\\left|\\left|1+2\\right|+3\\right|');
         });
 
@@ -759,7 +715,7 @@ suite('typing with auto-replaces', function() {
           assertLatex('0+1+\\left|2+3\\right|+4');
           mq.keystroke('Home Right Right').typedText('|');
           assertLatex('0+\\left|1+\\left|2+3\\right|+4\\right|');
-          mq.keystroke('Right Right Right Right Right Right Del');
+          mq.keystroke('Right Right Right Right Right Right Right Backspace');
           assertLatex('0+\\left|1+\\left|2+3+4\\right|\\right|');
         });
 
@@ -789,7 +745,7 @@ suite('typing with auto-replaces', function() {
         assertLatex('1+\\left(2+3\\right)');
         mq.keystroke('Right').typedText('+4');
         assertLatex('1+\\left(2+3\\right)+4');
-        mq.keystroke('Left Left Left Left Left Left Backspace');
+        mq.keystroke('Left Left Left Left Left Left Left Del');
         assertLatex('\\left(1+2+3\\right)+4');
       });
 


### PR DESCRIPTION
...ditto forward-deleting close-paren, if both sides were solidified,
and there's no half-open bracket pair that would match up.

Fixes #396. Adaptation of @eluberoff's #400.