### PR TITLE
`edit`, `edited` as aliases for `reflow` event

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,26 @@ Just load MathQuill and call our constructors on some HTML element DOM objects,
 for example:
 
 ```html
-<p>
-  Solve <span class="static-math">ax^2+bx+c=0</span>:
-  <span class="math-field">x=</span>
-</p>
 <link rel="stylesheet" href="/path/to/mathquill.css"/>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 <script src="/path/to/mathquill.js"></script>
 <script>
-  $('.static-math').each(function() { MathQuill.StaticMath(this); });
-  $('.math-field').each(function() { MathQuill.MathField(this); });
+  $(function() {
+    MathQuill.StaticMath($('#problem')[0]);
+    var answer = MathQuill.MathField($('#answer')[0], {
+      handlers: {
+        edit: function() {
+          checkAnswer(answer.latex());
+        }
+      }
+    });
+  });
 </script>
+
+<p>
+  Solve <span id="problem">ax^2 + bx + c = 0</span>:
+  <span id="answer">x=</span>
+</p>
 ```
 
 To load MathQuill,
@@ -142,7 +151,7 @@ var mathField = MathQuill.MathField(el[0], {
     return document.createElement('textarea');
   },
   handlers: {
-    reflow: function(mathField) { ... },
+    edit: function(mathField) { ... },
     upOutOf: function(mathField) { ... },
     moveOutOf: function(dir, mathField) { if (dir === L) ... else ... }
   }
@@ -232,7 +241,7 @@ keyboards just don't work in Desmos on iOS, the tradeoffs are up to you.
 Supported handlers:
 - `moveOutOf`, `deleteOutOf`, and `selectOutOf` are called with `dir` and the
   math field API object as arguments
-- `upOutOf`, `downOutOf`, `enter`, and `reflow` are called with just the API
+- `upOutOf`, `downOutOf`, `enter`, and `edit` are called with just the API
   object as the argument
 
 The `*OutOf` handlers are called when Left/Right/Up/Down/Backspace/Del/
@@ -245,8 +254,9 @@ arguments, and Backspace causes `deleteOutOf` (if provided) to be called with
 
 The `enter` handler is called whenever Enter is pressed.
 
-The `reflow` handler is called when the size of the field might have been
+The `edit` handler is called when the contents of the field might have been
 changed by stuff being typed, or deleted, or written with the API, etc.
+(Deprecated aliases: `edited`, `reflow`.)
 
 Handlers are always called directly on the `handlers` object passed in,
 preserving the `this` value, so you can do stuff like:
@@ -276,7 +286,7 @@ over the math field:
 var latex = '';
 var mathField = MathQuill.MathField($('#mathfield')[0], {
   handlers: {
-    reflow: function() { latex = mathField.latex(); },
+    edit: function() { latex = mathField.latex(); },
     enter: function() { submitLatex(latex); }
   }
 });

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -174,8 +174,13 @@ var EditableField = MathQuill.EditableField = P(AbstractMathQuill, function(_) {
 });
 
 function RootBlockMixin(_) {
-  var names = 'moveOutOf deleteOutOf selectOutOf upOutOf downOutOf reflow'.split(' ');
+  var names = 'moveOutOf deleteOutOf selectOutOf upOutOf downOutOf'.split(' ');
   for (var i = 0; i < names.length; i += 1) (function(name) {
     _[name] = function(dir) { this.controller.handle(name, dir); };
   }(names[i]));
+  _.reflow = function() {
+    this.controller.handle('reflow');
+    this.controller.handle('edited');
+    this.controller.handle('edit');
+  };
 }

--- a/test/basic.html
+++ b/test/basic.html
@@ -36,7 +36,7 @@ var latex = $('#basic-latex').on('keydown keypress', function() {
 });
 var mq = MathQuill.MathField($('#basic')[0], {
   autoSubscriptNumerals: true,
-  handlers: { reflow: function(mq) {
+  handlers: { edit: function(mq) {
     if (!latex.is(':focus')) latex.val(mq.latex());
   } }
 });

--- a/test/visual.html
+++ b/test/visual.html
@@ -91,7 +91,7 @@ td {
   $(function() {
     var count = 0;
     MathQuill.MathField($('#reflowing-test')[0], {
-      handlers: { reflow: function() { count += 1; } }, // also test 'reflow' hook
+      handlers: { edit: function() { count += 1; } }, // also test 'edit' hook
     }).focus().moveToLeftEnd().keystroke('Right');
     var textarea = $('#reflowing-test textarea');
     var oldcount = count;


### PR DESCRIPTION
What is currently on the `dev` branch known as the `reflow` event was
called `edited` when it was introduced in #241. @alopatin then brought
up a serious issue (#317) with the `edited` event as it was then
implemented, which is that you could edit < into ≤ (etc) without
triggering the event.

Rather than fixing the problem, I obstinately renamed the event from
`edited` to `reflow` so that I could claim that the event not being
triggered when no sizes change was a feature, not a bug (#325).

@jwmerrill finally cut through my bullshit and got @alopatin's fix
from #317 merged into `dev` (tweaked as #425), which made edits like
< into ≤ call the `reflow` handler, so that there'd be at least some
handler that's reliably called when the contents of a field changes.

Because the `reflow` event was so broken for so long, people like
@alopatin have been using a fork of `dev` with a fixed `edited`.
To ease their migration to v0.10.0, and also because the name makes
more sense for its current role, I want to add back `edited` as an
alias for `reflow` (without removing `reflow`).

While we're talking about a name that makes sense, what name for this
event do we want to recommend going forward? How about we get rid of
the inexplicable past tense and just call the event `edit`. Make that
the recommended alias in the docs.