### PR TITLE
Prevent overwriting preInterVerMathQuill

### DIFF
--- a/src/outro.js
+++ b/src/outro.js
@@ -7,7 +7,7 @@ for (var key in MathQuill) (function(key, val) {
     };
     preInterVerMathQuill[key].prototype = val.prototype;
   }
-  else preInterVerMathQuill = val;
+  else preInterVerMathQuill[key] = val;
 }(key, MathQuill[key]));
 
 }());


### PR DESCRIPTION
When the loop tries to set the interface on the preInterVerMathQuill
object, fails to correctly assign the currently tested value in the
else clause to the key.  Instead the val is set as the
preInterVerMathQuill object itself.  Chrome balked at this because the
value was 1.  I had assumed that the 1 was coming from my call to
MathQuill.interfaceVersion(1), but it was actually coming from
MathQuill[R].  Anyway, the fix is very simple: ensure that key is used
to assign the value to in the else-clause.