### PR TITLE
Remove a redundant bug fix for webkit.

### DIFF
--- a/src/css/math.less
+++ b/src/css/math.less
@@ -6,11 +6,6 @@
   white-space: nowrap;
   overflow: hidden;
   vertical-align: middle;
-  // &:after is a fix for
-  // https://bugs.webkit.org/show_bug.cgi?id=35443#c1
-  &:after {
-    content: '';
-  }
 }
 .mq-math-mode {
   font-variant: normal;

--- a/test/unit/css.test.js
+++ b/test/unit/css.test.js
@@ -16,7 +16,7 @@ suite('CSS', function() {
     $(mock).css({
       fontSize: '',
       height: '',
-      widht: ''
+      width: ''
     });
   });
 });

--- a/test/unit/css.test.js
+++ b/test/unit/css.test.js
@@ -19,4 +19,26 @@ suite('CSS', function() {
       width: ''
     });
   });
+
+  test('empty root block does not collapse', function() {
+    var testEl = $('<span></span>').appendTo('#mock');
+    var mq = MathQuill.MathField(testEl[0]);
+    var rootEl = testEl.find('.mq-root-block');
+
+    assert.ok(rootEl.hasClass('mq-empty'), 'Empty root block should have the mq-empty class name.');
+    assert.ok(rootEl.height() > 0, 'Empty root block height should be above 0.');
+
+    testEl.remove();
+  });
+
+  test('empty block does not collapse', function() {
+    var testEl = $('<span>\\frac{}{}</span>').appendTo('#mock');
+    var mq = MathQuill.MathField(testEl[0]);
+    var numeratorEl = testEl.find('.mq-numerator');
+
+    assert.ok(numeratorEl.hasClass('mq-empty'), 'Empty numerator should have the mq-empty class name.');
+    assert.ok(numeratorEl.height() > 0, 'Empty numerator height should be above 0.');
+
+    testEl.remove();
+  });
 });


### PR DESCRIPTION
Since we're now using "white-space: nowrap" instead of "pre" the bug no longer occurs.

The fix caused a regression after commit ee4c0b3a742a15da270f6cf51a70aa701f774be9.

The regression was that empty MathField's would change their height when focused/blurred.

Closes #470