### PR TITLE
Reverted call to moveTowards and added test case

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -109,7 +109,7 @@ var MathCommand = P(MathElement, function(_, super_) {
   };
   _.deleteTowards = function(dir, cursor) {
     if (this.isEmpty()) cursor[dir] = this.remove()[dir];
-    else cursor.insAtDirEnd(-dir, this.ends[-dir]);
+    else this.moveTowards(dir, cursor, null);
   };
   _.selectTowards = function(dir, cursor) {
     cursor[-dir] = this;

--- a/test/unit/backspace.test.js
+++ b/test/unit/backspace.test.js
@@ -197,6 +197,16 @@ suite('backspace', function() {
     assert.equal(mq.latex(),'n=1');
   });
 
+  test('backspace inside text block', function() {
+    mq.latex('\\text{x}');
+
+    mq.keystroke('Backspace');
+
+    var textBlock = rootBlock.ends[R];
+    assert.equal(cursor.parent, textBlock, 'cursor is in text block');
+    assert.equal(cursor[R], 0, 'cursor is at the end of text block');
+  });
+
   suite('empties', function() {
     test('backspace empty exponent', function() {
       mq.latex('x^{}');


### PR DESCRIPTION
Fix for #469

The change made in 6648709 caused backspacing into text blocks to break. The change worked fine for MathCommand but TextBlock has another implementation of moveTowards (text.js:r.79).

Included test case for this scenario.