### PR TITLE
Enabled autoscroll for API-calls cmd and write

### DIFF
--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -121,6 +121,7 @@ var EditableField = MathQuill.EditableField = P(AbstractMathQuill, function(_) {
   _.blur = function() { this.__controller.textarea.blur(); return this; };
   _.write = function(latex) {
     this.__controller.writeLatex(latex);
+    this.__controller.scrollHoriz();
     if (this.__controller.blurred) this.__controller.cursor.hide().parent.blur();
     return this;
   };
@@ -133,6 +134,7 @@ var EditableField = MathQuill.EditableField = P(AbstractMathQuill, function(_) {
         cmd = klass(cmd);
         if (cursor.selection) cmd.replaces(cursor.replaceSelection());
         cmd.createLeftOf(cursor.show());
+        this.__controller.scrollHoriz();
       }
       else /* TODO: API needs better error reporting */;
     }

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -162,6 +162,34 @@ suite('latex', function() {
         assertParsesLatex('   {}{} {{{}}  }', '');
       });
 
+      test('overflow triggers automatic horizontal scroll', function(done) {
+        var mqEl = mq.el();
+        var rootEl = mq.__controller.root.jQ[0];
+        var cursor = mq.__controller.cursor;
+
+        $(mqEl).width(10);
+        var previousScrollLeft = rootEl.scrollLeft;
+
+        mq.write("abc");
+        setTimeout(afterScroll, 150);
+
+        function afterScroll() {
+          cursor.show();
+
+          try {
+            assert.ok(rootEl.scrollLeft > previousScrollLeft, "scrolls on write");
+            assert.ok(mqEl.getBoundingClientRect().right > cursor.jQ[0].getBoundingClientRect().right,
+              "cursor right end is inside the field");
+          }
+          catch(error) {
+            done(error);
+            return;
+          }
+
+          done();
+        }
+      });
+
       suite('\\sum', function() {
         test('basic', function() {
           mq.write('\\sum_{n=0}^5');

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -288,6 +288,34 @@ suite('Public API', function() {
       mq.typedText('49').select().cmd('\\asdf').cmd('\\sqrt');
       assert.equal(mq.latex(), '\\sqrt{49}');
     });
+
+    test('overflow triggers automatic horizontal scroll', function(done) {
+      var mqEl = mq.el();
+      var rootEl = mq.__controller.root.jQ[0];
+      var cursor = mq.__controller.cursor;
+
+      $(mqEl).width(10);
+      var previousScrollLeft = rootEl.scrollLeft;
+
+      mq.cmd("\\alpha");
+      setTimeout(afterScroll, 150);
+
+      function afterScroll() {
+        cursor.show();
+
+        try {
+          assert.ok(rootEl.scrollLeft > previousScrollLeft, "scrolls on cmd");
+          assert.ok(mqEl.getBoundingClientRect().right > cursor.jQ[0].getBoundingClientRect().right,
+            "cursor right end is inside the field");
+        }
+        catch(error) {
+          done(error);
+          return;
+        }
+
+        done();
+      }
+    });
   });
 
   suite('spaceBehavesLikeTab', function() {


### PR DESCRIPTION
When calling public API methods cmd and write the automatic horizontal scroll is not enabled, causing overflowing input to remain hidden for editors that have a defined max width.

Calling `controller.scrollHoriz()`after input has been added solves this.