### PR TITLE
Feature: MathQuill.getInterface()

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ for example:
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 <script src="/path/to/mathquill.js"></script>
 <script>
-  MathQuill.interfaceVersion(1);
+  MathQuill = MathQuill.getInterface(1);
   $(function() {
     MathQuill.StaticMath($('#problem')[0]);
     var answer = MathQuill.MathField($('#answer')[0], {
@@ -49,10 +49,10 @@ To load MathQuill,
 [Google CDN-hosted copy]: http://code.google.com/apis/libraries/devguide.html#jquery
 [the latest tarball]: http://mathquill.com/downloads.html
 
-To use the MathQuill API, first declare an interface version:
+To use the MathQuill API, first get the latest version of the interface:
 
 ```js
-MathQuill.interfaceVersion(1);
+MathQuill = MathQuill.getInterface(1);
 ```
 
 Now you can call `MathQuill.StaticMath()` or `MathQuill.MathField()`, which
@@ -141,10 +141,17 @@ that with `.noConflict()` (similar to [`jQuery.noConflict()`]
 <script src="/path/to/first-mathquill.js"></script>
 <script src="/path/to/second-mathquill.js"></script>
 <script>
-var secondMathQuill = MathQuill.interfaceVersion(1).noConflict();
-secondMathQuill.StaticMath(...);
+var secondMQ = MathQuill.noConflict().getInterface(1);
+secondMQ.MathField(...);
+
+var firstMQ = MathQuill.getInterface(1);
+firstMQ.MathField(...);
 </script>
 ```
+
+(Warning: This lets different copies of MathQuill each power their own
+ math fields, using different copies on the same DOM element won't work.
+ Anyway, the main point of .noConflict() is to help you reduce globals.)
 
 #### Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ MQ(mathFieldSpan).id === mathField.id // => true
 var setOfMathFields = {};
 setOfMathFields[mathField.id] = mathField;
 MQ(mathFieldSpan).id in setOfMathFields // => true
-staticMath.id in setOfMathFields // false
+staticMath.id in setOfMathFields // => false
 ```
 
 [`Map`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
@@ -103,7 +103,7 @@ Similarly, API objects for the same MathQuill instance share a `.data` object
 ```js
 MQ(mathFieldSpan).data === mathField.data // => true
 mathField.data.foo = 'bar';
-MQ(mathFieldSpan).data.foo // 'bar'
+MQ(mathFieldSpan).data.foo // => 'bar'
 ```
 
 [`WeakMap`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakMap

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ for example:
 <script src="/path/to/mathquill.js"></script>
 <script>
   $(function() {
-    var MQ = MathQuill.getInterface(1);
+    var MQ = MathQuill.getInterface(2);
     MQ.StaticMath($('#problem')[0]);
     var answer = MQ.MathField($('#answer')[0], {
       handlers: {
@@ -52,7 +52,7 @@ To load MathQuill,
 To use the MathQuill API, first get the latest version of the interface:
 
 ```js
-var MQ = MathQuill.getInterface(1);
+var MQ = MathQuill.getInterface(2);
 ```
 
 Now you can call `MQ.StaticMath()` or `MQ.MathField()`, which MathQuill-ify
@@ -167,10 +167,10 @@ that with `.noConflict()` (similar to [`jQuery.noConflict()`]
 <script src="/path/to/first-mathquill.js"></script>
 <script src="/path/to/second-mathquill.js"></script>
 <script>
-var secondMQ = MathQuill.noConflict().getInterface(1);
+var secondMQ = MathQuill.noConflict().getInterface(2);
 secondMQ.MathField(...);
 
-var firstMQ = MathQuill.getInterface(1);
+var firstMQ = MathQuill.getInterface(2);
 firstMQ.MathField(...);
 </script>
 ```

--- a/README.md
+++ b/README.md
@@ -65,11 +65,13 @@ either an instance of itself, or `null`.
 var staticMath = MQ.StaticMath(staticMathSpan);
 mathField instanceof MQ.StaticMath // => true
 mathField instanceof MQ // => true
+mathField instanceof MathQuill // => true
 
 var mathField = MQ.MathField(mathFieldSpan);
 mathField instanceof MQ.MathField // => true
 mathField instanceof MQ.EditableField // => true
 mathField instanceof MQ // => true
+mathField instanceof MathQuill // => true
 ```
 
 `MQ` itself is a function that takes an HTML element and, if it's the root

--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ firstMQ.MathField(...);
 ```
 
 (Warning: This lets different copies of MathQuill each power their own
- math fields, using different copies on the same DOM element won't work.
- Anyway, the main point of .noConflict() is to help you reduce globals.)
+ math fields, but using different copies on the same DOM element won't
+ work. Anyway, .noConflict() is primarily to help you reduce globals.)
 
 #### Configuration Options
 

--- a/README.md
+++ b/README.md
@@ -18,24 +18,23 @@ for example:
 <link rel="stylesheet" href="/path/to/mathquill.css"/>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 <script src="/path/to/mathquill.js"></script>
-<script>
-  $(function() {
-    var MQ = MathQuill.getInterface(2);
-    MQ.StaticMath($('#problem')[0]);
-    var answer = MQ.MathField($('#answer')[0], {
-      handlers: {
-        edit: function() {
-          checkAnswer(answer.latex());
-        }
-      }
-    });
-  });
-</script>
 
 <p>
   Solve <span id="problem">ax^2 + bx + c = 0</span>:
   <span id="answer">x=</span>
 </p>
+
+<script>
+  var MQ = MathQuill.getInterface(2);
+  MQ.StaticMath($('#problem')[0]);
+  var answer = MQ.MathField($('#answer')[0], {
+    handlers: {
+      edit: function() {
+        checkAnswer(answer.latex());
+      }
+    }
+  });
+</script>
 ```
 
 To load MathQuill,

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ for example:
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
 <script src="/path/to/mathquill.js"></script>
 <script>
-  MathQuill = MathQuill.getInterface(1);
   $(function() {
-    MathQuill.StaticMath($('#problem')[0]);
-    var answer = MathQuill.MathField($('#answer')[0], {
+    var MQ = MathQuill.getInterface(1);
+    MQ.StaticMath($('#problem')[0]);
+    var answer = MQ.MathField($('#answer')[0], {
       handlers: {
         edit: function() {
           checkAnswer(answer.latex());
@@ -52,34 +52,34 @@ To load MathQuill,
 To use the MathQuill API, first get the latest version of the interface:
 
 ```js
-MathQuill = MathQuill.getInterface(1);
+var MQ = MathQuill.getInterface(1);
 ```
 
-Now you can call `MathQuill.StaticMath()` or `MathQuill.MathField()`, which
-MathQuill-ify an HTML element and return an API object. If the element had
-already been MathQuill-ified into the same kind, return the original API object
-(if different kind or not an HTML element, `null`). Note that it always returns
+Now you can call `MQ.StaticMath()` or `MQ.MathField()`, which MathQuill-ify
+an HTML element and return an API object. If the element had already been
+MathQuill-ified into the same kind, return the original API object (if
+different kind or not an HTML element, `null`). Note that it always returns
 either an instance of itself, or `null`.
 
 ```js
-var staticMath = MathQuill.StaticMath(staticMathSpan);
-mathField instanceof MathQuill.StaticMath // => true
-mathField instanceof MathQuill // => true
+var staticMath = MQ.StaticMath(staticMathSpan);
+mathField instanceof MQ.StaticMath // => true
+mathField instanceof MQ // => true
 
-var mathField = MathQuill.MathField(mathFieldSpan);
-mathField instanceof MathQuill.MathField // => true
-mathField instanceof MathQuill.EditableField // => true
-mathField instanceof MathQuill // => true
+var mathField = MQ.MathField(mathFieldSpan);
+mathField instanceof MQ.MathField // => true
+mathField instanceof MQ.EditableField // => true
+mathField instanceof MQ // => true
 ```
 
-The global `MathQuill()` function takes an HTML element and, if it's the root
+`MQ` is also a function that takes an HTML element and, if it's the root
 HTML element of a static math or math field, returns its API object (if not,
 `null`). Identity of API object guaranteed if called multiple times, e.g.
 (continuing previous example):
 
 ```js
-MathQuill(mathFieldSpan) === mathField // => true
-MathQuill(mathFieldSpan) === MathQuill(mathFieldSpan) // => true
+MQ(mathFieldSpan) === mathField // => true
+MQ(mathFieldSpan) === MQ(mathFieldSpan) // => true
 ```
 
 Any element that has been MathQuill-ified can be reverted:
@@ -90,7 +90,7 @@ Any element that has been MathQuill-ified can be reverted:
 </span>
 ```
 ```js
-MathQuill($('#revert-me')[0]).revert().html(); // => 'some <code>HTML</code>'
+MQ($('#revert-me')[0]).revert().html(); // => 'some <code>HTML</code>'
 ```
 
 MathQuill uses computed dimensions, so if they change (because an element was
@@ -99,7 +99,7 @@ changed), then you'll need to tell MathQuill to recompute:
 
 ```js
 var mathFieldSpan = $('<span>\\sqrt{2}</span>');
-var mathField = MathQuill.MathField(mathFieldSpan[0]);
+var mathField = MQ.MathField(mathFieldSpan[0]);
 mathFieldSpan.appendTo(document.body);
 mathField.reflow();
 ```
@@ -111,8 +111,8 @@ MathQuill API objects further expose the following public methods:
 * `.latex()` returns the contents as LaTeX
 * `.latex('a_n x^n')` will render the argument as LaTeX
 
-Additionally, descendants of `MathQuill.EditableField` (currently only
-`MathQuill.MathField`) expose:
+Additionally, descendants of `MQ.EditableField` (currently only `MQ.MathField`)
+expose:
 
 * `.write(' - 1')` will write some LaTeX at the current cursor position
 * `.cmd('\\sqrt')` will enter a LaTeX command at the current cursor position or
@@ -122,9 +122,8 @@ Additionally, descendants of `MathQuill.EditableField` (currently only
 * `.clearSelection()` clears the current selection
 * `.moveTo{Left,Right,Dir}End()` move the cursor to the left/right end of the
   editable field, respectively. (The first two are implemented in terms of
-  `.moveToDirEnd(dir)` where `dir` is one of `MathQuill.L` or `MathQuill.R`,
-  constants obeying the contract that `MathQuill.L === -MathQuill.R` and vice
-  versa.)
+  `.moveToDirEnd(dir)` where `dir` is one of `MQ.L` or `MQ.R`, constants that
+  obey the contract that `MQ.L === -MQ.R` and vice versa.)
 * `.keystroke(keys)` simulates keystrokes given a string like `"Ctrl-Home Del"`,
   a whitespace-delimited list of [key values][] with optional prefixes
 * `.typedText(text)` simulates typing text, one character at a time
@@ -155,12 +154,11 @@ firstMQ.MathField(...);
 
 #### Configuration Options
 
-`MathQuill.MathField()` can also take an options object:
+`MQ.MathField()` can also take an options object:
 
 ```js
-var L = MathQuill.L, R = MathQuill.R;
 var el = $('<span>x^2</span>').appendTo('body');
-var mathField = MathQuill.MathField(el[0], {
+var mathField = MQ.MathField(el[0], {
   spaceBehavesLikeTab: true,
   leftRightIntoCmdGoes: 'up',
   restrictMismatchedBrackets: true,
@@ -176,7 +174,7 @@ var mathField = MathQuill.MathField(el[0], {
   handlers: {
     edit: function(mathField) { ... },
     upOutOf: function(mathField) { ... },
-    moveOutOf: function(dir, mathField) { if (dir === L) ... else ... }
+    moveOutOf: function(dir, mathField) { if (dir === MQ.L) ... else ... }
   }
 });
 ```
@@ -184,7 +182,7 @@ var mathField = MathQuill.MathField(el[0], {
 To change `mathField`'s options, the `.config({ ... })` method takes an options
 object in the same format.
 
-Global defaults for a page may be set with `MathQuill.config({ ... })`.
+Global defaults for a page may be set with `MQ.config({ ... })`.
 
 If `spaceBehavesLikeTab` is true the keystrokes {Shift-,}Spacebar will behave
 like {Shift-,}Tab escaping from the current block (as opposed to the default
@@ -271,9 +269,9 @@ The `*OutOf` handlers are called when Left/Right/Up/Down/Backspace/Del/
 Shift-Left/Shift-Right is pressed but the cursor is at the left/right/top/bottom
 edge and so nothing happens within the math field. For example, when the cursor
 is at the left edge, pressing the Left key causes the `moveOutOf` handler (if
-provided) to be called with `MathQuill.L` and the math field API object as
-arguments, and Backspace causes `deleteOutOf` (if provided) to be called with
-`MathQuill.L` and the API object as arguments, etc.
+provided) to be called with `MQ.L` and the math field API object as arguments,
+and Backspace causes `deleteOutOf` (if provided) to be called with `MQ.L` and
+the API object as arguments, etc.
 
 The `enter` handler is called whenever Enter is pressed.
 
@@ -290,13 +288,13 @@ var MathList = P(function(_) {
     this.el = ...
   };
   _.add = function() {
-    var math = MathQuill.MathField($('<span/>')[0], { handlers: this });
+    var math = MQ.MathField($('<span/>')[0], { handlers: this });
     $(math.el()).appendTo(this.el);
     math.i = this.maths.length;
     this.maths.push(math);
   };
   _.moveOutOf = function(dir, math) {
-    var adjacentI = (dir === MathQuill.L ? math.i - 1 : math.i + 1);
+    var adjacentI = (dir === MQ.L ? math.i - 1 : math.i + 1);
     var adjacentMath = this.maths[adjacentI];
     if (adjacentMath) adjacentMath.focus().moveToDirEnd(-dir);
   };
@@ -307,7 +305,7 @@ Of course you can always ignore the last argument, like when the handlers close
 over the math field:
 ```js
 var latex = '';
-var mathField = MathQuill.MathField($('#mathfield')[0], {
+var mathField = MQ.MathField($('#mathfield')[0], {
   handlers: {
     edit: function() { latex = mathField.latex(); },
     enter: function() { submitLatex(latex); }
@@ -428,8 +426,8 @@ More specifically:
     + `controller.js` defines the base class for the **controller**, which each
       math field or static math instance has one of, and to which each service
       adds methods.
-- `publicapi.js` defines the global `MathQuill` function, the
-  `MathQuill.MathField()` etc. constructors, and the API objects returned by
+- `publicapi.js` defines the global `MathQuill.getInterface()` function, the
+  `MQ.MathField()` etc. constructors, and the API objects returned by
   them. The constructors, and the API methods on the objects they return, call
   appropriate controller methods to initialize and manipulate math field and
   static math instances.

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -429,10 +429,12 @@ var MathBlock = P(MathElement, function(_, super_) {
 });
 
 MQ.StaticMath = APIFnFor(P(AbstractMathQuill, function(_, super_) {
-  _.init = function(el) {
-    this.initRoot(MathBlock(), el.addClass('mq-math-mode'));
+  this.RootBlock = MathBlock;
+  _.__mathquillify = function() {
+    super_.__mathquillify.call(this, 'mq-math-mode');
     this.__controller.delegateMouseEvents();
     this.__controller.staticMathTextareaEvents();
+    return this;
   };
   _.latex = function() {
     var returned = super_.latex.apply(this, arguments);
@@ -444,9 +446,11 @@ MQ.StaticMath = APIFnFor(P(AbstractMathQuill, function(_, super_) {
 }));
 
 var RootMathBlock = P(MathBlock, RootBlockMixin);
-MQ.MathField = APIFnFor(P(EditableField, function(_, super_) {
-  _.init = function(el, opts) {
-    el.addClass('mq-editable-field mq-math-mode');
-    this.initRootAndEvents(RootMathBlock(), el, opts);
+var MathField = P(EditableField, function(_, super_) {
+  this.RootBlock = RootMathBlock;
+  _.__mathquillify = function(opts) {
+    this.config(opts);
+    return super_.__mathquillify.call(this, 'mq-editable-field mq-math-mode');
   };
-}));
+});
+MQ.MathField = APIFnFor(MathField);

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -428,32 +428,38 @@ var MathBlock = P(MathElement, function(_, super_) {
   };
 });
 
-API.StaticMath = P(AbstractMathQuill, function(_, super_) {
-  this.RootBlock = MathBlock;
-  _.__mathquillify = function() {
-    super_.__mathquillify.call(this, 'mq-math-mode');
-    this.__controller.delegateMouseEvents();
-    this.__controller.staticMathTextareaEvents();
-    return this;
-  };
-  _.init = function() {
-    super_.init.apply(this, arguments);
-    this.__controller.root.postOrder('registerInnerField', this.innerFields = []);
-  };
-  _.latex = function() {
-    var returned = super_.latex.apply(this, arguments);
-    if (arguments.length > 0) {
-      this.__controller.root.postOrder('registerInnerField', this.innerFields = []);
-    }
-    return returned;
-  };
-});
+API.StaticMath = function(APIClasses) {
+  return P(APIClasses.AbstractMathQuill, function(_, super_) {
+    this.RootBlock = MathBlock;
+    _.__mathquillify = function() {
+      super_.__mathquillify.call(this, 'mq-math-mode');
+      this.__controller.delegateMouseEvents();
+      this.__controller.staticMathTextareaEvents();
+      return this;
+    };
+    _.init = function() {
+      super_.init.apply(this, arguments);
+      this.__controller.root.postOrder(
+        'registerInnerField', this.innerFields = [], APIClasses.MathField);
+    };
+    _.latex = function() {
+      var returned = super_.latex.apply(this, arguments);
+      if (arguments.length > 0) {
+        this.__controller.root.postOrder(
+          'registerInnerField', this.innerFields = [], APIClasses.MathField);
+      }
+      return returned;
+    };
+  });
+};
 
 var RootMathBlock = P(MathBlock, RootBlockMixin);
-API.MathField = P(EditableField, function(_, super_) {
-  this.RootBlock = RootMathBlock;
-  _.__mathquillify = function(opts) {
-    this.config(opts);
-    return super_.__mathquillify.call(this, 'mq-editable-field mq-math-mode');
-  };
-});
+API.MathField = function(APIClasses) {
+  return P(APIClasses.EditableField, function(_, super_) {
+    this.RootBlock = RootMathBlock;
+    _.__mathquillify = function(opts) {
+      this.config(opts);
+      return super_.__mathquillify.call(this, 'mq-editable-field mq-math-mode');
+    };
+  });
+};

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -457,9 +457,12 @@ var RootMathBlock = P(MathBlock, RootBlockMixin);
 API.MathField = function(APIClasses) {
   return P(APIClasses.EditableField, function(_, super_) {
     this.RootBlock = RootMathBlock;
-    _.__mathquillify = function(opts) {
+    _.__mathquillify = function(opts, interfaceVersion) {
       this.config(opts);
-      return super_.__mathquillify.call(this, 'mq-editable-field mq-math-mode');
+      if (interfaceVersion > 1) this.__controller.root.reflow = noop;
+      super_.__mathquillify.call(this, 'mq-editable-field mq-math-mode');
+      delete this.__controller.root.reflow;
+      return this;
     };
   });
 };

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -428,7 +428,7 @@ var MathBlock = P(MathElement, function(_, super_) {
   };
 });
 
-MQ.StaticMath = APIFnFor(P(AbstractMathQuill, function(_, super_) {
+API.StaticMath = P(AbstractMathQuill, function(_, super_) {
   this.RootBlock = MathBlock;
   _.__mathquillify = function() {
     super_.__mathquillify.call(this, 'mq-math-mode');
@@ -447,14 +447,13 @@ MQ.StaticMath = APIFnFor(P(AbstractMathQuill, function(_, super_) {
     }
     return returned;
   };
-}));
+});
 
 var RootMathBlock = P(MathBlock, RootBlockMixin);
-var MathField = P(EditableField, function(_, super_) {
+API.MathField = P(EditableField, function(_, super_) {
   this.RootBlock = RootMathBlock;
   _.__mathquillify = function(opts) {
     this.config(opts);
     return super_.__mathquillify.call(this, 'mq-editable-field mq-math-mode');
   };
 });
-MQ.MathField = APIFnFor(MathField);

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -363,7 +363,7 @@ var MathBlock = P(MathElement, function(_, super_) {
   };
 
   _.keystroke = function(key, e, ctrlr) {
-    if (ctrlr.API.__options.spaceBehavesLikeTab
+    if (ctrlr.options.spaceBehavesLikeTab
         && (key === 'Spacebar' || key === 'Shift-Spacebar')) {
       e.preventDefault();
       ctrlr.escapeDir(key === 'Shift-Spacebar' ? L : R, key, e);

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -429,7 +429,7 @@ var MathBlock = P(MathElement, function(_, super_) {
 });
 
 var RootMathBlock = P(MathBlock, RootBlockMixin);
-MathQuill.MathField = APIFnFor(P(EditableField, function(_, super_) {
+MQ.MathField = APIFnFor(P(EditableField, function(_, super_) {
   _.init = function(el, opts) {
     el.addClass('mq-editable-field mq-math-mode');
     this.initRootAndEvents(RootMathBlock(), el, opts);

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -428,6 +428,21 @@ var MathBlock = P(MathElement, function(_, super_) {
   };
 });
 
+MQ.StaticMath = APIFnFor(P(AbstractMathQuill, function(_, super_) {
+  _.init = function(el) {
+    this.initRoot(MathBlock(), el.addClass('mq-math-mode'));
+    this.__controller.delegateMouseEvents();
+    this.__controller.staticMathTextareaEvents();
+  };
+  _.latex = function() {
+    var returned = super_.latex.apply(this, arguments);
+    if (arguments.length > 0) {
+      this.__controller.root.postOrder('registerInnerField', this.innerFields = []);
+    }
+    return returned;
+  };
+}));
+
 var RootMathBlock = P(MathBlock, RootBlockMixin);
 MQ.MathField = APIFnFor(P(EditableField, function(_, super_) {
   _.init = function(el, opts) {

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -436,6 +436,10 @@ MQ.StaticMath = APIFnFor(P(AbstractMathQuill, function(_, super_) {
     this.__controller.staticMathTextareaEvents();
     return this;
   };
+  _.init = function() {
+    super_.init.apply(this, arguments);
+    this.__controller.root.postOrder('registerInnerField', this.innerFields = []);
+  };
   _.latex = function() {
     var returned = super_.latex.apply(this, arguments);
     if (arguments.length > 0) {

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -727,7 +727,7 @@ LatexCmds.choose = P(Binomial, function(_) {
   _.createLeftOf = LiveFraction.prototype.createLeftOf;
 });
 
-var InnerMathField = P(MathQuill.MathField, function(_) {
+var InnerMathField = P(MQ.MathField, function(_) {
   _.init = function(root, container) {
     RootBlockMixin(root);
     this.__options = Options();

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -743,7 +743,7 @@ LatexCmds.MathQuillMathField = P(MathCommand, function(_, super_) {
   };
   _.finalizeTree = function() {
     var ctrlr = Controller(this.ends[L], this.jQ, Options());
-    MathField(ctrlr);
+    ctrlr.APIClass = MathField;
     ctrlr.editable = true;
     ctrlr.createTextarea();
     ctrlr.editablesTextareaEvents();
@@ -751,7 +751,7 @@ LatexCmds.MathQuillMathField = P(MathCommand, function(_, super_) {
     RootBlockMixin(ctrlr.root);
   };
   _.registerInnerField = function(innerFields) {
-    innerFields.push(innerFields[this.name] = this.ends[L].controller.API);
+    innerFields.push(innerFields[this.name] = MathField(this.ends[L].controller));
   };
   _.latex = function(){ return this.ends[L].latex(); };
   _.text = function(){ return this.ends[L].text(); };

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -731,7 +731,8 @@ var InnerMathField = P(MQ.MathField, function(_) {
   _.init = function(root, container) {
     RootBlockMixin(root);
     this.__options = Options();
-    var ctrlr = Controller(this, root, container);
+    var ctrlr = this.__controller = Controller(root, container, this.__options);
+    ctrlr.API = this;
     ctrlr.editable = true;
     ctrlr.createTextarea();
     ctrlr.editablesTextareaEvents();

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -727,18 +727,6 @@ LatexCmds.choose = P(Binomial, function(_) {
   _.createLeftOf = LiveFraction.prototype.createLeftOf;
 });
 
-var InnerMathField = P(MQ.MathField, function(_) {
-  _.init = function(root, container) {
-    RootBlockMixin(root);
-    this.__options = Options();
-    var ctrlr = this.__controller = Controller(root, container, this.__options);
-    ctrlr.API = this;
-    ctrlr.editable = true;
-    ctrlr.createTextarea();
-    ctrlr.editablesTextareaEvents();
-    ctrlr.cursor.insAtRightEnd(root);
-  };
-});
 LatexCmds.MathQuillMathField = P(MathCommand, function(_, super_) {
   _.ctrlSeq = '\\MathQuillMathField';
   _.htmlTemplate =
@@ -753,7 +741,15 @@ LatexCmds.MathQuillMathField = P(MathCommand, function(_, super_) {
       .map(function(name) { self.name = name; }).or(succeed())
       .then(super_.parser.call(self));
   };
-  _.finalizeTree = function() { InnerMathField(this.ends[L], this.jQ); };
+  _.finalizeTree = function() {
+    var ctrlr = Controller(this.ends[L], this.jQ, Options());
+    MathField(ctrlr);
+    ctrlr.editable = true;
+    ctrlr.createTextarea();
+    ctrlr.editablesTextareaEvents();
+    ctrlr.cursor.insAtRightEnd(ctrlr.root);
+    RootBlockMixin(ctrlr.root);
+  };
   _.registerInnerField = function(innerFields) {
     innerFields.push(innerFields[this.name] = this.ends[L].controller.API);
   };

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -750,8 +750,8 @@ LatexCmds.MathQuillMathField = P(MathCommand, function(_, super_) {
     ctrlr.cursor.insAtRightEnd(ctrlr.root);
     RootBlockMixin(ctrlr.root);
   };
-  _.registerInnerField = function(innerFields) {
-    innerFields.push(innerFields[this.name] = API.MathField(this.ends[L].controller));
+  _.registerInnerField = function(innerFields, MathField) {
+    innerFields.push(innerFields[this.name] = MathField(this.ends[L].controller));
   };
   _.latex = function(){ return this.ends[L].latex(); };
   _.text = function(){ return this.ends[L].text(); };

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -743,7 +743,7 @@ LatexCmds.MathQuillMathField = P(MathCommand, function(_, super_) {
   };
   _.finalizeTree = function() {
     var ctrlr = Controller(this.ends[L], this.jQ, Options());
-    ctrlr.APIClass = MathField;
+    ctrlr.KIND_OF_MQ = 'MathField';
     ctrlr.editable = true;
     ctrlr.createTextarea();
     ctrlr.editablesTextareaEvents();
@@ -751,7 +751,7 @@ LatexCmds.MathQuillMathField = P(MathCommand, function(_, super_) {
     RootBlockMixin(ctrlr.root);
   };
   _.registerInnerField = function(innerFields) {
-    innerFields.push(innerFields[this.name] = MathField(this.ends[L].controller));
+    innerFields.push(innerFields[this.name] = API.MathField(this.ends[L].controller));
   };
   _.latex = function(){ return this.ends[L].latex(); };
   _.text = function(){ return this.ends[L].text(); };

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -362,7 +362,7 @@ var RootTextBlock = P(RootMathBlock, function(_, super_) {
     }
   };
 });
-MathQuill.TextField = APIFnFor(P(EditableField, function(_) {
+MQ.TextField = APIFnFor(P(EditableField, function(_) {
   _.init = function(el) {
     el.addClass('mq-editable-field mq-text-mode');
     this.initRootAndEvents(RootTextBlock(), el);

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -362,7 +362,7 @@ var RootTextBlock = P(RootMathBlock, function(_, super_) {
     }
   };
 });
-MQ.TextField = APIFnFor(P(EditableField, function(_, super_) {
+API.TextField = P(EditableField, function(_, super_) {
   this.RootBlock = RootTextBlock;
   _.__mathquillify = function() {
     return super_.__mathquillify.call(this, 'mq-editable-field mq-text-mode');
@@ -375,4 +375,4 @@ MQ.TextField = APIFnFor(P(EditableField, function(_, super_) {
     }
     return this.__controller.exportLatex();
   };
-}));
+});

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -362,10 +362,10 @@ var RootTextBlock = P(RootMathBlock, function(_, super_) {
     }
   };
 });
-MQ.TextField = APIFnFor(P(EditableField, function(_) {
-  _.init = function(el) {
-    el.addClass('mq-editable-field mq-text-mode');
-    this.initRootAndEvents(RootTextBlock(), el);
+MQ.TextField = APIFnFor(P(EditableField, function(_, super_) {
+  this.RootBlock = RootTextBlock;
+  _.__mathquillify = function() {
+    return super_.__mathquillify.call(this, 'mq-editable-field mq-text-mode');
   };
   _.latex = function(latex) {
     if (arguments.length > 0) {

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -362,17 +362,19 @@ var RootTextBlock = P(RootMathBlock, function(_, super_) {
     }
   };
 });
-API.TextField = P(EditableField, function(_, super_) {
-  this.RootBlock = RootTextBlock;
-  _.__mathquillify = function() {
-    return super_.__mathquillify.call(this, 'mq-editable-field mq-text-mode');
-  };
-  _.latex = function(latex) {
-    if (arguments.length > 0) {
-      this.__controller.renderLatexText(latex);
-      if (this.__controller.blurred) this.__controller.cursor.hide().parent.blur();
-      return this;
-    }
-    return this.__controller.exportLatex();
-  };
-});
+API.TextField = function(APIClasses) {
+  return P(APIClasses.EditableField, function(_, super_) {
+    this.RootBlock = RootTextBlock;
+    _.__mathquillify = function() {
+      return super_.__mathquillify.call(this, 'mq-editable-field mq-text-mode');
+    };
+    _.latex = function(latex) {
+      if (arguments.length > 0) {
+        this.__controller.renderLatexText(latex);
+        if (this.__controller.blurred) this.__controller.cursor.hide().parent.blur();
+        return this;
+      }
+      return this.__controller.exportLatex();
+    };
+  });
+};

--- a/src/controller.js
+++ b/src/controller.js
@@ -7,19 +7,19 @@
  ********************************************/
 
 var Controller = P(function(_) {
-  _.init = function(API, root, container) {
-    this.API = API;
+  _.init = function(root, container, options) {
     this.root = root;
     this.container = container;
+    this.options = options;
 
-    API.__controller = root.controller = this;
+    root.controller = this;
 
-    this.cursor = root.cursor = Cursor(root, API.__options);
+    this.cursor = root.cursor = Cursor(root, options);
     // TODO: stop depending on root.cursor, and rm it
   };
 
   _.handle = function(name, dir) {
-    var handlers = this.API.__options.handlers;
+    var handlers = this.options.handlers;
     if (handlers && handlers[name]) {
       if (dir === L || dir === R) handlers[name](dir, this.API);
       else handlers[name](this.API);

--- a/src/controller.js
+++ b/src/controller.js
@@ -24,8 +24,9 @@ var Controller = P(function(_) {
   _.handle = function(name, dir) {
     var handlers = this.options.handlers;
     if (handlers && handlers[name]) {
-      if (dir === L || dir === R) handlers[name](dir, this.APIClass(this));
-      else handlers[name](this.APIClass(this));
+      var mq = API[this.KIND_OF_MQ](this);
+      if (dir === L || dir === R) handlers[name](dir, mq);
+      else handlers[name](mq);
     }
   };
 

--- a/src/controller.js
+++ b/src/controller.js
@@ -23,10 +23,10 @@ var Controller = P(function(_) {
 
   _.handle = function(name, dir) {
     var handlers = this.options.handlers;
-    if (handlers && handlers[name]) {
-      var mq = API[this.KIND_OF_MQ](this);
-      if (dir === L || dir === R) handlers[name](dir, mq);
-      else handlers[name](mq);
+    if (handlers && handlers.fns[name]) {
+      var mq = handlers.APIClasses[this.KIND_OF_MQ](this);
+      if (dir === L || dir === R) handlers.fns[name](dir, mq);
+      else handlers.fns[name](mq);
     }
   };
 

--- a/src/controller.js
+++ b/src/controller.js
@@ -8,6 +8,9 @@
 
 var Controller = P(function(_) {
   _.init = function(root, container, options) {
+    this.id = root.id;
+    this.data = {};
+
     this.root = root;
     this.container = container;
     this.options = options;
@@ -21,8 +24,8 @@ var Controller = P(function(_) {
   _.handle = function(name, dir) {
     var handlers = this.options.handlers;
     if (handlers && handlers[name]) {
-      if (dir === L || dir === R) handlers[name](dir, this.API);
-      else handlers[name](this.API);
+      if (dir === L || dir === R) handlers[name](dir, this.APIClass(this));
+      else handlers[name](this.APIClass(this));
     }
   };
 

--- a/src/outro.js
+++ b/src/outro.js
@@ -1,4 +1,4 @@
-for (var key in MQ) (function(key, val) {
+for (var key in MQ1) (function(key, val) {
   if (typeof val === 'function') {
     MathQuill[key] = function() {
       insistOnInterVer();
@@ -7,6 +7,6 @@ for (var key in MQ) (function(key, val) {
     MathQuill[key].prototype = val.prototype;
   }
   else MathQuill[key] = val;
-}(key, MQ[key]));
+}(key, MQ1[key]));
 
 }());

--- a/src/outro.js
+++ b/src/outro.js
@@ -1,4 +1,4 @@
-for (var key in MathQuill) (function(key, val) {
+for (var key in MQ) (function(key, val) {
   if (typeof val === 'function') {
     preInterVerMathQuill[key] = function() {
       insistOnInterVer();
@@ -7,6 +7,6 @@ for (var key in MathQuill) (function(key, val) {
     preInterVerMathQuill[key].prototype = val.prototype;
   }
   else preInterVerMathQuill[key] = val;
-}(key, MathQuill[key]));
+}(key, MQ[key]));
 
 }());

--- a/src/outro.js
+++ b/src/outro.js
@@ -1,12 +1,12 @@
 for (var key in MQ) (function(key, val) {
   if (typeof val === 'function') {
-    preInterVerMathQuill[key] = function() {
+    MathQuill[key] = function() {
       insistOnInterVer();
       return val.apply(this, arguments);
     };
-    preInterVerMathQuill[key].prototype = val.prototype;
+    MathQuill[key].prototype = val.prototype;
   }
-  else preInterVerMathQuill[key] = val;
+  else MathQuill[key] = val;
 }(key, MQ[key]));
 
 }());

--- a/src/outro.js
+++ b/src/outro.js
@@ -1,5 +1,4 @@
 for (var key in MathQuill) (function(key, val) {
-  if (preInterVerMathQuill[key]) return; // already set .noConflict
   if (typeof val === 'function') {
     preInterVerMathQuill[key] = function() {
       insistOnInterVer();

--- a/src/outro.js
+++ b/src/outro.js
@@ -1,3 +1,4 @@
+var MQ1 = getInterface(1);
 for (var key in MQ1) (function(key, val) {
   if (typeof val === 'function') {
     MathQuill[key] = function() {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -34,12 +34,11 @@ MathQuill.getInterface = function(v) {
 
   /**
    * Function that takes an HTML element and, if it's the root HTML element of a
-   * static math or math or text field, returns its API object (if not, null).
-   * Identity of API object guaranteed if called multiple times, i.e.:
+   * static math or math or text field, returns an API object for it (else, null).
    *
    *   var mathfield = MQ.MathField(mathFieldSpan);
-   *   assert(MQ(mathFieldSpan) === mathfield);
-   *   assert(MQ(mathFieldSpan) === MQ(mathFieldSpan));
+   *   assert(MQ(mathFieldSpan).id === mathfield.id);
+   *   assert(MQ(mathFieldSpan).id === MQ(mathFieldSpan).id);
    *
    */
   function MQ(el) {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -14,13 +14,15 @@ var API = {}, Options = P(), optionProcessors = {}, Progenote = P();
  */
 function insistOnInterVer() {
   if (window.console) console.warn(
-    'This usage of the MathQuill API will fail in v1.0.0. The easiest fix is ' +
-    'to get interface version 1 before doing anything else:\n' +
+    'You are using the MathQuill API without specifying an interface version, ' +
+    'which will fail in v1.0.0. You can fix this easily by doing this before ' +
+    'doing anything else:\n' +
     '\n' +
     '    MathQuill = MathQuill.getInterface(1);\n' +
     '    // now MathQuill.MathField() works like it used to\n' +
-    ' '
-//   ^ apparently necessary to show the empty line in Blink/WebKit
+    '\n' +
+    'See also the "`dev` branch (2014–2015) → v0.10.0 Migration Guide" at\n' +
+    '  https://github.com/mathquill/mathquill/wiki/%60dev%60-branch-(2014%E2%80%932015)-%E2%86%92-v0.10.0-Migration-Guide'
   );
 }
 // globally exported API object
@@ -32,7 +34,21 @@ MathQuill.prototype = Progenote.p;
 MathQuill.interfaceVersion = function(v) {
   // shim for #459-era interface versioning (ended with #495)
   if (v !== 1) throw 'Only interface version 1 supported. You specified: ' + v;
-  return window.MathQuill = MQ1;
+  insistOnInterVer = function() {
+    if (window.console) console.warn(
+      'You called MathQuill.interfaceVersion(1); to specify the interface ' +
+      'version, which will fail in v1.0.0. You can fix this easily by doing ' +
+      'this before doing anything else:\n' +
+      '\n' +
+      '    MathQuill = MathQuill.getInterface(1);\n' +
+      '    // now MathQuill.MathField() works like it used to\n' +
+      '\n' +
+      'See also the "`dev` branch (2014–2015) → v0.10.0 Migration Guide" at\n' +
+      '  https://github.com/mathquill/mathquill/wiki/%60dev%60-branch-(2014%E2%80%932015)-%E2%86%92-v0.10.0-Migration-Guide'
+    );
+  };
+  insistOnInterVer();
+  return MathQuill;
 };
 MathQuill.getInterface = getInterface;
 
@@ -203,7 +219,6 @@ function getInterface(v) {
 
   return MQ;
 }
-var MQ1 = getInterface(1);
 
 MathQuill.noConflict = function() {
   window.MathQuill = origMathQuill;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -91,20 +91,6 @@ var AbstractMathQuill = P(function(_) {
 });
 MQ.prototype = AbstractMathQuill.prototype;
 
-MQ.StaticMath = APIFnFor(P(AbstractMathQuill, function(_, super_) {
-  _.init = function(el) {
-    this.initRoot(MathBlock(), el.addClass('mq-math-mode'));
-    this.__controller.delegateMouseEvents();
-    this.__controller.staticMathTextareaEvents();
-  };
-  _.latex = function() {
-    var returned = super_.latex.apply(this, arguments);
-    if (arguments.length > 0) {
-      this.__controller.root.postOrder('registerInnerField', this.innerFields = []);
-    }
-    return returned;
-  };
-}));
 
 var EditableField = MQ.EditableField = P(AbstractMathQuill, function(_) {
   _.initRootAndEvents = function(root, el, opts) {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -5,9 +5,9 @@
 var API = {}, Options = P(), optionProcessors = {}, Progenote = P();
 
 /**
- * Interface Versioning (#459) to allow us to virtually guarantee backcompat.
- * v0.10.x introduces it, so for now, don't completely break the API for
- * people who don't know about it, just complain with console.warn().
+ * Interface Versioning (#459, #495) to allow us to virtually guarantee
+ * backcompat. v0.10.x introduces it, so for now, don't completely break the
+ * API for people who don't know about it, just complain with console.warn().
  *
  * The methods are shimmed in outro.js so that MQ.MathField.prototype etc can
  * be accessed.
@@ -29,6 +29,11 @@ function MathQuill(el) {
   return MQ1(el);
 };
 MathQuill.prototype = Progenote.p;
+MathQuill.interfaceVersion = function(v) {
+  // shim for #459-era interface versioning (ended with #495)
+  if (v !== 1) throw 'Only interface version 1 supported. You specified: ' + v;
+  return window.MathQuill = MQ1;
+};
 MathQuill.getInterface = getInterface;
 
 var MIN = getInterface.MIN = 1;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -2,6 +2,8 @@
  * The publicly exposed MathQuill API.
  ********************************************************/
 
+var API = {}, Options = P(), optionProcessors = {};
+
 /**
  * Interface Versioning (#459) to allow us to virtually guarantee backcompat.
  * v0.10.x introduces it, so for now, don't completely break the API for
@@ -27,164 +29,173 @@ function MathQuill(el) {
   return MQ1(el);
 };
 
-/**
- * Function that takes an HTML element and, if it's the root HTML element of a
- * static math or math or text field, returns its API object (if not, null).
- * Identity of API object guaranteed if called multiple times, i.e.:
- *
- *   var mathfield = MQ.MathField(mathFieldSpan);
- *   assert(MQ(mathFieldSpan) === mathfield);
- *   assert(MQ(mathFieldSpan) === MQ(mathFieldSpan));
- *
- */
-function MQ(el) {
-  if (!el || !el.nodeType) return null; // check that `el` is a HTML element, using the
-    // same technique as jQuery: https://github.com/jquery/jquery/blob/679536ee4b7a92ae64a5f58d90e9cc38c001e807/src/core/init.js#L92
-  var blockId = $(el).children('.mq-root-block').attr(mqBlockId);
-  var ctrlr = blockId && Node.byId[blockId].controller;
-  return ctrlr ? API[ctrlr.KIND_OF_MQ](ctrlr) : null;
-};
-
-var API = {}, Options = P(), optionProcessors = {};
-function config(currentOptions, newOptions) {
-  for (var name in newOptions) if (newOptions.hasOwnProperty(name)) {
-    var value = newOptions[name], processor = optionProcessors[name];
-    currentOptions[name] = (processor ? processor(value) : value);
-  }
-}
-MQ.config = function(opts) { config(Options.p, opts); return this; };
-
-var AbstractMathQuill = P(function(_) {
-  _.init = function(ctrlr) {
-    this.__controller = ctrlr;
-    this.__options = ctrlr.options;
-    this.id = ctrlr.id;
-    this.data = ctrlr.data;
-  };
-  _.__mathquillify = function(classNames) {
-    var ctrlr = this.__controller, root = ctrlr.root, el = ctrlr.container;
-    ctrlr.createTextarea();
-
-    var contents = el.addClass(classNames).contents().detach();
-    root.jQ =
-      $('<span class="mq-root-block"/>').attr(mqBlockId, root.id).appendTo(el);
-    this.latex(contents.text());
-
-    this.revert = function() {
-      return el.empty().unbind('.mathquill')
-      .removeClass('mq-editable-field mq-math-mode mq-text-mode')
-      .append(contents);
-    };
-  };
-  _.config = function(opts) { config(this.__options, opts); return this; };
-  _.el = function() { return this.__controller.container[0]; };
-  _.text = function() { return this.__controller.exportText(); };
-  _.latex = function(latex) {
-    if (arguments.length > 0) {
-      this.__controller.renderLatexMath(latex);
-      if (this.__controller.blurred) this.__controller.cursor.hide().parent.blur();
-      return this;
-    }
-    return this.__controller.exportLatex();
-  };
-  _.html = function() {
-    return this.__controller.root.jQ.html()
-      .replace(/ mathquill-(?:command|block)-id="?\d+"?/g, '')
-      .replace(/<span class="?mq-cursor( mq-blink)?"?>.?<\/span>/i, '')
-      .replace(/ mq-hasCursor|mq-hasCursor ?/, '')
-      .replace(/ class=(""|(?= |>))/g, '');
-  };
-  _.reflow = function() {
-    this.__controller.root.postOrder('reflow');
-    return this;
-  };
-});
-MQ.prototype = AbstractMathQuill.prototype;
-
-var EditableField = P(AbstractMathQuill, function(_, super_) {
-  _.__mathquillify = function() {
-    super_.__mathquillify.apply(this, arguments);
-    this.__controller.editable = true;
-    this.__controller.delegateMouseEvents();
-    this.__controller.editablesTextareaEvents();
-    return this;
-  };
-  _.focus = function() { this.__controller.textarea.focus(); return this; };
-  _.blur = function() { this.__controller.textarea.blur(); return this; };
-  _.write = function(latex) {
-    this.__controller.writeLatex(latex);
-    if (this.__controller.blurred) this.__controller.cursor.hide().parent.blur();
-    return this;
-  };
-  _.cmd = function(cmd) {
-    var ctrlr = this.__controller.notify(), cursor = ctrlr.cursor;
-    if (/^\\[a-z]+$/i.test(cmd)) {
-      cmd = cmd.slice(1);
-      var klass = LatexCmds[cmd];
-      if (klass) {
-        cmd = klass(cmd);
-        if (cursor.selection) cmd.replaces(cursor.replaceSelection());
-        cmd.createLeftOf(cursor.show());
-      }
-      else /* TODO: API needs better error reporting */;
-    }
-    else cursor.parent.write(cursor, cmd);
-    if (ctrlr.blurred) cursor.hide().parent.blur();
-    return this;
-  };
-  _.select = function() {
-    var ctrlr = this.__controller;
-    ctrlr.notify('move').cursor.insAtRightEnd(ctrlr.root);
-    while (ctrlr.cursor[L]) ctrlr.selectLeft();
-    return this;
-  };
-  _.clearSelection = function() {
-    this.__controller.cursor.clearSelection();
-    return this;
-  };
-
-  _.moveToDirEnd = function(dir) {
-    this.__controller.notify('move').cursor.insAtDirEnd(dir, this.__controller.root);
-    return this;
-  };
-  _.moveToLeftEnd = function() { return this.moveToDirEnd(L); };
-  _.moveToRightEnd = function() { return this.moveToDirEnd(R); };
-
-  _.keystroke = function(keys) {
-    var keys = keys.replace(/^\s+|\s+$/g, '').split(/\s+/);
-    for (var i = 0; i < keys.length; i += 1) {
-      this.__controller.keystroke(keys[i], { preventDefault: noop });
-    }
-    return this;
-  };
-  _.typedText = function(text) {
-    for (var i = 0; i < text.length; i += 1) this.__controller.typedText(text.charAt(i));
-    return this;
-  };
-});
-MQ.EditableField = function() { throw "wtf don't call me, I'm 'abstract'"; };
-MQ.EditableField.prototype = EditableField.prototype;
-
-/**
- * Export the API functions that MathQuill-ify an HTML element into API objects
- * of each class. If the element had already been MathQuill-ified but into a
- * different kind (or it's not an HTML element), return null.
- */
-for (var kind in API) (function(kind, APIClass) {
-  MQ[kind] = function(el, opts) {
-    var mq = MQ(el);
-    if (mq instanceof APIClass || !el || !el.nodeType) return mq;
-    var ctrlr = Controller(APIClass.RootBlock(), $(el), Options());
-    ctrlr.KIND_OF_MQ = kind;
-    return APIClass(ctrlr).__mathquillify(opts);
-  };
-  MQ[kind].prototype = APIClass.prototype;
-}(kind, API[kind]));
-
 MathQuill.getInterface = function(v) {
   if (v !== 1) throw 'Only interface version 1 supported. You specified: ' + v;
+
+  /**
+   * Function that takes an HTML element and, if it's the root HTML element of a
+   * static math or math or text field, returns its API object (if not, null).
+   * Identity of API object guaranteed if called multiple times, i.e.:
+   *
+   *   var mathfield = MQ.MathField(mathFieldSpan);
+   *   assert(MQ(mathFieldSpan) === mathfield);
+   *   assert(MQ(mathFieldSpan) === MQ(mathFieldSpan));
+   *
+   */
+  function MQ(el) {
+    if (!el || !el.nodeType) return null; // check that `el` is a HTML element, using the
+      // same technique as jQuery: https://github.com/jquery/jquery/blob/679536ee4b7a92ae64a5f58d90e9cc38c001e807/src/core/init.js#L92
+    var blockId = $(el).children('.mq-root-block').attr(mqBlockId);
+    var ctrlr = blockId && Node.byId[blockId].controller;
+    return ctrlr ? APIClasses[ctrlr.KIND_OF_MQ](ctrlr) : null;
+  };
+  var APIClasses = {};
+
+  MQ.L = L;
+  MQ.R = R;
+
+  function config(currentOptions, newOptions) {
+    if (newOptions && newOptions.handlers) {
+      newOptions.handlers = { fns: newOptions.handlers, APIClasses: APIClasses };
+    }
+    for (var name in newOptions) if (newOptions.hasOwnProperty(name)) {
+      var value = newOptions[name], processor = optionProcessors[name];
+      currentOptions[name] = (processor ? processor(value) : value);
+    }
+  }
+  MQ.config = function(opts) { config(Options.p, opts); return this; };
+
+  var AbstractMathQuill = APIClasses.AbstractMathQuill = P(function(_) {
+    _.init = function(ctrlr) {
+      this.__controller = ctrlr;
+      this.__options = ctrlr.options;
+      this.id = ctrlr.id;
+      this.data = ctrlr.data;
+    };
+    _.__mathquillify = function(classNames) {
+      var ctrlr = this.__controller, root = ctrlr.root, el = ctrlr.container;
+      ctrlr.createTextarea();
+
+      var contents = el.addClass(classNames).contents().detach();
+      root.jQ =
+        $('<span class="mq-root-block"/>').attr(mqBlockId, root.id).appendTo(el);
+      this.latex(contents.text());
+
+      this.revert = function() {
+        return el.empty().unbind('.mathquill')
+        .removeClass('mq-editable-field mq-math-mode mq-text-mode')
+        .append(contents);
+      };
+    };
+    _.config = function(opts) { config(this.__options, opts); return this; };
+    _.el = function() { return this.__controller.container[0]; };
+    _.text = function() { return this.__controller.exportText(); };
+    _.latex = function(latex) {
+      if (arguments.length > 0) {
+        this.__controller.renderLatexMath(latex);
+        if (this.__controller.blurred) this.__controller.cursor.hide().parent.blur();
+        return this;
+      }
+      return this.__controller.exportLatex();
+    };
+    _.html = function() {
+      return this.__controller.root.jQ.html()
+        .replace(/ mathquill-(?:command|block)-id="?\d+"?/g, '')
+        .replace(/<span class="?mq-cursor( mq-blink)?"?>.?<\/span>/i, '')
+        .replace(/ mq-hasCursor|mq-hasCursor ?/, '')
+        .replace(/ class=(""|(?= |>))/g, '');
+    };
+    _.reflow = function() {
+      this.__controller.root.postOrder('reflow');
+      return this;
+    };
+  });
+  MQ.prototype = AbstractMathQuill.prototype;
+
+  APIClasses.EditableField = P(AbstractMathQuill, function(_, super_) {
+    _.__mathquillify = function() {
+      super_.__mathquillify.apply(this, arguments);
+      this.__controller.editable = true;
+      this.__controller.delegateMouseEvents();
+      this.__controller.editablesTextareaEvents();
+      return this;
+    };
+    _.focus = function() { this.__controller.textarea.focus(); return this; };
+    _.blur = function() { this.__controller.textarea.blur(); return this; };
+    _.write = function(latex) {
+      this.__controller.writeLatex(latex);
+      if (this.__controller.blurred) this.__controller.cursor.hide().parent.blur();
+      return this;
+    };
+    _.cmd = function(cmd) {
+      var ctrlr = this.__controller.notify(), cursor = ctrlr.cursor;
+      if (/^\\[a-z]+$/i.test(cmd)) {
+        cmd = cmd.slice(1);
+        var klass = LatexCmds[cmd];
+        if (klass) {
+          cmd = klass(cmd);
+          if (cursor.selection) cmd.replaces(cursor.replaceSelection());
+          cmd.createLeftOf(cursor.show());
+        }
+        else /* TODO: API needs better error reporting */;
+      }
+      else cursor.parent.write(cursor, cmd);
+      if (ctrlr.blurred) cursor.hide().parent.blur();
+      return this;
+    };
+    _.select = function() {
+      var ctrlr = this.__controller;
+      ctrlr.notify('move').cursor.insAtRightEnd(ctrlr.root);
+      while (ctrlr.cursor[L]) ctrlr.selectLeft();
+      return this;
+    };
+    _.clearSelection = function() {
+      this.__controller.cursor.clearSelection();
+      return this;
+    };
+
+    _.moveToDirEnd = function(dir) {
+      this.__controller.notify('move').cursor.insAtDirEnd(dir, this.__controller.root);
+      return this;
+    };
+    _.moveToLeftEnd = function() { return this.moveToDirEnd(L); };
+    _.moveToRightEnd = function() { return this.moveToDirEnd(R); };
+
+    _.keystroke = function(keys) {
+      var keys = keys.replace(/^\s+|\s+$/g, '').split(/\s+/);
+      for (var i = 0; i < keys.length; i += 1) {
+        this.__controller.keystroke(keys[i], { preventDefault: noop });
+      }
+      return this;
+    };
+    _.typedText = function(text) {
+      for (var i = 0; i < text.length; i += 1) this.__controller.typedText(text.charAt(i));
+      return this;
+    };
+  });
+  MQ.EditableField = function() { throw "wtf don't call me, I'm 'abstract'"; };
+  MQ.EditableField.prototype = APIClasses.EditableField.prototype;
+
+  /**
+   * Export the API functions that MathQuill-ify an HTML element into API objects
+   * of each class. If the element had already been MathQuill-ified but into a
+   * different kind (or it's not an HTML element), return null.
+   */
+  for (var kind in API) (function(kind, defAPIClass) {
+    var APIClass = APIClasses[kind] = defAPIClass(APIClasses);
+    MQ[kind] = function(el, opts) {
+      var mq = MQ(el);
+      if (mq instanceof APIClass || !el || !el.nodeType) return mq;
+      var ctrlr = Controller(APIClass.RootBlock(), $(el), Options());
+      ctrlr.KIND_OF_MQ = kind;
+      return APIClass(ctrlr).__mathquillify(opts);
+    };
+    MQ[kind].prototype = APIClass.prototype;
+  }(kind, API[kind]));
+
   return MQ;
 };
+var MQ1 = MathQuill.getInterface(1);
 
 MathQuill.noConflict = function() {
   window.MathQuill = origMathQuill;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -37,7 +37,13 @@ function APIFnFor(APIClass) {
 }
 
 var Options = P(), optionProcessors = {};
-MQ.__options = Options.p;
+function config(currentOptions, newOptions) {
+  for (var name in newOptions) if (newOptions.hasOwnProperty(name)) {
+    var value = newOptions[name], processor = optionProcessors[name];
+    currentOptions[name] = (processor ? processor(value) : value);
+  }
+}
+MQ.config = function(opts) { config(Options.p, opts); return this; };
 
 var AbstractMathQuill = P(function(_) {
   _.init = function(ctrlr) {
@@ -60,14 +66,7 @@ var AbstractMathQuill = P(function(_) {
       .append(contents);
     };
   };
-  _.config =
-  MQ.config = function(opts) {
-    for (var opt in opts) if (opts.hasOwnProperty(opt)) {
-      var optVal = opts[opt], processor = optionProcessors[opt];
-      this.__options[opt] = (processor ? processor(optVal) : optVal);
-    }
-    return this;
-  };
+  _.config = function(opts) { config(this.__options, opts); return this; };
   _.el = function() { return this.__controller.container[0]; };
   _.text = function() { return this.__controller.exportText(); };
   _.latex = function(latex) {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -36,9 +36,7 @@ MathQuill.interfaceVersion = function(v) {
 };
 MathQuill.getInterface = getInterface;
 
-var MIN = getInterface.MIN = 1;
-var MAX = getInterface.MAX = 2;
-
+var MIN = getInterface.MIN = 1, MAX = getInterface.MAX = 2;
 function getInterface(v) {
   if (!(MIN <= v && v <= MAX)) throw 'Only interface versions between ' +
     MIN + ' and ' + MAX + ' supported. You specified: ' + v;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -44,7 +44,8 @@ var AbstractMathQuill = P(function(_) {
     this.__options = Options();
     this.config(opts);
 
-    var ctrlr = Controller(this, root, el);
+    var ctrlr = this.__controller = Controller(root, el, this.__options);
+    ctrlr.API = this;
     ctrlr.createTextarea();
 
     var contents = el.contents().detach();

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -16,7 +16,8 @@ function MQ(el) {
   if (!el || !el.nodeType) return null; // check that `el` is a HTML element, using the
     // same technique as jQuery: https://github.com/jquery/jquery/blob/679536ee4b7a92ae64a5f58d90e9cc38c001e807/src/core/init.js#L92
   var blockId = $(el).children('.mq-root-block').attr(mqBlockId);
-  return blockId ? Node.byId[blockId].controller.API : null;
+  var ctrlr = blockId && Node.byId[blockId].controller;
+  return ctrlr ? ctrlr.APIClass(ctrlr) : null;
 };
 
 /**
@@ -30,6 +31,7 @@ function APIFnFor(APIClass) {
     var mq = MQ(el);
     if (mq instanceof APIClass || !el || !el.nodeType) return mq;
     var ctrlr = Controller(APIClass.RootBlock(), $(el), Options());
+    ctrlr.APIClass = APIClass;
     return APIClass(ctrlr).__mathquillify(opts);
   }
   APIFn.prototype = APIClass.prototype;
@@ -49,7 +51,8 @@ var AbstractMathQuill = P(function(_) {
   _.init = function(ctrlr) {
     this.__controller = ctrlr;
     this.__options = ctrlr.options;
-    ctrlr.API = this;
+    this.id = ctrlr.id;
+    this.data = ctrlr.data;
   };
   _.__mathquillify = function(classNames) {
     var ctrlr = this.__controller, root = ctrlr.root, el = ctrlr.container;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -197,19 +197,20 @@ function insistOnInterVer() {
 //   ^ apparently necessary to show the empty line in Blink/WebKit
   );
 }
-function preInterVerMathQuill(el) {
+// globally exported API object
+function MathQuill(el) {
   insistOnInterVer();
   return MQ(el);
 };
 
-preInterVerMathQuill.getInterface = function(v) {
+MathQuill.getInterface = function(v) {
   if (v !== 1) throw 'Only interface version 1 supported. You specified: ' + v;
   return MQ;
 };
 
-preInterVerMathQuill.noConflict = function() {
+MathQuill.noConflict = function() {
   window.MathQuill = origMathQuill;
-  return preInterVerMathQuill;
+  return MathQuill;
 };
 var origMathQuill = window.MathQuill;
-window.MathQuill = preInterVerMathQuill;
+window.MathQuill = MathQuill;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -192,7 +192,7 @@ function getInterface(v) {
       if (mq instanceof APIClass || !el || !el.nodeType) return mq;
       var ctrlr = Controller(APIClass.RootBlock(), $(el), Options());
       ctrlr.KIND_OF_MQ = kind;
-      return APIClass(ctrlr).__mathquillify(opts);
+      return APIClass(ctrlr).__mathquillify(opts, v);
     };
     MQ[kind].prototype = APIClass.prototype;
   }(kind, API[kind]));

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -202,7 +202,6 @@ function preInterVerMathQuill(el) {
   insistOnInterVer();
   return MathQuill(el);
 };
-preInterVerMathQuill.prototype = MathQuill.prototype;
 
 preInterVerMathQuill.getInterface = function(v) {
   if (v !== 1) throw 'Only interface version 1 supported. You specified: ' + v;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -3,8 +3,8 @@
  ********************************************************/
 
 /**
- * Global function that takes an HTML element and, if it's the root HTML element
- * of a static math or math or text field, returns its API object (if not, null).
+ * Function that takes an HTML element and, if it's the root HTML element of a
+ * static math or math or text field, returns its API object (if not, null).
  * Identity of API object guaranteed if called multiple times, i.e.:
  *
  *   var mathfield = MathQuill.MathField(mathFieldSpan);
@@ -17,11 +17,6 @@ function MathQuill(el) {
     // same technique as jQuery: https://github.com/jquery/jquery/blob/679536ee4b7a92ae64a5f58d90e9cc38c001e807/src/core/init.js#L92
   var blockId = $(el).children('.mq-root-block').attr(mqBlockId);
   return blockId ? Node.byId[blockId].controller.API : null;
-};
-
-MathQuill.noConflict = function() {
-  window.MathQuill = origMathQuill;
-  return MathQuill;
 };
 
 /**
@@ -185,18 +180,22 @@ function RootBlockMixin(_) {
 
 /**
  * Interface Versioning (#459) to allow us to virtually guarantee backcompat.
- * v0.10.x introduces it, so for now, don't completely break the API before
- * MathQuill.interfaceVersion(1) is called, just complain with console.warn().
+ * v0.10.x introduces it, so for now, don't completely break the API for
+ * people who don't know about it, just complain with console.warn().
  *
- * .noConflict() is shimmed here directly because it needs to be modified,
- * the rest are shimmed in outro.js so that MathQuill.MathField.prototype etc
+ * The methods are shimmed in outro.js so that MathQuill.MathField.prototype etc
  * can be accessed (same reason this is at the end of publicapi.js, so that
  * MathQuill.prototype can be accessed).
  */
 function insistOnInterVer() {
   if (window.console) console.warn(
-    'Please call MathQuill.interfaceVersion(1) before doing anything else ' +
-    'with the MathQuill API. This will be required starting v1.0.0.'
+    'This usage of the MathQuill API will fail in v1.0.0. The easiest fix is ' +
+    'to get interface version 1 before doing anything else:\n' +
+    '\n' +
+    '    MathQuill = MathQuill.getInterface(1);\n' +
+    '    // now MathQuill.MathField() works like it used to\n' +
+    ' '
+//   ^ apparently necessary to show the empty line in Blink/WebKit
   );
 }
 function preInterVerMathQuill(el) {
@@ -205,13 +204,12 @@ function preInterVerMathQuill(el) {
 };
 preInterVerMathQuill.prototype = MathQuill.prototype;
 
-preInterVerMathQuill.interfaceVersion = function(v) {
+preInterVerMathQuill.getInterface = function(v) {
   if (v !== 1) throw 'Only interface version 1 supported. You specified: ' + v;
-  return window.MathQuill = MathQuill;
+  return MathQuill;
 };
 
 preInterVerMathQuill.noConflict = function() {
-  insistOnInterVer();
   window.MathQuill = origMathQuill;
   return preInterVerMathQuill;
 };

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -7,12 +7,12 @@
  * static math or math or text field, returns its API object (if not, null).
  * Identity of API object guaranteed if called multiple times, i.e.:
  *
- *   var mathfield = MathQuill.MathField(mathFieldSpan);
- *   assert(MathQuill(mathFieldSpan) === mathfield);
- *   assert(MathQuill(mathFieldSpan) === MathQuill(mathFieldSpan));
+ *   var mathfield = MQ.MathField(mathFieldSpan);
+ *   assert(MQ(mathFieldSpan) === mathfield);
+ *   assert(MQ(mathFieldSpan) === MQ(mathFieldSpan));
  *
  */
-function MathQuill(el) {
+function MQ(el) {
   if (!el || !el.nodeType) return null; // check that `el` is a HTML element, using the
     // same technique as jQuery: https://github.com/jquery/jquery/blob/679536ee4b7a92ae64a5f58d90e9cc38c001e807/src/core/init.js#L92
   var blockId = $(el).children('.mq-root-block').attr(mqBlockId);
@@ -27,7 +27,7 @@ function MathQuill(el) {
  */
 function APIFnFor(APIClass) {
   function APIFn(el, opts) {
-    var mq = MathQuill(el);
+    var mq = MQ(el);
     if (mq instanceof APIClass || !el || !el.nodeType) return mq;
     return APIClass($(el), opts);
   }
@@ -36,7 +36,7 @@ function APIFnFor(APIClass) {
 }
 
 var Options = P(), optionProcessors = {};
-MathQuill.__options = Options.p;
+MQ.__options = Options.p;
 
 var AbstractMathQuill = P(function(_) {
   _.init = function() { throw "wtf don't call me, I'm 'abstract'"; };
@@ -59,7 +59,7 @@ var AbstractMathQuill = P(function(_) {
     };
   };
   _.config =
-  MathQuill.config = function(opts) {
+  MQ.config = function(opts) {
     for (var opt in opts) if (opts.hasOwnProperty(opt)) {
       var optVal = opts[opt], processor = optionProcessors[opt];
       this.__options[opt] = (processor ? processor(optVal) : optVal);
@@ -88,9 +88,9 @@ var AbstractMathQuill = P(function(_) {
     return this;
   };
 });
-MathQuill.prototype = AbstractMathQuill.prototype;
+MQ.prototype = AbstractMathQuill.prototype;
 
-MathQuill.StaticMath = APIFnFor(P(AbstractMathQuill, function(_, super_) {
+MQ.StaticMath = APIFnFor(P(AbstractMathQuill, function(_, super_) {
   _.init = function(el) {
     this.initRoot(MathBlock(), el.addClass('mq-math-mode'));
     this.__controller.delegateMouseEvents();
@@ -105,7 +105,7 @@ MathQuill.StaticMath = APIFnFor(P(AbstractMathQuill, function(_, super_) {
   };
 }));
 
-var EditableField = MathQuill.EditableField = P(AbstractMathQuill, function(_) {
+var EditableField = MQ.EditableField = P(AbstractMathQuill, function(_) {
   _.initRootAndEvents = function(root, el, opts) {
     this.initRoot(root, el, opts);
     this.__controller.editable = true;
@@ -183,8 +183,8 @@ function RootBlockMixin(_) {
  * v0.10.x introduces it, so for now, don't completely break the API for
  * people who don't know about it, just complain with console.warn().
  *
- * The methods are shimmed in outro.js so that MathQuill.MathField.prototype etc
- * can be accessed.
+ * The methods are shimmed in outro.js so that MQ.MathField.prototype etc can
+ * be accessed.
  */
 function insistOnInterVer() {
   if (window.console) console.warn(
@@ -199,12 +199,12 @@ function insistOnInterVer() {
 }
 function preInterVerMathQuill(el) {
   insistOnInterVer();
-  return MathQuill(el);
+  return MQ(el);
 };
 
 preInterVerMathQuill.getInterface = function(v) {
   if (v !== 1) throw 'Only interface version 1 supported. You specified: ' + v;
-  return MathQuill;
+  return MQ;
 };
 
 preInterVerMathQuill.noConflict = function() {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -2,7 +2,7 @@
  * The publicly exposed MathQuill API.
  ********************************************************/
 
-var API = {}, Options = P(), optionProcessors = {};
+var API = {}, Options = P(), optionProcessors = {}, Progenote = P();
 
 /**
  * Interface Versioning (#459) to allow us to virtually guarantee backcompat.
@@ -28,6 +28,7 @@ function MathQuill(el) {
   insistOnInterVer();
   return MQ1(el);
 };
+MathQuill.prototype = Progenote.p;
 MathQuill.getInterface = getInterface;
 
 var MIN = getInterface.MIN = 1;
@@ -69,7 +70,7 @@ function getInterface(v) {
   }
   MQ.config = function(opts) { config(Options.p, opts); return this; };
 
-  var AbstractMathQuill = APIClasses.AbstractMathQuill = P(function(_) {
+  var AbstractMathQuill = APIClasses.AbstractMathQuill = P(Progenote, function(_) {
     _.init = function(ctrlr) {
       this.__controller = ctrlr;
       this.__options = ctrlr.options;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -28,9 +28,14 @@ function MathQuill(el) {
   insistOnInterVer();
   return MQ1(el);
 };
+MathQuill.getInterface = getInterface;
 
-MathQuill.getInterface = function(v) {
-  if (v !== 1) throw 'Only interface version 1 supported. You specified: ' + v;
+var MIN = getInterface.MIN = 1;
+var MAX = getInterface.MAX = 2;
+
+function getInterface(v) {
+  if (!(MIN <= v && v <= MAX)) throw 'Only interface versions between ' +
+    MIN + ' and ' + MAX + ' supported. You specified: ' + v;
 
   /**
    * Function that takes an HTML element and, if it's the root HTML element of a
@@ -193,8 +198,8 @@ MathQuill.getInterface = function(v) {
   }(kind, API[kind]));
 
   return MQ;
-};
-var MQ1 = MathQuill.getInterface(1);
+}
+var MQ1 = getInterface(1);
 
 MathQuill.noConflict = function() {
   window.MathQuill = origMathQuill;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -184,8 +184,7 @@ function RootBlockMixin(_) {
  * people who don't know about it, just complain with console.warn().
  *
  * The methods are shimmed in outro.js so that MathQuill.MathField.prototype etc
- * can be accessed (same reason this is at the end of publicapi.js, so that
- * MathQuill.prototype can be accessed).
+ * can be accessed.
  */
 function insistOnInterVer() {
   if (window.console) console.warn(

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -10,7 +10,7 @@ Controller.open(function(_) {
   };
   _.createTextarea = function() {
     var textareaSpan = this.textareaSpan = $('<span class="mq-textarea"></span>'),
-      textarea = this.API.__options.substituteTextarea();
+      textarea = this.options.substituteTextarea();
     if (!textarea.nodeType) {
       throw 'substituteTextarea() must return a DOM element, got ' + textarea;
     }
@@ -38,7 +38,7 @@ Controller.open(function(_) {
     var latex = '';
     if (this.cursor.selection) {
       latex = this.cursor.selection.join('latex');
-      if (this.API.__options.statelessClipboard) {
+      if (this.options.statelessClipboard) {
         // FIXME: like paste, only this works for math fields; should ask parent
         latex = '$' + latex + '$';
       }
@@ -97,7 +97,7 @@ Controller.open(function(_) {
     // (currently only works in math fields, so worse than pointless, it
     //  only gets in the way by \text{}-ifying pasted stuff and $-ifying
     //  cut/copied LaTeX)
-    if (this.API.__options.statelessClipboard) {
+    if (this.options.statelessClipboard) {
       if (text.slice(0,1) === '$' && text.slice(-1) === '$') {
         text = text.slice(1, -1);
       }

--- a/src/tree.js
+++ b/src/tree.js
@@ -11,8 +11,8 @@
 //
 // the contract is that they can be used as object properties
 // and (-L) === R, and (-R) === L.
-var L = MQ.L = -1;
-var R = MQ.R = 1;
+var L = -1;
+var R = 1;
 
 function prayDirection(dir) {
   pray('a direction was passed', dir === L || dir === R);

--- a/src/tree.js
+++ b/src/tree.js
@@ -11,8 +11,8 @@
 //
 // the contract is that they can be used as object properties
 // and (-L) === R, and (-R) === L.
-var L = MathQuill.L = -1;
-var R = MathQuill.R = 1;
+var L = MQ.L = -1;
+var R = MQ.R = 1;
 
 function prayDirection(dir) {
   pray('a direction was passed', dir === L || dir === R);

--- a/test/basic.html
+++ b/test/basic.html
@@ -27,7 +27,7 @@
 <script type="text/javascript" src="support/jquery-1.7.2.js"></script>
 <script type="text/javascript" src="../build/mathquill-basic.js"></script>
 <script type="text/javascript">
-MQ = MathQuill.getInterface(1);
+MQ = MathQuill.getInterface(MathQuill.getInterface.MAX);
 
 var latex = $('#basic-latex').on('keydown keypress', function() {
   var prev = latex.val();

--- a/test/basic.html
+++ b/test/basic.html
@@ -27,7 +27,7 @@
 <script type="text/javascript" src="support/jquery-1.7.2.js"></script>
 <script type="text/javascript" src="../build/mathquill-basic.js"></script>
 <script type="text/javascript">
-MathQuill = MathQuill.getInterface(1);
+MQ = MathQuill.getInterface(1);
 
 var latex = $('#basic-latex').on('keydown keypress', function() {
   var prev = latex.val();
@@ -36,7 +36,7 @@ var latex = $('#basic-latex').on('keydown keypress', function() {
     if (now !== prev) mq.latex(now);
   });
 });
-var mq = MathQuill.MathField($('#basic')[0], {
+var mq = MQ.MathField($('#basic')[0], {
   autoSubscriptNumerals: true,
   handlers: { edit: function(mq) {
     if (!latex.is(':focus')) latex.val(mq.latex());

--- a/test/basic.html
+++ b/test/basic.html
@@ -27,7 +27,7 @@
 <script type="text/javascript" src="support/jquery-1.7.2.js"></script>
 <script type="text/javascript" src="../build/mathquill-basic.js"></script>
 <script type="text/javascript">
-MathQuill.interfaceVersion(1);
+MathQuill = MathQuill.getInterface(1);
 
 var latex = $('#basic-latex').on('keydown keypress', function() {
   var prev = latex.val();

--- a/test/basic.html
+++ b/test/basic.html
@@ -38,10 +38,11 @@ var latex = $('#basic-latex').on('keydown keypress', function() {
 });
 var mq = MQ.MathField($('#basic')[0], {
   autoSubscriptNumerals: true,
-  handlers: { edit: function(mq) {
+  handlers: { edit: function() {
     if (!latex.is(':focus')) latex.val(mq.latex());
   } }
 });
+latex.val(mq.latex());
 </script>
 </body>
 </html>

--- a/test/demo.html
+++ b/test/demo.html
@@ -63,7 +63,7 @@ code span {
 <script type="text/javascript" src="support/jquery-1.7.2.js"></script>
 <script type="text/javascript" src="../build/mathquill.js"></script>
 <script type="text/javascript">
-MQ = MathQuill.getInterface(1);
+MQ = MathQuill.getInterface(MathQuill.getInterface.MAX);
 
 //on document ready, mathquill-ify all `<tag class="mathquill-*">latex</tag>`
 //elements according to their CSS class.

--- a/test/demo.html
+++ b/test/demo.html
@@ -63,7 +63,7 @@ code span {
 <script type="text/javascript" src="support/jquery-1.7.2.js"></script>
 <script type="text/javascript" src="../build/mathquill.js"></script>
 <script type="text/javascript">
-MathQuill.interfaceVersion(1);
+MathQuill = MathQuill.getInterface(1);
 
 //on document ready, mathquill-ify all `<tag class="mathquill-*">latex</tag>`
 //elements according to their CSS class.

--- a/test/demo.html
+++ b/test/demo.html
@@ -57,20 +57,20 @@ code span {
 
 <p>LaTeX math can also have textboxes inside: <span class="mathquill-static-math">\int\MathQuillMathField{}dx</span> or even <span class="mathquill-static-math">\sqrt{\MathQuillMathField{x^2+y^2}}</span></p>
 
-<p>This button runs the JavaScript code written on it to MathQuill-ify the following <code>&lt;span&gt;</code> element into an editable math textbox: <button onclick="$(this).text('MathQuill(this.nextSibling).revert()'); MathQuill.MathField(this.nextSibling); var orig = arguments.callee; this.onclick = function(){ $(this).text('MathQuill.MathField(this.nextSibling)'); MathQuill(this.nextSibling).revert(); this.onclick = orig; };">MathQuill.MathField(this.nextSibling)</button><span>\frac{d}{dx}\sqrt{x} = \frac{d}{dx}x^{\frac{1}{2}} = \frac{1}{2}x^{-\frac{1}{2}} = \frac{1}{2\sqrt{x}}</span></p>
+<p>This button runs the JavaScript code written on it to MathQuill-ify the following <code>&lt;span&gt;</code> element into an editable math textbox: <button onclick="$(this).text('MQ(this.nextSibling).revert()'); MQ.MathField(this.nextSibling); var orig = arguments.callee; this.onclick = function(){ $(this).text('MQ.MathField(this.nextSibling)'); MQ(this.nextSibling).revert(); this.onclick = orig; };">MQ.MathField(this.nextSibling)</button><span>\frac{d}{dx}\sqrt{x} = \frac{d}{dx}x^{\frac{1}{2}} = \frac{1}{2}x^{-\frac{1}{2}} = \frac{1}{2\sqrt{x}}</span></p>
 
 </div>
 <script type="text/javascript" src="support/jquery-1.7.2.js"></script>
 <script type="text/javascript" src="../build/mathquill.js"></script>
 <script type="text/javascript">
-MathQuill = MathQuill.getInterface(1);
+MQ = MathQuill.getInterface(1);
 
 //on document ready, mathquill-ify all `<tag class="mathquill-*">latex</tag>`
 //elements according to their CSS class.
 $(function() {
-  $('.mathquill-static-math').each(function() { MathQuill.StaticMath(this); });
-  $('.mathquill-math-field').each(function() { MathQuill.MathField(this); });
-  $('.mathquill-text-field').each(function() { MathQuill.TextField(this); });
+  $('.mathquill-static-math').each(function() { MQ.StaticMath(this); });
+  $('.mathquill-math-field').each(function() { MQ.MathField(this); });
+  $('.mathquill-text-field').each(function() { MQ.TextField(this); });
 });
 
 $('#show-html-source').toggle(function() {
@@ -88,7 +88,7 @@ $('#codecogs').click(function() {
 });
 
 $(function() {
-  var latexMath = MathQuill($('#editable-math')[0]);
+  var latexMath = MQ($('#editable-math')[0]);
   $(latexMath.el()).bind('keydown keypress', function() {
     setTimeout(function() {
       var latex = latexMath.latex();

--- a/test/unit.html
+++ b/test/unit.html
@@ -36,8 +36,8 @@
     <link rel="stylesheet" type="text/css" href="../build/mathquill.css" />
     <script type="text/javascript" src="../build/mathquill-basic.js"></script>
     <script type="text/javascript">
-      MQBasic = MathQuill.noConflict().getInterface(1);
-      MQ = MathQuill.getInterface(1);
+      MQBasic = MathQuill.noConflict().getInterface(MathQuill.getInterface.MAX);
+      MQ = MathQuill.getInterface(MathQuill.getInterface.MAX);
     </script>
 
   </head>

--- a/test/unit.html
+++ b/test/unit.html
@@ -36,8 +36,8 @@
     <link rel="stylesheet" type="text/css" href="../build/mathquill.css" />
     <script type="text/javascript" src="../build/mathquill-basic.js"></script>
     <script type="text/javascript">
-      MathQuillBasic = MathQuill.noConflict().getInterface(1);
-      MathQuill = MathQuill.getInterface(1);
+      MQBasic = MathQuill.noConflict().getInterface(1);
+      MQ = MathQuill.getInterface(1);
     </script>
 
   </head>

--- a/test/unit.html
+++ b/test/unit.html
@@ -36,8 +36,8 @@
     <link rel="stylesheet" type="text/css" href="../build/mathquill.css" />
     <script type="text/javascript" src="../build/mathquill-basic.js"></script>
     <script type="text/javascript">
-      MathQuillBasic = MathQuill.interfaceVersion(1).noConflict();
-      MathQuill.interfaceVersion(1);
+      MathQuillBasic = MathQuill.noConflict().getInterface(1);
+      MathQuill = MathQuill.getInterface(1);
     </script>
 
   </head>

--- a/test/unit/SupSub.test.js
+++ b/test/unit/SupSub.test.js
@@ -1,7 +1,7 @@
 suite('SupSub', function() {
   var mq;
   setup(function() {
-    mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+    mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
   });
   teardown(function() {
     $(mq.el()).remove();

--- a/test/unit/autoOperatorNames.test.js
+++ b/test/unit/autoOperatorNames.test.js
@@ -1,7 +1,7 @@
 suite('autoOperatorNames', function() {
   var mq;
   setup(function() {
-    mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+    mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
   });
   teardown(function() {
     $(mq.el()).remove();
@@ -79,30 +79,30 @@ suite('autoOperatorNames', function() {
 
   suite('override autoOperatorNames', function() {
     test('basic', function() {
-      MathQuill.config({ autoOperatorNames: 'sin lol' });
+      MQ.config({ autoOperatorNames: 'sin lol' });
       mq.typedText('arcsintrololol');
       assert.equal(mq.latex(), 'arc\\sin tro\\operatorname{lol}ol');
     });
 
     test('command contains non-letters', function() {
-      assert.throws(function() { MathQuill.config({ autoOperatorNames: 'e1' }); });
+      assert.throws(function() { MQ.config({ autoOperatorNames: 'e1' }); });
     });
 
     test('command length less than 2', function() {
-      assert.throws(function() { MathQuill.config({ autoOperatorNames: 'e' }); });
+      assert.throws(function() { MQ.config({ autoOperatorNames: 'e' }); });
     });
 
     suite('command list not perfectly space-delimited', function() {
       test('double space', function() {
-        assert.throws(function() { MathQuill.config({ autoOperatorNames: 'pi  theta' }); });
+        assert.throws(function() { MQ.config({ autoOperatorNames: 'pi  theta' }); });
       });
 
       test('leading space', function() {
-        assert.throws(function() { MathQuill.config({ autoOperatorNames: ' pi' }); });
+        assert.throws(function() { MQ.config({ autoOperatorNames: ' pi' }); });
       });
 
       test('trailing space', function() {
-        assert.throws(function() { MathQuill.config({ autoOperatorNames: 'pi ' }); });
+        assert.throws(function() { MQ.config({ autoOperatorNames: 'pi ' }); });
       });
     });
   });

--- a/test/unit/autosubscript.test.js
+++ b/test/unit/autosubscript.test.js
@@ -1,7 +1,7 @@
 suite('autoSubscript', function() {
   var mq;
   setup(function() {
-    mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0], {autoSubscriptNumerals: true});
+    mq = MQ.MathField($('<span></span>').appendTo('#mock')[0], {autoSubscriptNumerals: true});
     rootBlock = mq.__controller.root;
     controller = mq.__controller;
     cursor = controller.cursor;

--- a/test/unit/backspace.test.js
+++ b/test/unit/backspace.test.js
@@ -205,7 +205,7 @@ suite('backspace', function() {
     var textBlock = rootBlock.ends[R];
     assert.equal(cursor.parent, textBlock, 'cursor is in text block');
     assert.equal(cursor[R], 0, 'cursor is at the end of text block');
-    assert.equal(cursor[L].ctrlSeq, 'x', 'cursor is rightward of the x');
+    assert.equal(cursor[L].text, 'x', 'cursor is rightward of the x');
   });
 
   suite('empties', function() {

--- a/test/unit/backspace.test.js
+++ b/test/unit/backspace.test.js
@@ -197,7 +197,7 @@ suite('backspace', function() {
     assert.equal(mq.latex(),'n=1');
   });
 
-  test('backspace inside text block', function() {
+  test('backspace into text block', function() {
     mq.latex('\\text{x}');
 
     mq.keystroke('Backspace');
@@ -205,6 +205,7 @@ suite('backspace', function() {
     var textBlock = rootBlock.ends[R];
     assert.equal(cursor.parent, textBlock, 'cursor is in text block');
     assert.equal(cursor[R], 0, 'cursor is at the end of text block');
+    assert.equal(cursor[L].ctrlSeq, 'x', 'cursor is rightward of the x');
   });
 
   suite('empties', function() {

--- a/test/unit/backspace.test.js
+++ b/test/unit/backspace.test.js
@@ -1,7 +1,7 @@
 suite('backspace', function() {
   var mq, rootBlock, controller, cursor;
   setup(function() {
-    mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+    mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
     rootBlock = mq.__controller.root;
     controller = mq.__controller;
     cursor = controller.cursor;

--- a/test/unit/css.test.js
+++ b/test/unit/css.test.js
@@ -8,7 +8,7 @@ suite('CSS', function() {
     assert.equal(mock.scrollHeight, 25);
     assert.equal(mock.scrollWidth, 25);
 
-    var mq = MathQuill.MathField($('<span style="box-sizing:border-box;height:100%;width:100%"></span>').appendTo(mock)[0]);
+    var mq = MQ.MathField($('<span style="box-sizing:border-box;height:100%;width:100%"></span>').appendTo(mock)[0]);
     assert.equal(mock.scrollHeight, 25);
     assert.equal(mock.scrollWidth, 25);
 
@@ -22,7 +22,7 @@ suite('CSS', function() {
 
   test('empty root block does not collapse', function() {
     var testEl = $('<span></span>').appendTo('#mock');
-    var mq = MathQuill.MathField(testEl[0]);
+    var mq = MQ.MathField(testEl[0]);
     var rootEl = testEl.find('.mq-root-block');
 
     assert.ok(rootEl.hasClass('mq-empty'), 'Empty root block should have the mq-empty class name.');
@@ -33,7 +33,7 @@ suite('CSS', function() {
 
   test('empty block does not collapse', function() {
     var testEl = $('<span>\\frac{}{}</span>').appendTo('#mock');
-    var mq = MathQuill.MathField(testEl[0]);
+    var mq = MQ.MathField(testEl[0]);
     var numeratorEl = testEl.find('.mq-numerator');
 
     assert.ok(numeratorEl.hasClass('mq-empty'), 'Empty numerator should have the mq-empty class name.');

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -105,7 +105,7 @@ suite('latex', function() {
   suite('public API', function() {
     var mq;
     setup(function() {
-      mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+      mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
     });
     teardown(function() {
       $(mq.el()).remove();
@@ -190,7 +190,7 @@ suite('latex', function() {
   suite('\\MathQuillMathField', function() {
     var outer, inner1, inner2;
     setup(function() {
-      outer = MathQuill.StaticMath(
+      outer = MQ.StaticMath(
         $('<span>\\frac{\\MathQuillMathField{x_0 + x_1 + x_2}}{\\MathQuillMathField{3}}</span>')
         .appendTo('#mock')[0]
       );
@@ -245,7 +245,7 @@ suite('latex', function() {
   suite('error handling', function() {
     var mq;
     setup(function() {
-      mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+      mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
     });
     teardown(function() {
       $(mq.el()).remove();

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -240,6 +240,13 @@ suite('latex', function() {
       exp.latex('8');
       assert.equal(outer.latex(), '1.2345\\cdot10^8');
     });
+
+    test('separate API object', function() {
+      var outer2 = MQ(outer.el());
+      assert.equal(outer2.innerFields.length, 2);
+      assert.equal(outer2.innerFields[0].id, inner1.id);
+      assert.equal(outer2.innerFields[1].id, inner2.id);
+    });
   });
 
   suite('error handling', function() {

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -16,6 +16,17 @@ suite('Public API', function() {
       assert.ok(mathField instanceof MQ.MathField);
       assert.ok(mathField instanceof MQ.EditableField);
       assert.ok(mathField instanceof MQ);
+      assert.ok(mathField instanceof MathQuill);
+    });
+
+    test('interface versioning isolates prototype chain', function() {
+      var mathFieldSpan = $('<span/>')[0];
+      var mathField = MQ.MathField(mathFieldSpan);
+
+      var MQ1 = MathQuill.getInterface(1);
+      assert.ok(!(mathField instanceof MQ1.MathField));
+      assert.ok(!(mathField instanceof MQ1.EditableField));
+      assert.ok(!(mathField instanceof MQ1));
     });
 
     test('identity of API object returned by MQ()', function() {

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -1,43 +1,43 @@
 suite('Public API', function() {
   suite('global functions', function() {
     test('null', function() {
-      assert.equal(MathQuill(), null);
-      assert.equal(MathQuill(0), null);
-      assert.equal(MathQuill('<span/>'), null);
-      assert.equal(MathQuill($('<span/>')[0]), null);
-      assert.equal(MathQuill.MathField(), null);
-      assert.equal(MathQuill.MathField(0), null);
-      assert.equal(MathQuill.MathField('<span/>'), null);
+      assert.equal(MQ(), null);
+      assert.equal(MQ(0), null);
+      assert.equal(MQ('<span/>'), null);
+      assert.equal(MQ($('<span/>')[0]), null);
+      assert.equal(MQ.MathField(), null);
+      assert.equal(MQ.MathField(0), null);
+      assert.equal(MQ.MathField('<span/>'), null);
     });
 
-    test('MathQuill.MathField()', function() {
+    test('MQ.MathField()', function() {
       var el = $('<span>x^2</span>');
-      var mathField = MathQuill.MathField(el[0]);
-      assert.ok(mathField instanceof MathQuill.MathField);
-      assert.ok(mathField instanceof MathQuill.EditableField);
-      assert.ok(mathField instanceof MathQuill);
+      var mathField = MQ.MathField(el[0]);
+      assert.ok(mathField instanceof MQ.MathField);
+      assert.ok(mathField instanceof MQ.EditableField);
+      assert.ok(mathField instanceof MQ);
     });
 
-    test('identity of API object returned by MathQuill()', function() {
+    test('identity of API object returned by MQ()', function() {
       var mathFieldSpan = $('<span/>')[0];
-      var mathfield = MathQuill.MathField(mathFieldSpan);
-      assert.equal(MathQuill(mathFieldSpan), mathfield);
-      assert.equal(MathQuill(mathFieldSpan), MathQuill(mathFieldSpan));
+      var mathfield = MQ.MathField(mathFieldSpan);
+      assert.equal(MQ(mathFieldSpan), mathfield);
+      assert.equal(MQ(mathFieldSpan), MQ(mathFieldSpan));
     });
 
     test('blurred when created', function() {
       var el = $('<span/>');
-      MathQuill.MathField(el[0]);
+      MQ.MathField(el[0]);
       var rootBlock = el.find('.mq-root-block');
       assert.ok(rootBlock.hasClass('mq-empty'));
       assert.ok(!rootBlock.hasClass('mq-hasCursor'));
     });
   });
 
-  suite('MathQuillBasic', function() {
+  suite('mathquill-basic', function() {
     var mq;
     setup(function() {
-      mq = MathQuillBasic.MathField($('<span></span>').appendTo('#mock')[0]);
+      mq = MQBasic.MathField($('<span></span>').appendTo('#mock')[0]);
     });
     teardown(function() {
       $(mq.el()).remove();
@@ -62,14 +62,14 @@ suite('Public API', function() {
   suite('basic API methods', function() {
     var mq;
     setup(function() {
-      mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+      mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
     });
     teardown(function() {
       $(mq.el()).remove();
     });
 
     test('.revert()', function() {
-      var mq = MathQuill.MathField($('<span>some <code>HTML</code></span>')[0]);
+      var mq = MQ.MathField($('<span>some <code>HTML</code></span>')[0]);
       assert.equal(mq.revert().html(), 'some <code>HTML</code>');
     });
 
@@ -139,26 +139,26 @@ suite('Public API', function() {
   });
 
   suite('*OutOf handlers', function() {
-    testHandlers('MathQuill.MathField() constructor', function(options) {
-      return MathQuill.MathField($('<span></span>').appendTo('#mock')[0], options);
+    testHandlers('MQ.MathField() constructor', function(options) {
+      return MQ.MathField($('<span></span>').appendTo('#mock')[0], options);
     });
-    testHandlers('MathQuill.MathField::config()', function(options) {
-      return MathQuill.MathField($('<span></span>').appendTo('#mock')[0]).config(options);
+    testHandlers('MQ.MathField::config()', function(options) {
+      return MQ.MathField($('<span></span>').appendTo('#mock')[0]).config(options);
     });
-    testHandlers('.config() on \\MathQuillMathField{} in a MathQuill.StaticMath', function(options) {
-      return MathQuill.MathField($('<span></span>').appendTo('#mock')[0]).config(options);
+    testHandlers('.config() on \\MathQuillMathField{} in a MQ.StaticMath', function(options) {
+      return MQ.MathField($('<span></span>').appendTo('#mock')[0]).config(options);
     });
-    suite('global MathQuill.config()', function() {
-      testHandlers('a MathQuill.MathField', function(options) {
-        MathQuill.config(options);
-        return MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+    suite('global MQ.config()', function() {
+      testHandlers('a MQ.MathField', function(options) {
+        MQ.config(options);
+        return MQ.MathField($('<span></span>').appendTo('#mock')[0]);
       });
-      testHandlers('\\MathQuillMathField{} in a MathQuill.StaticMath', function(options) {
-        MathQuill.config(options);
-        return MathQuill.StaticMath($('<span>\\MathQuillMathField{}</span>').appendTo('#mock')[0]).innerFields[0];
+      testHandlers('\\MathQuillMathField{} in a MQ.StaticMath', function(options) {
+        MQ.config(options);
+        return MQ.StaticMath($('<span>\\MathQuillMathField{}</span>').appendTo('#mock')[0]).innerFields[0];
       });
       teardown(function() {
-        MathQuill.config({ handlers: undefined });
+        MQ.config({ handlers: undefined });
       });
     });
     function testHandlers(title, mathFieldMaker) {
@@ -250,7 +250,7 @@ suite('Public API', function() {
   suite('.cmd(...)', function() {
     var mq;
     setup(function() {
-      mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+      mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
     });
     teardown(function() {
       $(mq.el()).remove();
@@ -293,7 +293,7 @@ suite('Public API', function() {
   suite('spaceBehavesLikeTab', function() {
     var mq, rootBlock, cursor;
     test('space behaves like tab with default opts', function() {
-      mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+      mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
       rootBlock = mq.__controller.root;
       cursor = mq.__controller.cursor;
 
@@ -315,7 +315,7 @@ suite('Public API', function() {
     });
     test('space behaves like tab when spaceBehavesLikeTab is true', function() {
       var opts = { 'spaceBehavesLikeTab': true };
-      mq = MathQuill.MathField( $('<span></span>').appendTo('#mock')[0], opts)
+      mq = MQ.MathField( $('<span></span>').appendTo('#mock')[0], opts)
       rootBlock = mq.__controller.root;
       cursor = mq.__controller.cursor;
 
@@ -334,9 +334,9 @@ suite('Public API', function() {
       $(mq.el()).remove();
     });
     test('space behaves like tab when globally set to true', function() {
-      MathQuill.config({ spaceBehavesLikeTab: true });
+      MQ.config({ spaceBehavesLikeTab: true });
 
-      mq = MathQuill.MathField( $('<span></span>').appendTo('#mock')[0]);
+      mq = MQ.MathField( $('<span></span>').appendTo('#mock')[0]);
       rootBlock = mq.__controller.root;
       cursor = mq.__controller.cursor;
 
@@ -355,7 +355,7 @@ suite('Public API', function() {
     suite('default', function() {
       var mq, textarea;
       setup(function() {
-        mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+        mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
         textarea = $(mq.el()).find('textarea');;
       });
       teardown(function() {
@@ -398,7 +398,7 @@ suite('Public API', function() {
     suite('statelessClipboard set to true', function() {
       var mq, textarea;
       setup(function() {
-        mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0],
+        mq = MQ.MathField($('<span></span>').appendTo('#mock')[0],
                                  { statelessClipboard: true });
         textarea = $(mq.el()).find('textarea');;
       });
@@ -445,13 +445,13 @@ suite('Public API', function() {
   suite('leftRightIntoCmdGoes: "up"/"down"', function() {
     test('"up" or "down" required', function() {
       assert.throws(function() {
-        MathQuill.MathField($('<span></span>')[0], { leftRightIntoCmdGoes: 1 });
+        MQ.MathField($('<span></span>')[0], { leftRightIntoCmdGoes: 1 });
       });
     });
     suite('default', function() {
       var mq;
       setup(function() {
-        mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+        mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
       });
       teardown(function() {
         $(mq.el()).remove();
@@ -551,7 +551,7 @@ suite('Public API', function() {
     suite('"up"', function() {
       var mq;
       setup(function() {
-        mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0],
+        mq = MQ.MathField($('<span></span>').appendTo('#mock')[0],
                                  { leftRightIntoCmdGoes: 'up' });
       });
       teardown(function() {
@@ -631,7 +631,7 @@ suite('Public API', function() {
 
   suite('sumStartsWithNEquals', function() {
     test('sum defaults to empty limits', function() {
-      var mq = MathQuill.MathField($('<span>').appendTo('#mock')[0]);
+      var mq = MQ.MathField($('<span>').appendTo('#mock')[0]);
       assert.equal(mq.latex(), '');
 
       mq.cmd('\\sum');
@@ -643,7 +643,7 @@ suite('Public API', function() {
       $(mq.el()).remove();
     });
     test('sum starts with `n=`', function() {
-      var mq = MathQuill.MathField($('<span>').appendTo('#mock')[0], {
+      var mq = MQ.MathField($('<span>').appendTo('#mock')[0], {
         sumStartsWithNEquals: true
       });
       assert.equal(mq.latex(), '');
@@ -660,7 +660,7 @@ suite('Public API', function() {
 
   suite('substituteTextarea', function() {
     test('doesn\'t blow up on selection', function() {
-      var mq = MathQuill.MathField($('<span>').appendTo('#mock')[0], {
+      var mq = MQ.MathField($('<span>').appendTo('#mock')[0], {
         substituteTextarea: function() {
           return $('<span tabindex=0 style="display:inline-block;width:1px;height:1px" />')[0];
         }

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -20,9 +20,15 @@ suite('Public API', function() {
 
     test('identity of API object returned by MQ()', function() {
       var mathFieldSpan = $('<span/>')[0];
-      var mathfield = MQ.MathField(mathFieldSpan);
-      assert.equal(MQ(mathFieldSpan), mathfield);
-      assert.equal(MQ(mathFieldSpan), MQ(mathFieldSpan));
+      var mathField = MQ.MathField(mathFieldSpan);
+
+      assert.ok(MQ(mathFieldSpan) !== mathField);
+
+      assert.equal(MQ(mathFieldSpan).id, mathField.id);
+      assert.equal(MQ(mathFieldSpan).id, MQ(mathFieldSpan).id);
+
+      assert.equal(MQ(mathFieldSpan).data, mathField.data);
+      assert.equal(MQ(mathFieldSpan).data, MQ(mathFieldSpan).data);
     });
 
     test('blurred when created', function() {
@@ -170,23 +176,23 @@ suite('Public API', function() {
           handlers: {
             enter: function(_mq) {
               assert.equal(arguments.length, 1);
-              assert.equal(_mq, mq);
+              assert.equal(_mq.id, mq.id);
               enterCounter += 1;
             },
             upOutOf: function(_mq) {
               assert.equal(arguments.length, 1);
-              assert.equal(_mq, mq);
+              assert.equal(_mq.id, mq.id);
               upCounter += 1;
             },
             moveOutOf: function(_dir, _mq) {
               assert.equal(arguments.length, 2);
-              assert.equal(_mq, mq);
+              assert.equal(_mq.id, mq.id);
               dir = _dir;
               moveCounter += 1;
             },
             deleteOutOf: function(_dir, _mq) {
               assert.equal(arguments.length, 2);
-              assert.equal(_mq, mq);
+              assert.equal(_mq.id, mq.id);
               dir = _dir;
               deleteCounter += 1;
             }

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -144,6 +144,37 @@ suite('Public API', function() {
     });
   });
 
+  test('edit handler interface versioning', function() {
+    var count = 0;
+
+    // interface version 2 (latest)
+    var mq2 = MQ.MathField($('<span></span>').appendTo('#mock')[0], {
+      handlers: {
+        edit: function(_mq) {
+          assert.equal(mq2.id, _mq.id);
+          count += 1;
+        }
+      }
+    });
+    assert.equal(count, 0);
+    mq2.latex('x^2');
+    assert.equal(count, 2); // sigh, once for postOrder and once for bubble
+
+    count = 0;
+    // interface version 1
+    var MQ1 = MathQuill.getInterface(1);
+    var mq1 = MQ1.MathField($('<span></span>').appendTo('#mock')[0], {
+      handlers: {
+        edit: function(_mq) {
+          if (count <= 2) assert.equal(mq1, undefined);
+          else assert.equal(mq1.id, _mq.id);
+          count += 1;
+        }
+      }
+    });
+    assert.equal(count, 2);
+  });
+
   suite('*OutOf handlers', function() {
     testHandlers('MQ.MathField() constructor', function(options) {
       return MQ.MathField($('<span></span>').appendTo('#mock')[0], options);

--- a/test/unit/text.test.js
+++ b/test/unit/text.test.js
@@ -29,7 +29,7 @@ suite('text', function() {
 
   test('changes the text nodes as the cursor moves around', function() {
     var block = fromLatex('\\text{abc}');
-    var ctrlr = Controller({ __options: 0 }, block);
+    var ctrlr = Controller(block, 0, 0);
     var cursor = ctrlr.cursor.insAtRightEnd(block);
 
     ctrlr.moveLeft();

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1,7 +1,7 @@
 suite('typing with auto-replaces', function() {
   var mq;
   setup(function() {
-    mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+    mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
   });
   teardown(function() {
     $(mq.el()).remove();
@@ -23,8 +23,8 @@ suite('typing with auto-replaces', function() {
       assertLatex('1\\ \\frac{2}{3}');
     });
 
-    test('MathQuill-basic', function() {
-      var mq_basic = MathQuillBasic.MathField($('<span></span>').appendTo('#mock')[0]);
+    test('mathquill-basic', function() {
+      var mq_basic = MQBasic.MathField($('<span></span>').appendTo('#mock')[0]);
       mq_basic.typedText('1/2');
       assert.equal(mq_basic.latex(), '\\frac{1}{2}');
       $(mq_basic.el()).remove();
@@ -811,8 +811,10 @@ suite('typing with auto-replaces', function() {
   });
 
   suite('autoCommands', function() {
-    MathQuill.config({
-      autoCommands: 'pi tau phi theta Gamma sum prod sqrt nthroot'
+    setup(function() {
+      MQ.config({
+        autoCommands: 'pi tau phi theta Gamma sum prod sqrt nthroot'
+      });
     });
 
     test('individual commands', function(){
@@ -879,43 +881,43 @@ suite('typing with auto-replaces', function() {
     });
 
     test('command contains non-letters', function() {
-      assert.throws(function() { MathQuill.config({ autoCommands: 'e1' }); });
+      assert.throws(function() { MQ.config({ autoCommands: 'e1' }); });
     });
 
     test('command length less than 2', function() {
-      assert.throws(function() { MathQuill.config({ autoCommands: 'e' }); });
+      assert.throws(function() { MQ.config({ autoCommands: 'e' }); });
     });
 
     test('command is a built-in operator name', function() {
       var cmds = ('Pr arg deg det dim exp gcd hom inf ker lg lim ln log max min sup'
                   + ' limsup liminf injlim projlim Pr').split(' ');
       for (var i = 0; i < cmds.length; i += 1) {
-        assert.throws(function() { MathQuill.config({ autoCommands: cmds[i] }) },
-                      'MathQuill.config({ autoCommands: "'+cmds[i]+'" })');
+        assert.throws(function() { MQ.config({ autoCommands: cmds[i] }) },
+                      'MQ.config({ autoCommands: "'+cmds[i]+'" })');
       }
     });
 
     test('built-in operator names even after auto-operator names overridden', function() {
-      MathQuill.config({ autoOperatorNames: 'sin inf arcosh cosh cos cosec csc' });
+      MQ.config({ autoOperatorNames: 'sin inf arcosh cosh cos cosec csc' });
         // ^ happen to be the ones required by autoOperatorNames.test.js
       var cmds = 'Pr arg deg det exp gcd inf lg lim ln log max min sup'.split(' ');
       for (var i = 0; i < cmds.length; i += 1) {
-        assert.throws(function() { MathQuill.config({ autoCommands: cmds[i] }) },
-                      'MathQuill.config({ autoCommands: "'+cmds[i]+'" })');
+        assert.throws(function() { MQ.config({ autoCommands: cmds[i] }) },
+                      'MQ.config({ autoCommands: "'+cmds[i]+'" })');
       }
     });
 
     suite('command list not perfectly space-delimited', function() {
       test('double space', function() {
-        assert.throws(function() { MathQuill.config({ autoCommands: 'pi  theta' }); });
+        assert.throws(function() { MQ.config({ autoCommands: 'pi  theta' }); });
       });
 
       test('leading space', function() {
-        assert.throws(function() { MathQuill.config({ autoCommands: ' pi' }); });
+        assert.throws(function() { MQ.config({ autoCommands: ' pi' }); });
       });
 
       test('trailing space', function() {
-        assert.throws(function() { MathQuill.config({ autoCommands: 'pi ' }); });
+        assert.throws(function() { MQ.config({ autoCommands: 'pi ' }); });
       });
     });
   });
@@ -990,7 +992,7 @@ suite('typing with auto-replaces', function() {
       assert.equal(mq.typedText('x^=2n').latex(), 'x^{=2n}');
       mq.latex('');
 
-      MathQuill.config({ charsThatBreakOutOfSupSub: '+-=<>' });
+      MQ.config({ charsThatBreakOutOfSupSub: '+-=<>' });
 
       assert.equal(mq.typedText('x^2n+y').latex(), 'x^{2n}+y');
       mq.latex('');
@@ -1026,7 +1028,7 @@ suite('typing with auto-replaces', function() {
       assert.equal(mq.typedText('n').latex(), 'x^{^{2n}}');
 
       mq.latex('');
-      MathQuill.config({ supSubsRequireOperand: true });
+      MQ.config({ supSubsRequireOperand: true });
 
       assert.equal(mq.typedText('^').latex(), '');
       assert.equal(mq.typedText('2').latex(), '2');

--- a/test/unit/updown.test.js
+++ b/test/unit/updown.test.js
@@ -1,7 +1,7 @@
 suite('up/down', function() {
   var mq, rootBlock, controller, cursor;
   setup(function() {
-    mq = MathQuill.MathField($('<span></span>').appendTo('#mock')[0]);
+    mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
     rootBlock = mq.__controller.root;
     controller = mq.__controller;
     cursor = controller.cursor;
@@ -175,10 +175,10 @@ suite('up/down', function() {
   });
 
   test('\\MathQuillMathField{} in a fraction', function() {
-    var outer = MathQuill.MathField(
+    var outer = MQ.MathField(
       $('<span>\\frac{\\MathQuillMathField{n}}{2}</span>').appendTo('#mock')[0]
     );
-    var inner = MathQuill($(outer.el()).find('.mq-editable-field')[0]);
+    var inner = MQ($(outer.el()).find('.mq-editable-field')[0]);
 
     assert.equal(inner.__controller.cursor.parent, inner.__controller.root);
     inner.keystroke('Down');

--- a/test/visual.html
+++ b/test/visual.html
@@ -90,7 +90,7 @@ td {
 <script type="text/javascript">
   $(function() {
     var count = 0;
-    MathQuill.MathField($('#reflowing-test')[0], {
+    MQ.MathField($('#reflowing-test')[0], {
       handlers: { edit: function() { count += 1; } }, // also test 'edit' hook
     }).focus().moveToLeftEnd().keystroke('Right');
     var textarea = $('#reflowing-test textarea');
@@ -109,7 +109,7 @@ td {
 
 <script>
 $(function() {
-  MathQuill.MathField($('#custom-behavior')[0], {
+  MQ.MathField($('#custom-behavior')[0], {
     spaceBehavesLikeTab: true,
     leftRightIntoCmdGoes: 'up',
     restrictMismatchedBrackets: true,
@@ -147,7 +147,7 @@ $(function() {
 <script>
 $(function() {
   var overflowTest = $('#overflow-test');
-  MathQuill.MathField(overflowTest[0]);
+  MQ.MathField(overflowTest[0]);
   var width = overflowTest.outerWidth(true);
   if (width !== 102) {
     throw 'math field '+width+'px wide instead of 102px';
@@ -176,7 +176,7 @@ $(function() {
   <td><span>\frac{ \text{apples} }{ \text{oranges} } = \text{NaN}</span>
 </table>
 <table id="dynamic-reflow">
-<tr><th colspan=3><code>MathQuill(...).reflow()</code>
+<tr><th colspan=3><code>MQ(...).reflow()</code>
 <tr>
   <td><span>\sqrt{ \left ( \frac{x^2 + y^2}{2} \right ) } + \binom{n}{k}</span>
   <td><span>\sqrt{ \left ( \frac{x^2 + y^2}{2} \right ) } + \binom{n}{k}</span>
@@ -209,7 +209,7 @@ $('#paren-alignment button').click(function() {
   }
   html += '</div>';
   $(html).insertAfter('#paren-alignment').find('.mathquill-static-math').each(function() {
-    MathQuill.StaticMath(this);
+    MQ.StaticMath(this);
   });
 });
 </script>
@@ -256,7 +256,7 @@ window.onerror = function() {
 </script>
 <script type="text/javascript" src="../build/mathquill.js"></script>
 <script type="text/javascript">
-MathQuill = MathQuill.getInterface(1);
+MQ = MathQuill.getInterface(1);
 
 $('#show-textareas-button').click(function() {
   $(document.body).toggleClass('show-textareas');
@@ -265,9 +265,9 @@ $('#show-textareas-button').click(function() {
 //on document ready, mathquill-ify all `<tag class="mathquill-*">latex</tag>`
 //elements according to their CSS class.
 $(function() {
-  $('.mathquill-static-math').each(function() { MathQuill.StaticMath(this); });
-  $('.mathquill-math-field').each(function() { MathQuill.MathField(this); });
-  $('.mathquill-text-field').each(function() { MathQuill.TextField(this); });
+  $('.mathquill-static-math').each(function() { MQ.StaticMath(this); });
+  $('.mathquill-math-field').each(function() { MQ.MathField(this); });
+  $('.mathquill-text-field').each(function() { MQ.TextField(this); });
 });
 
 // test selecting from outside the mathquill editable
@@ -293,32 +293,32 @@ $('#dynamic-initial tr').each(function() {
   var math = $('span', this);
   if (!math.length) return;
 
-  MathQuill.StaticMath(math[0]);
-  MathQuill.MathField(math[1]);
-  MathQuill.MathField(math[2]).revert();
+  MQ.StaticMath(math[0]);
+  MQ.MathField(math[1]);
+  MQ.MathField(math[2]).revert();
 });
-// MathQuill(...).reflow()
+// MQ(...).reflow()
 $('#dynamic-reflow tr').each(function() {
   var math = $('span', this), td;
   if (!math.length) return;
 
   td = math.eq(0).parent();
   math.eq(0).detach();
-  MathQuill.StaticMath(math[0]);
+  MQ.StaticMath(math[0]);
   math.eq(0).appendTo(td);
-  MathQuill(math[0]).reflow();
+  MQ(math[0]).reflow();
 
   td = math.eq(1).parent();
   math.eq(1).detach();
-  MathQuill.MathField(math[1]);
+  MQ.MathField(math[1]);
   math.eq(1).appendTo(td);
-  MathQuill(math[1]).reflow();
+  MQ(math[1]).reflow();
 
   td = math.eq(2).parent();
   math.eq(2).detach();
-  MathQuill.MathField(math[2]).revert();
+  MQ.MathField(math[2]).revert();
   math.eq(2).appendTo(td);
-  if (MathQuill(math[2])) throw 'should been have reverted';
+  if (MQ(math[2])) throw 'should been have reverted';
 });
 
 // Dynamic rendering performance
@@ -394,7 +394,7 @@ function timeAndLog(f) {
   });
 }());
 
-MathQuill.MathField($('#no-kbd-math')[0], {
+MQ.MathField($('#no-kbd-math')[0], {
   substituteTextarea: function() {
     return $('<span tabindex=0 style="display:inline-block;width:1px;height:1px" />')[0];
   }

--- a/test/visual.html
+++ b/test/visual.html
@@ -94,11 +94,10 @@ td {
       handlers: { edit: function() { count += 1; } }, // also test 'edit' hook
     }).focus().moveToLeftEnd().keystroke('Right');
     var textarea = $('#reflowing-test textarea');
-    var oldcount = count;
     // paste some stuff that needs resizing
     textarea.trigger('paste');
     textarea.val('\\pi\\sqrt{\\sqrt{\\frac12}}\\int');
-    setTimeout(function() { if (count === oldcount) throw 'reflow not called'; });
+    setTimeout(function() { if (count !== 1) throw 'reflow not called'; });
   });
 </script>
 

--- a/test/visual.html
+++ b/test/visual.html
@@ -256,7 +256,7 @@ window.onerror = function() {
 </script>
 <script type="text/javascript" src="../build/mathquill.js"></script>
 <script type="text/javascript">
-MathQuill.interfaceVersion(1);
+MathQuill = MathQuill.getInterface(1);
 
 $('#show-textareas-button').click(function() {
   $(document.body).toggleClass('show-textareas');

--- a/test/visual.html
+++ b/test/visual.html
@@ -256,7 +256,7 @@ window.onerror = function() {
 </script>
 <script type="text/javascript" src="../build/mathquill.js"></script>
 <script type="text/javascript">
-MQ = MathQuill.getInterface(1);
+MQ = MathQuill.getInterface(MathQuill.getInterface.MAX);
 
 $('#show-textareas-button').click(function() {
   $(document.body).toggleClass('show-textareas');


### PR DESCRIPTION
Fix #464: as [pointed out](https://github.com/mathquill/mathquill/issues/464#issuecomment-166861641), the `MathQuill.interfaceVersion()` declaration results in a version dependency hell if an app uses third-party scripts that also use MathQuill. Now, no more mutation, instead `MathQuill.getInterface()` nonmutatively creates a whole new copy of the entire API,
closing over the specified interface version:
```js
var MQ1 = MathQuill.getInterface(1);
var MQ2 = MathQuill.getInterface(2);
// MQ1 and MQ2 are two wholly separate instances of the entire API,
// with different interface versions

var mq1 = MQ1.MathField(mathFieldSpan);
var mq2 = MQ2(mathFieldSpan);
// mq1 and mq2 are API objects for the same math field, but they
// have different interface versions
```

There were 2 main sacrifices:
- There's no longer a unique API object per actual, "physical" instance of a math field or static math, `mq1` and `mq2` are API objects for the same math field. This way a third-party script, or another module of your app, can do `var MQ = MathQuill.getInterface(3)` in its own scope, and it can do `MQ(mathFieldSpan)` to use interface version 3 to manipulate the same math field that the above example is using interface versions 1 and 2 to manipulate.
- Internally, registration of public API methods/classes (`MQ.MathField()`, `MQ.StaticMath()`) is more complicated now because `getInterface()` has to create them with a bound interface version and an isolated prototype chain (`mq1` shouldn't be `instanceof` `MQ2.MathField`)

The first breaking change using interface versioning was super easy, though, so that's a good sign: https://github.com/mathquill/mathquill/commit/2f78c8c5b5dd5ed7e4e12692759ffe0d1700e026#diff-8909a7456a5a30d96a556982356b4909

--

Though the changes are hundreds of lines, the net increase in source code is only 32 lines, which is pretty small right?
```
$ git diff --shortstat 09d8dbde723f19e80c8c362cbd0f91081ca37375^..2f78c8c5b5dd5ed7e4e12692759ffe0d1700e026^ src
 8 files changed, 277 insertions(+), 245 deletions(-)
```
(That range is from the commit where we diverge from `dev`, until 2f78c8c5b5dd5ed7e4e12692759ffe0d1700e026 which implements the first interface version check.)