### PR TITLE
Dead keys Safari 6

### DIFF
--- a/src/services/saneKeyboardEvents.util.js
+++ b/src/services/saneKeyboardEvents.util.js
@@ -195,13 +195,17 @@ var saneKeyboardEvents = (function() {
       if (text.length === 1) {
         textarea.val('');
 
-        // Chrome and newer Safari versions trigger compositionend when the dead key
-        // character is removed from the textarea. Older Safari triggers it after the next
-        // keydown event while Firefox triggers it right before the next input event.
-        // Older versions of Safari even breaks if this character is removed, so we have to put
-        // it back in the textarea. These Safari versions also insert a duplicate character to replace
-        // the first one. To make behaviour consistent cross-browser we always consume the
-        // first character and if a duplicate one is detected it is ignored.
+        // We always remove the character from the textarea because on Chrome and newer Safari versions
+        // this triggers compositionend when a dead key has been typed. On Firefox and older Safari versions
+        // it does not trigger however, and older Safari versions will even break if the character is removed.
+        // So, if after we've removed it we're still in 'deadkey' state, we put the character back.
+        // See https://github.com/mathquill/mathquill/issues/205
+        //
+        // After the current input event, Firefox will trigger compositionend and an additional input event which
+        // replaces the first character. Older Safari versions triggers the first input event before the keydown
+        // event for dead keys, followed by compositionend and a second input event which replaces the first
+        // character (this is where it breaks if the first character is suddenly gone). In both these cases we
+        // need to identify duplicate dead key characters (deadkeyChar) and ignore them.
         if (deadkey) {
           textarea.val(text);
           deadkeyChar = text;

--- a/test/unit/saneKeyboardEvents.test.js
+++ b/test/unit/saneKeyboardEvents.test.js
@@ -410,4 +410,40 @@ suite('key', function() {
       el.trigger('input');
     });
   });
+
+  suite('dead keys', function() {
+    var expectedText;
+
+    setup(function() {
+      expectedText = '';
+
+      saneKeyboardEvents(el, {
+        keystroke: noop,
+        typedText: function(text) {
+          assert.equal(text, expectedText);
+        }
+      });
+    });
+
+    test('character consumed and removed at first input event (Chrome and Safari 9)', function() {
+      el.trigger('keypress'); // Needed to bind typedText to checkTextarea.
+      el.val(expectedText = '^');
+      el.trigger('input');
+      assert.equal(el.val(), '');
+    });
+
+    test('character consumed at first input event but removed on the second (Firefox and Safari 6)', function() {
+      el.trigger('keypress'); // Needed to bind typedText to checkTextarea.
+      el.val(expectedText = '^');
+      el.trigger('compositionstart');
+      el.trigger('input');
+      assert.equal(el.val(), expectedText); // The character remains even though consumed
+                                            // to prevent Safari 6 from breaking.
+
+      expectedText = ''; // handler.typedText should receive no text.
+      el.trigger('compositionend');
+      el.trigger('input');
+      assert.equal(el.val(), expectedText); // Character has been removed.
+    });
+  });
 });


### PR DESCRIPTION
Fixes #205.
Might also affect #22.

This affected all dead keys such as ´,`,^,¨,~.

Tested on:
- Safari 6, 7 and 9 (OS X)
- Chrome 48 (Win and OS X)
- Firefox 42 (Win and OS X)
- IE 11
- Edge

Note that currently the Mathquill dev branch does not work in Safari 6 out of the box. Font size 0 set on the textarea (https://github.com/mathquill/mathquill/blob/dev/src/css/textarea.less#L17) prevents any input. We solved this by setting font-size to 1 and moving the hidden text-area offscreen. Don't know if this is a practical solution to implement in Mathquill, but given that the textarea uses absolute positioning it could work.