### PR TITLE
Kill \caret and \underscore

### DIFF
--- a/src/commands/math/advancedSymbols.js
+++ b/src/commands/math/advancedSymbols.js
@@ -218,9 +218,6 @@ LatexCmds['∫'] =
 LatexCmds['int'] =
 LatexCmds.integral = bind(Symbol,'\\int ','<big>&int;</big>');
 
-LatexCmds.caret = bind(VanillaSymbol,'\\text{^}','^');
-LatexCmds.underscore = bind(VanillaSymbol,'\\_','_');
-
 LatexCmds.slash = bind(VanillaSymbol, '/');
 LatexCmds.vert = bind(VanillaSymbol,'|');
 LatexCmds.perp = LatexCmds.perpendicular = bind(VanillaSymbol,'\\perp ','&perp;');


### PR DESCRIPTION
Ugh.

As noted in 0afc6ab on #323, neither of these are real LaTeX commands.

The real LaTeX command for an underscore character is simply `\_`:
  http://mathb.in/52174
That'd be great except that there's no easy way for MathQuill to parse
`\_` differently from plain `_` because the way the parser works,
there's just one registry entry `LatexCmds._` that parses both.

There is no one real LaTeX command for a caret character. This post
suggests 8 ways to show various caret-like characters in real LaTeX:
  http://tex.stackexchange.com/a/77647
Only 4 of those 8 ways work in MathJax, and only one of those 4 is a
normal caret character: http://mathb.in/52187
Only 2 work in KaTeX v0.5.1, and neither are normal caret characters.
The thing that works in MathJax is `\verb`, whose name is short for
"verbatim" and is essentially the LaTeX equivalent of HTML's &lt;pre&gt;,
which is really not worth our time fully implementing (which is why
KaTeX doesn't have it).

Simpler to just have no way of displaying a caret character, like KaTeX.