### PR TITLE
API to enable "fast clicks" on touch devices

### DIFF
--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -94,6 +94,15 @@ var AbstractMathQuill = P(function(_) {
     this.__controller.root.postOrder('reflow');
     return this;
   };
+  _.fastClick = function(target, clientX, clientY) {
+    var ctrlr = this.__controller, root = ctrlr.root;
+    var el = document.elementFromPoint(clientX, clientY);
+    if (!jQuery.contains(root.jQ[0], el)) el = root.jQ[0];
+    ctrlr.seek($(el), clientX + pageXOffset, clientY + pageYOffset);
+  };
+  _.ignoreNextMousedown = function(fn) {
+    this.__controller.cursor.options.ignoreNextMousedown = fn;
+  };
 });
 MathQuill.prototype = AbstractMathQuill.prototype;
 

--- a/src/services/mouse.js
+++ b/src/services/mouse.js
@@ -3,6 +3,7 @@
  *******************************************************/
 
 Controller.open(function(_) {
+  Options.p.ignoreNextMousedown = noop;
   _.delegateMouseEvents = function() {
     var ultimateRootjQ = this.root.jQ;
     //drag-to-select event handling
@@ -11,6 +12,9 @@ Controller.open(function(_) {
       var root = Node.byId[rootjQ.attr(mqBlockId) || ultimateRootjQ.attr(mqBlockId)];
       var ctrlr = root.controller, cursor = ctrlr.cursor, blink = cursor.blink;
       var textareaSpan = ctrlr.textareaSpan, textarea = ctrlr.textarea;
+
+      if (cursor.options.ignoreNextMousedown(e)) return;
+      else cursor.options.ignoreNextMousedown = noop;
 
       var target;
       function mousemove(e) { target = $(e.target); }

--- a/test/visual.html
+++ b/test/visual.html
@@ -76,7 +76,7 @@ td {
   <td><span class="mathquill-static-math">\sqrt{\MathQuillMathField{x^2+y^2}}</span>
 </table>
 
-<p>Clicks/mousedown to drag should work anywhere in the blue box: <div class="math-container" style="border: solid 1px lightblue; height: 5em; width: 15em; line-height: 5em; text-align: center"><span class="mathquill-math-field">a_2 x^2 + a_1 x + a_0 = 0</span></div>
+<p>Touch taps/clicks/mousedown to drag should work anywhere in the blue box: <div class="math-container" style="border: solid 1px lightblue; height: 5em; width: 15em; line-height: 5em; text-align: center; -webkit-tap-highlight-color: rgba(0,0,0,0)"><span class="mathquill-math-field">a_2 x^2 + a_1 x + a_0 = 0</span></div>
 
 <h3>Redrawing</h3>
 <p>
@@ -270,8 +270,21 @@ $(function() {
 
 // test selecting from outside the mathquill editable
 var $mq = $('.math-container .mathquill-math-field');
-$('.math-container').mousedown(function(e) {
-  if (!jQuery.contains($mq[0], e.target)) $mq.triggerHandler(e);
+$('.math-container').on('touchstart', function() {
+  var moved = false;
+  $(this).on('touchmove.tmp', function() { moved = true; })
+  .on('touchend.tmp', function(e) {
+    $(this).off('.tmp');
+    MathQuill($mq[0]).ignoreNextMousedown(function() {
+      return Date.now() < e.timeStamp + 1000;
+    });
+    if (moved) return;
+    var touch = e.originalEvent.changedTouches[0];
+    MathQuill($mq[0]).fastClick(touch.target, touch.clientX, touch.clientY);
+  });
+}).mousedown(function(e) {
+  if (e.target === $mq[0] || $.contains($mq[0], e.target)) return;
+  $mq.triggerHandler(e);
 });
 
 // Selection Tests


### PR DESCRIPTION
Argghhhhh. Want touch swipes to scroll the page, even if they start in
MathQuill (so that it's possible to scroll an expression list filled to
the brim with nothing but MathQuills), but touch taps to place the
cursor. Now, with mouse events, if all you care about is a logical
"click" on the current platform, you just listen for the click event and
the browser will take care of whether a particular sequence of
mousedown-mousemoves-mouseup is a click or not. With touch events,
there's no equivalent logical "tap" event, and while legacy mouse events
do fire if you don't preventDefault() on touchstart, Safari on iOS waits
a glacial ~360ms [1] after a tap in case you're actually doing the
double-tap gesture to zoom in.

[1]: Videos: http://developer.telerik.com/featured/300-ms-click-delay-ios-8/

It get's better. Not only are the legacy mouse events unhelpful, they're
misleading, because there is no way to directly tell them apart from
real mouse events and no way to get them not to fire except calling
preventDefault(), which breaks touch-swipe-to-scroll.

As a result, across the Web there are dozens of blog posts about, and
shitty JS libraries for, "fast clicks", that all disagree on what counts
as a "tap", and also when to ignore a mouse event because it's probably
a legacy one 300ms after a touch event that's already been dealt with.
By far the 2 most-cited "fast click" solutions are Google Developer's
["Fast Buttons"][2] article and FT Labs' [FastClick][3] library; only the
latter ignores taps that are to stop scrolling after a fling, taps where
touchend is >700ms after touchstart, or taps with more than one finger,
but only the former appears to put a time and distance limit on mouse
events to ignore (FastClick just ignores the next one).

[2]: https://web.archive.org/web/20150406091222/https://developers.google.com/mobile/articles/fast_buttons
[3]: https://github.com/ftlabs/fastclick

(Google seems to have lost the original widely-cited "Fast Buttons" article: https://developers.google.com/mobile/articles/fast_buttons )

MathQuill's sponsor, Desmos, has a custom touch events library whose
definition of "tap", and whose strategy for ignoring delayed mouse
events, is different from either of the above. Clearly, this stuff needs
to be decided by the parent application using MathQuill.

So, with heart-wrenching despair, here are 2 new API calls:

- .fastClick(target, clientX, clientY) takes in the touch event info
  and places the cursor like there was a click there

- .ignoreNextMousedown(fn) takes a function that is called on subsequent
  mousedown events, which MathQuill will ignore if true is returned.
  MathQuill stops calling the function once it returns false.
  Meant to be called on touchend before every expected legacy mousedown,
  regardless of whether there was a logical "tap".

--

The test case has a trivial notion of logical "tap", which is if no
touchmoves happen between the touchstart and touchend. Note that it
calls .ignoreNextMousedown() after every touchend, or else sometimes if
you wiggle your finger a little but not much, the logical "tap" won't
happen but Safari on iOS will still fire a legacy mousedown event.

Test case also gained -webkit-tap-highlight-color to to hide the gray
tap highlight box.