### PR TITLE
Fix TextBlock cursor movement bug

### DIFF
--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -170,7 +170,7 @@ var TextBlock = P(Node, function(_, super_) {
   function fuseChildren(self) {
     self.jQ[0].normalize();
 
-    var textPcDom = self.jQ[0].firstChild;
+    var textPcDom = self.jQ.contents().filter(function (i, el) { return el.nodeType === 3; })[0]
     var textPc = TextPiece(textPcDom.data);
     textPc.jQadd(textPcDom);
 

--- a/test/unit/text.test.js
+++ b/test/unit/text.test.js
@@ -53,4 +53,16 @@ suite('text', function() {
     ctrlr.moveRight();
     assertSplit(cursor.jQ, 'abc', null);
   });
+
+  test('does not change latex as the cursor moves around', function() {
+    var block = fromLatex('\\text{x}');
+    var ctrlr = Controller({ __options: 0 }, block);
+    var cursor = ctrlr.cursor.insAtRightEnd(block);
+
+    ctrlr.moveLeft();
+    ctrlr.moveLeft();
+    ctrlr.moveLeft();
+
+    assert.equal(block.latex(), '\\text{x}');
+  });
 });


### PR DESCRIPTION
Continuation of #430 targeted at `master` instead of `dev`.