### PR TITLE
Support for diacritical marks + tilde

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -457,17 +457,6 @@ LatexCmds['√'] = P(MathCommand, function(_, super_) {
   };
 });
 
-var Vec = LatexCmds.vec = P(MathCommand, function(_, super_) {
-  _.ctrlSeq = '\\vec';
-  _.htmlTemplate =
-      '<span class="mq-non-leaf">'
-    +   '<span class="mq-vector-prefix">&rarr;</span>'
-    +   '<span class="mq-vector-stem">&0</span>'
-    + '</span>'
-  ;
-  _.textTemplate = ['vec(', ')'];
-});
-
 var NthRoot =
 LatexCmds.nthroot = P(SquareRoot, function(_, super_) {
   _.htmlTemplate =
@@ -482,6 +471,25 @@ LatexCmds.nthroot = P(SquareRoot, function(_, super_) {
     return '\\sqrt['+this.ends[L].latex()+']{'+this.ends[R].latex()+'}';
   };
 });
+
+var DiacriticAbove = P(MathCommand, function(_, super_) {
+  _.init = function(ctrlSeq, symbol, textTemplate) {
+    var htmlTemplate =
+      '<span class="mq-non-leaf">'
+      +   '<span class="mq-diacritic-above">'+symbol+'</span>'
+      +   '<span class="mq-diacritic-stem">&0</span>'
+      + '</span>'
+    ;
+
+    super_.init.call(this, ctrlSeq, htmlTemplate, textTemplate);
+  };
+});
+
+var Vec =
+LatexCmds.vec = bind(DiacriticAbove, '\\vec', '&rarr;', ['vec(', ')']);
+
+var Tilde =
+LatexCmds.tilde = bind(DiacriticAbove, '\\tilde', '&#126;', ['tilde(', ')']);
 
 function DelimsMixin(_, super_) {
   _.jQadd = function() {

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -271,7 +271,7 @@
     padding-top: 1px;
   }
 
-  .mq-vector-prefix {
+  .mq-diacritic-above {
     display: block;
     text-align: center;
     line-height: .25em;
@@ -279,7 +279,7 @@
     font-size: 0.75em;
   }
 
-  .mq-vector-stem {
+  .mq-diacritic-stem {
     display: block;
   }
 

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -274,13 +274,12 @@
   .mq-diacritic-above {
     display: block;
     text-align: center;
-    line-height: .25em;
-    margin-bottom: -.1em;
-    font-size: 0.75em;
+    line-height: .4em;
   }
 
   .mq-diacritic-stem {
     display: block;
+    text-align: center;
   }
 
   .mq-large-operator {


### PR DESCRIPTION
See discussion in #489. (This is the same PR but targeted at `master` instead of `dev`.)