### PR TITLE
Changed ** in text mode to ^

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -306,7 +306,7 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
     +   '<span class="mq-sup">&0</span>'
     + '</span>'
   ;
-  _.textTemplate = [ '**' ];
+  _.textTemplate = [ '^' ];
   _.finalizeTree = function() {
     this.upInto = this.sup = this.ends[R];
     this.sup.downOutOf = insLeftOfMeUnlessAtEnd;

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -137,9 +137,9 @@ suite('Public API', function() {
       mq.latex('\\div');
       assert.equal(mq.text(), '[/]');
       mq.latex('^{}');
-      assert.equal(mq.text(), '**');
+      assert.equal(mq.text(), '^');
       mq.latex('3^{4}');
-      assert.equal(mq.text(), '3**4');
+      assert.equal(mq.text(), '3^4');
     });
 
     test('.moveToDirEnd(dir)', function() {


### PR DESCRIPTION
^ is a more commonly used way to represent superscript