### PR TITLE
Fix TextBlock cursor movement bug

### DIFF
--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -171,6 +171,10 @@ var TextBlock = P(Node, function(_, super_) {
     self.jQ[0].normalize();
 
     var textPcDom = self.jQ[0].firstChild;
+    pray('only node in TextBlock span is Text node', textPcDom.nodeType === 3);
+    // nodeType === 3 has meant a Text node since ancient times:
+    //   http://reference.sitepoint.com/javascript/Node/nodeType
+
     var textPc = TextPiece(textPcDom.data);
     textPc.jQadd(textPcDom);
 

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -50,16 +50,19 @@ var Cursor = P(Point, function(_) {
   };
 
   _.withDirInsertAt = function(dir, parent, withDir, oppDir) {
-    if (parent !== this.parent && this.parent.blur) this.parent.blur();
+    var oldParent = this.parent;
     this.parent = parent;
     this[dir] = withDir;
     this[-dir] = oppDir;
+    // by contract, .blur() is called after all has been said and done
+    // and the cursor has actually been moved
+    if (oldParent !== parent && oldParent.blur) oldParent.blur();
   };
   _.insDirOf = function(dir, el) {
     prayDirection(dir);
+    this.jQ.insDirOf(dir, el.jQ);
     this.withDirInsertAt(dir, el.parent, el[dir], el);
     this.parent.jQ.addClass('mq-hasCursor');
-    this.jQ.insDirOf(dir, el.jQ);
     return this;
   };
   _.insLeftOf = function(el) { return this.insDirOf(L, el); };
@@ -67,8 +70,8 @@ var Cursor = P(Point, function(_) {
 
   _.insAtDirEnd = function(dir, el) {
     prayDirection(dir);
-    this.withDirInsertAt(dir, el, 0, el.ends[dir]);
     this.jQ.insAtDirEnd(dir, el.jQ);
+    this.withDirInsertAt(dir, el, 0, el.ends[dir]);
     el.focus();
     return this;
   };

--- a/test/unit/text.test.js
+++ b/test/unit/text.test.js
@@ -53,4 +53,16 @@ suite('text', function() {
     ctrlr.moveRight();
     assertSplit(cursor.jQ, 'abc', null);
   });
+
+  test('does not change latex as the cursor moves around', function() {
+    var block = fromLatex('\\text{x}');
+    var ctrlr = Controller({ __options: 0 }, block);
+    var cursor = ctrlr.cursor.insAtRightEnd(block);
+
+    ctrlr.moveLeft();
+    ctrlr.moveLeft();
+    ctrlr.moveLeft();
+
+    assert.equal(block.latex(), '\\text{x}');
+  });
 });


### PR DESCRIPTION
Fix #429 can't move cursor left out of TextBlock.

Enforce contract that by the time `.blur()` on a node is being called, all
has been said and done and the cursor has already been moved out of the
node.

Note that the main other case that calls `.blur()` is intentional blur,
where already the cursor is hidden before `.blur()` is called on its
parent:
https://github.com/mathquill/mathquill/blob/c103063a62c85127c7eca33fa153a78a3dab6be5/src/services/focusBlur.js#L32

Supersedes and closes #516 and #430.