### PR TITLE
Feature: .registerEmbed()

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ expose:
     latex: function() { return '\customEmbed'; }
   }
   ```
+* `ᴇxᴘᴇʀɪᴍᴇɴᴛᴀʟ` `.registerEmbed('name', function(id){return options})` allows MathQuill to parse custom embedded objects from latex, where `options` is an object like the one defined above in `.dropEmbedded`. This will parse the following latex into the embedded object you defined: `\embed{name}[id]}`
 
 [on `textarea`s]: http://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-48880622
 [on `input`s]: http://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-34677168

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -777,7 +777,11 @@ var Embed = LatexCmds.embed = P(Symbol, function(_, super_) {
     var self = this;
       string = Parser.string, regex = Parser.regex, succeed = Parser.succeed;
     return string('{').then(regex(/^[a-z][a-z0-9]*/i)).skip(string('}'))
-      .map(function(name) { return self.setOptions(EMBEDS[name]); })
+      .then(function(name) {
+        return latexMathParser.optBlock.or(succeed()).map(function(data) {
+          return self.setOptions(EMBEDS[name](data));
+        });
+      })
     ;
   };
 });

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -758,12 +758,26 @@ LatexCmds.MathQuillMathField = P(MathCommand, function(_, super_) {
   _.text = function(){ return this.ends[L].text(); };
 });
 
-var Embed = P(Symbol, function(_, super_) {
-  _.init = function(options) {
-    super_.init.call(this);
+// Embed arbitrary things
+// Probably the closest DOM analogue would be an iframe?
+// From MathQuill's perspective, it's a Symbol, it can be
+// anywhere and the cursor can go around it but never in it.
+// Create by calling public API method .dropEmbedded(),
+// or by calling the global public API method .registerEmbed()
+// and rendering LaTeX like \embed{registeredName} (see test).
+var Embed = LatexCmds.embed = P(Symbol, function(_, super_) {
+  _.setOptions = function(options) {
     function noop () { return ""; }
     this.text = options.text || noop;
     this.htmlTemplate = options.htmlString || "";
     this.latex = options.latex || noop;
-  }
+    return this;
+  };
+  _.parser = function() {
+    var self = this;
+      string = Parser.string, regex = Parser.regex, succeed = Parser.succeed;
+    return string('{').then(regex(/^[a-z][a-z0-9]*/i)).skip(string('}'))
+      .map(function(name) { return self.setOptions(EMBEDS[name]); })
+    ;
+  };
 });

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -2,7 +2,7 @@
  * The publicly exposed MathQuill API.
  ********************************************************/
 
-var API = {}, Options = P(), optionProcessors = {}, Progenote = P();
+var API = {}, Options = P(), optionProcessors = {}, Progenote = P(), EMBEDS = {};
 
 /**
  * Interface Versioning (#459, #495) to allow us to virtually guarantee
@@ -88,6 +88,12 @@ function getInterface(v) {
     }
   }
   MQ.config = function(opts) { config(Options.p, opts); return this; };
+  MQ.registerEmbed = function(name, options) {
+    if (!/^[a-z][a-z0-9]*$/i.test(name)) {
+      throw 'Embed name must start with letter and be only letters and digits';
+    }
+    EMBEDS[name] = options;
+  };
 
   var AbstractMathQuill = APIClasses.AbstractMathQuill = P(Progenote, function(_) {
     _.init = function(ctrlr) {
@@ -204,9 +210,9 @@ function getInterface(v) {
 
       var el = document.elementFromPoint(clientX, clientY);
       this.__controller.seek($(el), pageX, pageY);
-      var cmd = Embed(options);
+      var cmd = Embed().setOptions(options);
       cmd.createLeftOf(this.__controller.cursor);
-    }
+    };
   });
   MQ.EditableField = function() { throw "wtf don't call me, I'm 'abstract'"; };
   MQ.EditableField.prototype = APIClasses.EditableField.prototype;

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -754,16 +754,16 @@ suite('Public API', function() {
 
   suite('dropEmbedded', function() {
     test('inserts into empty', function() {
-      var mq = MQ.MathField($('<span>').appendTo('#mock')[0], {});
+      var mq = MQ.MathField($('<span>').appendTo('#mock')[0]);
       mq.dropEmbedded(0, 0, {
-       htmlString: '<span class="test-span">EMBED HTML FN</span>',
-       text: function () { return "embeded text" },
-       latex: function () { return "embeded latex" }
+        htmlString: '<span class="embedded-html"></span>',
+        text: function () { return "embedded text" },
+        latex: function () { return "embedded latex" }
       });
 
-      assert.ok(jQuery('.test-span').length);
-      assert.equal(mq.text(), "embeded text");
-      assert.equal(mq.latex(), "embeded latex");
+      assert.ok(jQuery('.embedded-html').length);
+      assert.equal(mq.text(), "embedded text");
+      assert.equal(mq.latex(), "embedded latex");
 
       $(mq.el()).remove();
     });
@@ -774,7 +774,7 @@ suite('Public API', function() {
       var filler = $('<div>').height(windowHeight);
       filler.insertBefore('#mock');
 
-      var mq = MQ.MathField($('<span>').appendTo('#mock')[0], {});
+      var mq = MQ.MathField($('<span>').appendTo('#mock')[0]);
       mq.typedText("mmmm/mmmm");
       var pos = $(mq.el()).offset();
       var mqx = pos.left;
@@ -783,14 +783,14 @@ suite('Public API', function() {
       mq.el().scrollIntoView();
 
       mq.dropEmbedded(mqx + 30, mqy + 40, {
-       htmlString: '<span class="test-span">EMBED HTML FN</span>',
-       text: function () { return "embeded text" },
-       latex: function () { return "embeded latex" }
+        htmlString: '<span class="embedded-html"></span>',
+        text: function () { return "embedded text" },
+        latex: function () { return "embedded latex" }
       });
 
-      assert.ok(jQuery('.test-span').length);
-      assert.equal(mq.text(), "(m*m*m*m)/(m*m*embeded text*m*m)");
-      assert.equal(mq.latex(), "\\frac{mmmm}{mmembeded latexmm}");
+      assert.ok(jQuery('.embedded-html').length);
+      assert.equal(mq.text(), "(m*m*m*m)/(m*m*embedded text*m*m)");
+      assert.equal(mq.latex(), "\\frac{mmmm}{mmembedded latexmm}");
 
       filler.remove();
       $(mq.el()).remove();

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -798,12 +798,27 @@ suite('Public API', function() {
   });
 
   test('.registerEmbed()', function() {
-    MQ.registerEmbed('thing', {
-      htmlString: '<span class="embedded-html"></span>',
-      text: function () { return "embedded text" },
-      latex: function () { return "embedded latex" }
+    var calls = 0, data;
+    MQ.registerEmbed('thing', function(data_) {
+      calls += 1;
+      data = data_;
+      return {
+        htmlString: '<span class="embedded-html"></span>',
+        text: function () { return "embedded text" },
+        latex: function () { return "embedded latex" }
+      };
     });
     var mq = MQ.MathField($('<span>\\sqrt{\\embed{thing}}</span>').appendTo('#mock')[0]);
+    assert.equal(calls, 1);
+    assert.equal(data, undefined);
+
+    assert.ok(jQuery('.embedded-html').length);
+    assert.equal(mq.text(), "sqrt(embedded text)");
+    assert.equal(mq.latex(), "\\sqrt{embedded latex}");
+
+    mq.latex('\\sqrt{\\embed{thing}[data]}');
+    assert.equal(calls, 2);
+    assert.equal(data, 'data');
 
     assert.ok(jQuery('.embedded-html').length);
     assert.equal(mq.text(), "sqrt(embedded text)");

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -796,4 +796,19 @@ suite('Public API', function() {
       $(mq.el()).remove();
     });
   });
+
+  test('.registerEmbed()', function() {
+    MQ.registerEmbed('thing', {
+      htmlString: '<span class="embedded-html"></span>',
+      text: function () { return "embedded text" },
+      latex: function () { return "embedded latex" }
+    });
+    var mq = MQ.MathField($('<span>\\sqrt{\\embed{thing}}</span>').appendTo('#mock')[0]);
+
+    assert.ok(jQuery('.embedded-html').length);
+    assert.equal(mq.text(), "sqrt(embedded text)");
+    assert.equal(mq.latex(), "\\sqrt{embedded latex}");
+
+    $(mq.el()).remove();
+  });
 });


### PR DESCRIPTION
<s>Usage (copied from test case):</s> (outdated, see below)
```js
    MQ.registerEmbed('thing', {
      htmlString: '<span class="embedded-html"></span>',
      text: function () { return "embedded text" },
      latex: function () { return "embedded latex" }
    });

    var mq = MQ.MathField($('<span>\\sqrt{\\embed{thing}}</span>').appendTo('#mock')[0]);
 
    assert.ok(jQuery('.embedded-html').length);
    assert.equal(mq.text(), "sqrt(embedded text)");
    assert.equal(mq.latex(), "\\sqrt{embedded latex}");
 ```