### PR TITLE
[LRN] Add InertMath: non-editable with no mouse events or cursor

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -466,3 +466,18 @@ API.MathField = function(APIClasses) {
     };
   });
 };
+
+/**
+ * This is almost the same as StaticMath, except we don't
+ * bind any mouse events (which give us selectability and move
+ * around an invisible cursor).
+ *
+ * Otherwise, if you have a button that contains a rendered StaticMath symbol
+ * which causes something to be written into an editable mathquill,
+ * the mouseup event will hijack focus.
+ */
+MathQuill.InertMath = APIFnFor(P(AbstractMathQuill, function(_) {
+  _.init = function(el, opts) {
+    this.initRoot(MathBlock(), el.addClass('mq-math-mode'), opts);
+  };
+}));

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -49,6 +49,12 @@ suite('Public API', function() {
       assert.ok(rootBlock.hasClass('mq-empty'));
       assert.ok(!rootBlock.hasClass('mq-hasCursor'));
     });
+
+    test('MathQuill.InertMath', function() {
+      var el = $('<span>x</span>');
+      MathQuill.InertMath(el[0]);
+      assert.ok(el.find('var').length);
+    });
   });
 
   suite('mathquill-basic', function() {


### PR DESCRIPTION
Used to render keyboard buttons so that they don't hijack
focus when they're mousdown'ed.

Conflicts:
	src/commands/math.js