### PR TITLE
[LRN] Allow direct entry of $ (dollar sign)

### DIFF
--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -287,7 +287,6 @@ var TextPiece = P(Node, function(_, super_) {
   };
 });
 
-CharCmds.$ =
 LatexCmds.text =
 LatexCmds.textnormal =
 LatexCmds.textrm =

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -56,6 +56,11 @@ suite('typing with auto-replaces', function() {
       mq.typedText('\\asdf+');
       assertLatex('\\text{asdf}+');
     });
+
+    test('dollar sign', function() {
+      mq.typedText('$');
+      assertLatex('\\$');
+    });
   });
 
   suite('auto-expanding parens', function() {


### PR DESCRIPTION
By removing the binding that creates a text block
when $ is pressed.