### PR TITLE
Add getSelection API function

### DIFF
--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -179,6 +179,13 @@ function getInterface(v) {
       this.__controller.cursor.clearSelection();
       return this;
     };
+    _.getSelection = function() {
+      if (this.__controller.cursor.selection) {
+        return this.__controller.cursor.selection.join('latex');
+      } else {
+	return null;
+      }
+    };
 
     _.moveToDirEnd = function(dir) {
       this.__controller.notify('move').cursor.insAtDirEnd(dir, this.__controller.root);


### PR DESCRIPTION
I was trying to figure out how to use the API to wrap the current selection with an expression larger than one symbol, like wrapping the selection in `\\sin\right( [selection] \left) `, and couldn't figure a way.  

This PR adds a new API function to return the current selection will allow users to utilize the current selection, then update it with an API .write() command.