### PR TITLE
[LRN] Add InertMath: non-editable with no mouse events or cursor

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -466,3 +466,22 @@ API.MathField = function(APIClasses) {
     };
   });
 };
+
+/**
+ * This is almost the same as StaticMath, except we don't
+ * bind any mouse events (which give us selectability and move
+ * around an invisible cursor).
+ *
+ * Otherwise, if you have a button that contains a rendered StaticMath symbol
+ * which causes something to be written into an editable mathquill,
+ * the mouseup event will hijack focus.
+ */
+API.InertMath = function(APIClasses) {
+  return P(APIClasses.AbstractMathQuill, function(_, super_) {
+    this.RootBlock = MathBlock;
+    _.__mathquillify = function() {
+      super_.__mathquillify.call(this, 'mq-math-mode');
+      return this;
+    };
+  });
+};

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -483,5 +483,18 @@ API.InertMath = function(APIClasses) {
       super_.__mathquillify.call(this, 'mq-math-mode');
       return this;
     };
+    _.init = function() {
+      super_.init.apply(this, arguments);
+      this.__controller.root.postOrder(
+        'registerInnerField', this.innerFields = [], APIClasses.MathField);
+    };
+    _.latex = function() {
+      var returned = super_.latex.apply(this, arguments);
+      if (arguments.length > 0) {
+        this.__controller.root.postOrder(
+          'registerInnerField', this.innerFields = [], APIClasses.MathField);
+      }
+      return returned;
+    };
   });
 };

--- a/test/demo.html
+++ b/test/demo.html
@@ -61,6 +61,7 @@ code span {
 
 <p>
   Insert using inertMath <button class="insert-trigger" data-latex="\sqrt{4}"><span class="mathquill-inert-math">\sqrt{4}</span></button> inside formulas below:<br>
+  Insert using inertMath with innerFields <button class="insert-trigger" data-latex="\sqrt{4}\frac{1}{\MathQuillMathField{\sqrt{4}}}"><span class="mathquill-inert-math">\sqrt{4}\frac{1}{\MathQuillMathField{\sqrt{4}}}</span></button> inside formulas below:<br>
   <span class="mathquill-math-field"></span><br>
   or here: <span class="mathquill-math-field">\frac{2}{3}</span><br>
   Now insert using staticMath <button class="insert-trigger" data-latex="\sqrt{4}"><span class="mathquill-static-math">\sqrt{4}</span></button> to the same formulas above, and notice that you can select all the text within a button.<br>

--- a/test/demo.html
+++ b/test/demo.html
@@ -59,6 +59,13 @@ code span {
 
 <p>This button runs the JavaScript code written on it to MathQuill-ify the following <code>&lt;span&gt;</code> element into an editable math textbox: <button onclick="$(this).text('MQ(this.nextSibling).revert()'); MQ.MathField(this.nextSibling); var orig = arguments.callee; this.onclick = function(){ $(this).text('MQ.MathField(this.nextSibling)'); MQ(this.nextSibling).revert(); this.onclick = orig; };">MQ.MathField(this.nextSibling)</button><span>\frac{d}{dx}\sqrt{x} = \frac{d}{dx}x^{\frac{1}{2}} = \frac{1}{2}x^{-\frac{1}{2}} = \frac{1}{2\sqrt{x}}</span></p>
 
+<p>
+  Insert using inertMath <button class="insert-trigger" data-latex="\sqrt{4}"><span class="mathquill-inert-math">\sqrt{4}</span></button> inside formulas below:<br>
+  <span class="mathquill-math-field"></span><br>
+  or here: <span class="mathquill-math-field">\frac{2}{3}</span><br>
+  Now insert using staticMath <button class="insert-trigger" data-latex="\sqrt{4}"><span class="mathquill-static-math">\sqrt{4}</span></button> to the same formulas above, and notice that you can select all the text within a button.<br>
+</p>
+
 </div>
 <script type="text/javascript" src="support/jquery-1.7.2.js"></script>
 <script type="text/javascript" src="../build/mathquill.js"></script>
@@ -69,6 +76,7 @@ MQ = MathQuill.getInterface(MathQuill.getInterface.MAX);
 //elements according to their CSS class.
 $(function() {
   $('.mathquill-static-math').each(function() { MQ.StaticMath(this); });
+  $('.mathquill-inert-math').each(function() { MQ.InertMath(this); });
   $('.mathquill-math-field').each(function() { MQ.MathField(this); });
   $('.mathquill-text-field').each(function() { MQ.TextField(this); });
 });
@@ -114,6 +122,14 @@ $(function() {
 
   if(location.hash && location.hash.length > 1)
     latexMath.latex(decodeURIComponent(location.hash.slice(1))).focus();
+});
+
+$(".insert-trigger").click(function () {
+  var latex = $(this).data('latex');
+  $(this).parent().find('.mathquill-math-field').each(function () {
+    var mathquill = MQ(this);
+    mathquill.write(latex);
+  });
 });
 
 //print the HTML source as an indented tree. TODO: syntax highlight

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -49,6 +49,12 @@ suite('Public API', function() {
       assert.ok(rootBlock.hasClass('mq-empty'));
       assert.ok(!rootBlock.hasClass('mq-hasCursor'));
     });
+
+    test('MathQuill.InertMath', function() {
+      var el = $('<span>x</span>');
+      MathQuill.InertMath(el[0]);
+      assert.ok(el.find('var').length);
+    });
   });
 
   suite('mathquill-basic', function() {


### PR DESCRIPTION
Used to render keyboard buttons so that they don't hijack
focus when they're mousdown'ed.

Conflicts:
    src/commands/math.js
