### PR TITLE
Add keyboard passthrough for substituteTextarea

### DIFF
--- a/src/services/saneKeyboardEvents.util.js
+++ b/src/services/saneKeyboardEvents.util.js
@@ -166,6 +166,8 @@ var saneKeyboardEvents = (function() {
 	  var chr = String.fromCharCode(which);
 	  if (chr=='C') {
 	    onSoftCopy();
+	  } else if (chr=='X') {
+	    onSoftCut();
 	  } else if (chr=='V') {
 	    onSoftPaste();
 	  } else {
@@ -180,10 +182,18 @@ var saneKeyboardEvents = (function() {
       	handleKey();
       }
     }
-    function onSoftCopy(evt) {
-      window.MathQuillClipboard = handlers.cursor.selection.join('latex');
+    function onSoftCopy() {
+      if (handlers.cursor.selection) {
+        window.MathQuillClipboard = handlers.cursor.selection.join('latex');
+      }
     }
-    function onSoftPaste(evt) {
+    function onSoftCut() {
+      if (handlers.cursor.selection) {
+        window.MathQuillClipboard = handlers.cursor.selection.join('latex');
+        handlers.cursor.deleteSelection();
+      }
+    }
+    function onSoftPaste() {
       if (window.MathQuillClipboard) {
         handlers.writeLatex(window.MathQuillClipboard);
       }

--- a/src/services/saneKeyboardEvents.util.js
+++ b/src/services/saneKeyboardEvents.util.js
@@ -162,7 +162,7 @@ var saneKeyboardEvents = (function() {
         var keyVal = KEY_VALUES[which];
        
 	//handle copy/paste keystrokes, control sequences
-	if (e.ctrlKey) {
+	if (e.ctrlKey || (e.originalEvent && e.originalEvent.metaKey)) {
 	  var chr = String.fromCharCode(which);
 	  if (chr=='C') {
 	    onSoftCopy();


### PR DESCRIPTION
When using substituteTextarea with a <span tabindex="0"> element to prevent a mobile onscreen keyboard from displaying, the downside is that the regular keyboard doesn't work either.

This PR adds another config option: `keyboardPassthrough: true`, which listens for keypresses on the span element and passes them through to the MathField's keystroke handler. This seems to work fine for basic characters and control sequences.

For Ctrl-C, Ctrl-X, and Ctrl-V copy/paste, to avoid compatibility issues an internal clipboard is used, allowing copy/pasting within and between MathQuill areas, but not from/to other textfields. 

I don't know if this is the best approach, but it seems to work OK.