### PR TITLE
Fix optional data argument to \embed

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -778,9 +778,13 @@ var Embed = LatexCmds.embed = P(Symbol, function(_, super_) {
       string = Parser.string, regex = Parser.regex, succeed = Parser.succeed;
     return string('{').then(regex(/^[a-z][a-z0-9]*/i)).skip(string('}'))
       .then(function(name) {
-        return latexMathParser.optBlock.or(succeed()).map(function(data) {
-          return self.setOptions(EMBEDS[name](data));
-        });
+        // the chars allowed in the optional data block are arbitrary other than
+        // excluding curly braces and square brackets (which'd be too confusing)
+        return string('[').then(regex(/^[-\w\s]*/)).skip(string(']'))
+          .or(succeed()).map(function(data) {
+            return self.setOptions(EMBEDS[name](data));
+          })
+        ;
       })
     ;
   };


### PR DESCRIPTION
Somehow test was broken and neither of us noticed?

Be a little more forgiving for data than for embed name, allow letters
digits dashes underscores and whitespace