### PR TITLE
[LRN] Add `empty()` public method and `clear()` as its alias

### DIFF
--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -158,6 +158,10 @@ function getInterface(v) {
       if (this.__controller.blurred) this.__controller.cursor.hide().parent.blur();
       return this;
     };
+    _.empty = _.clear = function() {
+      this.select().__controller.backspace();
+      return this;
+    };
     _.cmd = function(cmd) {
       var ctrlr = this.__controller.notify(), cursor = ctrlr.cursor;
       if (/^\\[a-z]+$/i.test(cmd)) {

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -114,7 +114,7 @@ suite('Public API', function() {
       mq.latex('x+y');
       assert.equal(mq.html(), '<var>x</var><span class="mq-binary-operator">+</span><var>y</var>');
     });
-    
+
     test('.text() with incomplete commands', function() {
       assert.equal(mq.text(), '');
       mq.typedText('\\');
@@ -124,7 +124,7 @@ suite('Public API', function() {
       mq.typedText('qrt');
       assert.equal(mq.text(), '\\sqrt');
     });
-    
+
     test('.text() with complete commands', function() {
       mq.latex('\\sqrt{}');
       assert.equal(mq.text(), 'sqrt()');
@@ -154,6 +154,18 @@ suite('Public API', function() {
       mq.moveToRightEnd();
       assert.equal(mq.__controller.cursor[L].ctrlSeq, '0');
       assert.equal(mq.__controller.cursor[R], 0);
+    });
+
+    test('.clear()', function() {
+      mq.latex('xyz');
+      mq.clear();
+      assert.equal(mq.latex(), '');
+    });
+
+    test('.empty()', function() {
+      mq.latex('xyz');
+      mq.empty();
+      assert.equal(mq.latex(), '');
     });
   });
 


### PR DESCRIPTION
Removes all math from the editable field

Conflicts:
    src/commands/math.js
    src/commands/math/commands.js
    src/publicapi.js
