### PR TITLE
[LRN] add \mathbb{} font with support for those letters: C, H, N, P, …

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -70,12 +70,80 @@ var Style = P(MathCommand, function(_, super_) {
   };
 });
 
+var DoubleStruck = P(Variable, function(_, super_) {
+  _.symbols = {
+    C: "&#8450;",
+    H: "&#8461;",
+    N: "&#8469;",
+    P: "&#8473;",
+    Q: "&#8474;",
+    R: "&#8477;",
+    Z: "&#8484;"
+  };
+  _.init = function(ch) {
+    var inner = ch;
+    if (this.symbols[ch]) {
+      inner = '<span class="mq-original">' + ch + '</span>' + this.symbols[ch];
+    }
+    super_.init.call(this, ch, inner);
+  };
+});
+
 //fonts
 LatexCmds.mathrm = bind(Style, '\\mathrm', 'span', 'class="mq-roman mq-font"');
 LatexCmds.mathit = bind(Style, '\\mathit', 'i', 'class="mq-font"');
 LatexCmds.mathbf = bind(Style, '\\mathbf', 'b', 'class="mq-font"');
 LatexCmds.mathsf = bind(Style, '\\mathsf', 'span', 'class="mq-sans-serif mq-font"');
 LatexCmds.mathtt = bind(Style, '\\mathtt', 'span', 'class="mq-monospace mq-font"');
+LatexCmds.mathbb = P(MathCommand, function(_, super_) {
+  _.init = function() {
+    super_.init.call(this, '\\mathbb', '<span class="mq-mathbb mq-font">&0</span>');
+  };
+  _.adopt = function() {
+    this.eachChild(function(child) {
+      if (!child.writeOverride) {
+        var origWrite = child.write,
+          origDeleteOutOf = child.deleteOutOf;
+        child.write = child.writeOverride = function(cursor, ch, replacedFragment) {
+          var cmd;
+          if (DoubleStruck.prototype.symbols[ch]) {
+            cmd = DoubleStruck(ch);
+            if (replacedFragment) cmd.replaces(replacedFragment);
+            cmd.createLeftOf(cursor);
+          } else {
+            return origWrite.apply(child, arguments);
+          }
+        };
+        child.deleteOutOf = function(dir, cursor) {
+          var variables = [];
+          child.eachChild(function(grand) {
+            var ch = grand.ctrlSeq;
+            variables.push(Variable(ch).adopt(child, child.ends[R], 0));
+            grand.remove();
+          });
+          if (variables.length) cursor[R] = variables[0];
+          child.jQize().appendTo(child.jQ);
+          return origDeleteOutOf.apply(child, arguments);
+        };
+      }
+    });
+    return super_.adopt.apply(this, arguments);
+  };
+  _.finalizeTree = function() {
+    this.eachChild(function(child) {
+      child.eachChild(function(grand) {
+        var ch = grand.ctrlSeq, NewCmd = Variable;
+        if (DoubleStruck.prototype.symbols[ch]) {
+          NewCmd = DoubleStruck;
+        }
+        NewCmd(ch).adopt(child, child.ends[R], 0);
+        grand.remove();
+      });
+      child.jQize().appendTo(child.jQ);
+    });
+  };
+});
+
 //text-decoration
 LatexCmds.underline = bind(Style, '\\underline', 'span', 'class="mq-non-leaf mq-underline"');
 LatexCmds.overline = LatexCmds.bar = bind(Style, '\\overline', 'span', 'class="mq-non-leaf mq-overline"');

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -95,6 +95,10 @@
     font-family: monospace, Symbola, serif;
   }
 
+  .mq-mathbb .mq-original {
+    display: none;
+  }
+
   .mq-overline {
     border-top: 1px solid black;
     margin-top: 1px;

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -107,6 +107,10 @@ suite('latex', function() {
     assertParsesLatex('\\circledot ', '\\odot ');
   });
 
+  test('miscellaneous symbols', function () {
+    assertParsesLatex('\\mathbb{AZ09}');
+  });
+
   suite('public API', function() {
     var mq;
     setup(function() {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1046,4 +1046,45 @@ suite('typing with auto-replaces', function() {
       assert.equal(mq.typedText('n').latex(), 'x^{2n}');
     });
   });
+
+  suite('Mathbb font', function() {
+    function assertVarCount(len) {
+      assert.equal($(mq.el()).find('var').length, len);
+    }
+
+    function assertContains(text, str) {
+      assert.ok(text.indexOf(str) > -1, 'expected string "' + text + '" to contain "' + str + '"');
+    }
+
+    test('can be typed in', function() {
+      mq.typedText('\\mathbb').keystroke('Spacebar').typedText('ABCXYZ');
+      assertLatex('\\mathbb{ABCXYZ}');
+      assertVarCount('ABCXYZ'.length);
+    });
+
+    test('can be directly set', function() {
+      mq.latex('\\mathbb{ABCXYZ}');
+      assertLatex('\\mathbb{ABCXYZ}');
+      assertVarCount('ABCXYZ'.length);
+    });
+
+    test('adds doublestruck characters', function() {
+      mq.latex('\\mathbb{CHNPQRZ}');
+      text = mq.el().textContent;
+      assertContains(text, 'ℂ');
+      assertContains(text, 'ℍ');
+      assertContains(text, 'ℤ');
+    });
+
+    test('can deleteOutOf without throwing error', function() {
+      mq.latex('\\mathbb{H}');
+      mq.keystroke('Left Left Backspace Backspace');
+    });
+
+    test('reverts to normal text on deleteOutOf', function() {
+      mq.latex('\\mathbb{CH}');
+      mq.keystroke('Left Left Left Backspace');
+      assertLatex('CH');
+    });
+  });
 });


### PR DESCRIPTION
…Q, R, Z

Conflicts:
	src/commands/math/commands.js
	src/css/math.less
	test/unit/latex.test.js
	test/unit/typing.test.js