### PR TITLE
[LRN] Add chemical bond symbols from mhchem

### DIFF
--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -317,6 +317,84 @@ LatexCmds.uppercase =
 LatexCmds.lowercase =
   makeTextBlock('\\lowercase', 'span', 'style="text-transform:lowercase" class="mq-text-mode"');
 
+// Chemical bonds in mhchem format
+LatexCmds.ce = P(TextBlock, function(_, super_) {
+  function wrapDots(html) {
+    return html.replace(/(&middot;)/g, '<span class="mq-bond-dot">$1</span>');
+  }
+  _.bondHtml = {
+    '-': '-',
+    '=': '=',
+    '#': '&#8801;',
+    '...': wrapDots('&middot;&middot;&middot;'),
+    '....': wrapDots('&middot;&middot;&middot;&middot;'),
+    '->': '&#8594;',
+    '<-': '&#8592;',
+  };
+  _.bond = null;
+  _.ctrlSeq = '\\ce';
+  _.regex = /^(\\bond{([^{}]+?)})/i;
+  _.jQadd = function(jQ) {
+    super_.jQadd.call(this, jQ);
+    if (this.bond) this.jQaddBond();
+  };
+  _.jQaddBond = function() {
+    this.jQ.empty()
+      .removeClass('mq-text-mode')
+      .addClass('mq-ce mq-bond')
+      .html(this.bondHtml[this.bond]);
+  };
+  _.parseBond = function (contents) {
+    if (contents.length) { 
+      this.bond = this.regex.exec(contents) &&
+        contents.replace(this.regex, '$2');
+    }
+    if (!this.bondHtml[this.bond]) this.bond = null;
+  };
+  _.latex = function() {
+    return (
+      '\\ce{' 
+      + (this.bond ? '\\bond{' + this.bond + '}' : this.textContents())
+      + '}'
+    );
+  };
+  _.text = function() { return this.bond || this.textContents(); };
+  _.isEmpty = function() { return !this.text(); };
+  _.moveOutOf = function(dir, cursor) {
+    if (!this.bond) {
+      this.parseEnteredText(dir, cursor);
+    }
+    cursor.insDirOf(dir, this); 
+  };
+  _.parseEnteredText = function(dir, cursor) {
+    var adj = cursor[-dir];
+    this.parseBond(this.textContents());
+    if (this.bond) {
+      while (adj instanceof TextPiece) {
+        adj = adj.remove()[-dir];
+      }
+      cursor[-dir] = this;
+      this.jQaddBond();
+    }
+  };
+  _.parser = function() {
+    var block = this;
+    var string = Parser.string;
+    var regex = Parser.regex;
+    var optWhitespace = Parser.optWhitespace;
+    return optWhitespace
+      .then(string('{')).then(regex(this.regex)).skip(string('}'))
+      .map(function(text) {
+        block.parseBond(text);
+        return block;
+      })
+    ;
+  };
+  _.moveTowards = Symbol.prototype.moveTowards;
+  _.deleteTowards = Symbol.prototype.deleteTowards;
+  _.seek = Symbol.prototype.seek;
+  _.blur = MathBlock.prototype.blur;
+});
 
 var RootMathCommand = P(MathCommand, function(_, super_) {
   _.init = function(cursor) {

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -298,6 +298,13 @@
     }
   }
 
+  .mq-ce.mq-bond {
+    margin: auto 0.1em;
+
+    .mq-bond-dot {
+      margin: auto 0.05em;
+    }
+  }
 
   &, .mq-editable-field {
     cursor: text;

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -465,6 +465,9 @@ suite('Public API', function() {
         assertPaste('1+\\text{lol}+2');
         assertPaste('\\frac{\\text{apples}}{\\text{oranges}}');
       });
+      test('\\ce{\\bond{...}}', function() {
+        assertPaste('\\ce{\\bond{...}}');
+      });
       test('selection', function(done) {
         mq.latex('x^2').select();
         setTimeout(function() {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1046,4 +1046,39 @@ suite('typing with auto-replaces', function() {
       assert.equal(mq.typedText('n').latex(), 'x^{2n}');
     });
   });
+
+  suite('Chemistry Symbols', function() {
+    test('add bond via mq.write', function() {
+      mq.write('\\ce{\\bond{#}}');
+      assertLatex('\\ce{\\bond{#}}');
+    });
+    test('invalid bond types not added', function() {
+      mq.write('\\ce{\\bond{x}}');
+      assertLatex('\\ce{}');
+    });
+    test('move cursor over each bond as single character', function() {
+      mq.write('\\pi\\ce{\\bond{#}}');
+      mq.keystroke('Left').typedText('\\sigma');
+      assertLatex('\\pi\\sigma\\ce{\\bond{#}}');
+    });
+    test('backspace deletes each bond as single character', function() {
+      mq.write('1\\ce{\\bond{#}}2');
+      mq.keystroke('Backspace Backspace');
+      assertLatex('1');
+    });
+    test('dotted bond maps to correct characters', function() {
+      mq.write('\\ce{\\bond{....}}');
+      assert.equal("····", $(mq.el()).text());
+    });
+    test('multiple bonds can be written', function() {
+      mq.write('\\ce{\\bond{....}}\\ce{\\bond{<-}}');
+      assertLatex('\\ce{\\bond{....}}\\ce{\\bond{<-}}');
+    });
+    test('cursor seeks to just outside bond symbol', function() {
+      mq.write('\\ce{\\bond{#}}\\sigma');
+      $(mq.el()).find('.mq-ce').trigger('mousedown');
+      mq.typedText('\\pi');
+      assertLatex('\\ce{\\bond{#}}\\pi\\sigma');
+    });
+  });
 });


### PR DESCRIPTION
These are standalone symbols - only the bond can be wrapped in \ce as
nothing else will be recognised.

\ce{\bond{-}}
\ce{\bond{=}}
\ce{\bond{#}}
\ce{\bond{...}}
\ce{\bond{....}}
\ce{\bond{->}}
\ce{\bond{<-}}

Conflicts:
	src/css/math.less
	test/unit/typing.test.js