### PR TITLE
Fix variables raised to exponents

### DIFF
--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -29,7 +29,7 @@ var Variable = P(Symbol, function(_, super_) {
         && this[L].ctrlSeq !== "\\ ")
       text = '*' + text;
     if (this[R] && !(this[R] instanceof BinaryOperator)
-        && !(this[R].ctrlSeq === '^'))
+        && !(this[R] instanceof SupSub))
       text += '*';
     return text;
   };

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -144,6 +144,8 @@ suite('Public API', function() {
       assert.equal(mq.text(), '3^4');
       mq.latex('3x+\\ 4');
       assert.equal(mq.text(), '3*x+ 4');
+      mq.latex('x^2');
+      assert.equal(mq.text(), 'x**2')
     });
 
     test('.moveToDirEnd(dir)', function() {

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -145,7 +145,7 @@ suite('Public API', function() {
       mq.latex('3x+\\ 4');
       assert.equal(mq.text(), '3*x+ 4');
       mq.latex('x^2');
-      assert.equal(mq.text(), 'x**2')
+      assert.equal(mq.text(), 'x^2')
     });
 
     test('.moveToDirEnd(dir)', function() {


### PR DESCRIPTION
Before, variables raised to exponents would insert three stars (`x***2`) instead of two as intended (`x**2`). It looks like someone tried to implement this before (or did, and it broke), but now it works as intended. I also added a test case in case it breaks again in the future.