### PR TITLE
Setting to map a sequence of typed letters to an _arbitrary_ control sequence

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ var mathField = MQ.MathField(el[0], {
   charsThatBreakOutOfSupSub: '+-=<>',
   autoSubscriptNumerals: true,
   autoCommands: 'pi theta sqrt sum',
+  autoCommandsMapping: {'sqrt': 'nthroot'},
   autoOperatorNames: 'sin cos etc',
   substituteTextarea: function() {
     return document.createElement('textarea');
@@ -275,6 +276,13 @@ LaTeX `x^{n+m}`, you have to type `x^(n+m` and delete the paren or something.
 letters only, min length 2), defines the (default empty) set of "auto-commands",
 commands automatically rendered by just typing the letters without typing a
 backslash first.
+
+`autoCommandsMapping`, an associative array of LaTeX control words (no
+backslash, letters only, min length 2) to different LaTeX control words. This
+allows you to override an `autoCommand` to map to an arbitrary control sequence
+rather than just the backslashed version. For example `{'sqrt': 'nthroot'}` maps
+typed 'sqrt' to `\nthroot` rather than `\sqrt` provided 'sqrt' is already
+defined as an `autoCommand`.
 
 `autoOperatorNames`, a list of the same form (space-delimited letters-only each
 length>=2), and overrides the set of operator names that automatically become

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -56,6 +56,8 @@ optionProcessors.autoCommands = function(cmds) {
   return dict;
 };
 
+Options.p.autoCommandsMapping = {};
+
 var Letter = P(Variable, function(_, super_) {
   _.init = function(ch) { return super_.init.call(this, this.letter = ch); };
   _.createLeftOf = function(cursor) {
@@ -73,6 +75,11 @@ var Letter = P(Variable, function(_, super_) {
           for (var i = 2, l = cursor[L]; i < str.length; i += 1, l = l[L]);
           Fragment(l, cursor[L]).remove();
           cursor[L] = l[L];
+
+          // sometimes we want map typed letters to a different latex control sequence
+          if (cursor.options.autoCommandsMapping.hasOwnProperty(str)) {
+            return LatexCmds[cursor.options.autoCommandsMapping[str]](str).createLeftOf(cursor)
+          }
           return LatexCmds[str](str).createLeftOf(cursor);
         }
         str = str.slice(1);

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -922,6 +922,22 @@ suite('typing with auto-replaces', function() {
     });
   });
 
+  suite('autoCommandsMapping', function() {
+    setup(function() {
+      MQ.config({
+        autoCommands: 'sqrt',
+        autoCommandsMapping: {'sqrt': 'nthroot'}
+      });
+    });
+
+    test('maps autoCommand to a different control sequence', function() {
+      mq.typedText('sqrt');
+      mq.typedText('n').keystroke('Right').typedText('100').keystroke('Right');
+      assertLatex('\\sqrt[n]{100}');
+      mq.keystroke('Ctrl-Backspace');
+    });
+  });
+
   suite('inequalities', function() {
     // assertFullyFunctioningInequality() checks not only that the inequality
     // has the right LaTeX and when you backspace it has the right LaTeX,


### PR DESCRIPTION
I made a new custom latex macro `\andword` and I’d like typing ‘and’ to map to it. The `autoCommands` setting maps typed 'and' to `\and`, but I want to it to map to `\andword`.

This introduces a new setting `autoCommandsMapping` which allows you to override the default mapping of LaTeX control words to other control sequences rather than just the backslashed version. 

Settings example: `autoCommands: 'and', autoCommandsMapping: {'and': 'andword'}`

This requires an `autoCommandMapping` key to already be defined in `autoCommands` for this to have an effect.

Could be useful for the LaTeX modulus operator, where you might want to map typed 'mod' to a specific mod control sequence like `\mod`, `\pmod` or `\bmod`.