### PR TITLE
[LRN] Added square unicode symbol:

### DIFF
--- a/src/commands/math/advancedSymbols.js
+++ b/src/commands/math/advancedSymbols.js
@@ -194,6 +194,7 @@ LatexCmds.heartsuit = bind(VanillaSymbol, '\\heartsuit ', '&#9825;');
 LatexCmds.spadesuit = bind(VanillaSymbol, '\\spadesuit ', '&#9824;');
 //not real LaTex command see https://github.com/mathquill/mathquill/pull/552 for more details
 LatexCmds.parallelogram = bind(VanillaSymbol, '\\parallelogram ', '&#9649;');
+LatexCmds.square = bind(VanillaSymbol, '\\square ', '&#11036;');
 
 //variable-sized
 LatexCmds.oint = bind(VanillaSymbol, '\\oint ', '&#8750;');

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -105,6 +105,7 @@ suite('latex', function() {
   test('not real LaTex commands, but valid symbols', function() {
     assertParsesLatex('\\parallelogram ');
     assertParsesLatex('\\circledot ', '\\odot ');
+    assertParsesLatex('\\square ');
   });
 
   suite('public API', function() {


### PR DESCRIPTION
\\square

Conflicts:
	src/commands/math/advancedSymbols.js
	test/unit/latex.test.js