### PR TITLE
Kill `font-size: 0`, fixes many typing issues

### DIFF
--- a/src/css/mixins/css3.less
+++ b/src/css/mixins/css3.less
@@ -5,6 +5,13 @@
   -o-transform-origin: @arguments;
   transform-origin: @arguments;
 }
+.transform (...) {
+  -webkit-transform: @arguments;
+  -moz-transform: @arguments;
+  -ms-transform: @arguments;
+  -o-transform: @arguments;
+  transform: @arguments;
+}
 
 .user-select (...) {
   -webkit-user-select: @arguments;

--- a/src/css/textarea.less
+++ b/src/css/textarea.less
@@ -14,7 +14,7 @@
     position: absolute; // the only way to hide the textarea *and* the
     clip: rect(1em 1em 1em 1em); // blinking insertion point in IE
 
-    font-size: 0; // the only way to hide the blinking blue cursor in iOS 8
+    .transform(scale(0)); // the only way to hide the blinking blue cursor in iOS 8 #584
 
     resize: none; // hotfix: https://code.google.com/p/chromium/issues/detail?id=355199#c1
 

--- a/src/services/keystroke.js
+++ b/src/services/keystroke.js
@@ -129,9 +129,6 @@ Node.open(function(_) {
       while (cursor[L]) ctrlr.selectLeft();
       break;
 
-    case 'Enter':
-      return ctrlr.handle('enter');
-
     default:
       return;
     }

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -86,6 +86,7 @@ Controller.open(function(_) {
     this.focusBlurEvents();
   };
   _.typedText = function(ch) {
+    if (ch === '\n') return this.handle('enter');
     var cursor = this.notify().cursor;
     cursor.parent.write(cursor, ch);
     this.scrollHoriz();


### PR DESCRIPTION
Resolves #584 "Hide iOS blinking blue cursor *without* breaking typing in Chrome".

In Safari on my iPhone 5 running iOS 9.2.1, the blinking blue cursor
doesn't show up at all when focusing and typing in this thing:
    http://jsbin.com/sodaji/edit?html,css,js,output
And in all browsers typing in that works just fine, including typing
newlines by pressing Enter or combos like Shift-Enter.

And with this patch, typing on `/test/demo.html` works great on my iPhone:
    <img alt="screenshot" src="https://git.io/vaoNb" width=240>
(Notice that it's not zoomed wayyyy in, like it used to)

As detailed by #584:
Fixes #540
Fixes #566
Hopefully addresses #559?