### PR TITLE
[Mathspace] Initialise cursor in StaticMath blocks

### DIFF
--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -51,6 +51,7 @@ Controller.open(function(_) {
 
     this.container.prepend('<span class="mq-selectable">$'+ctrlr.exportLatex()+'$</span>');
     ctrlr.blurred = true;
+    cursor.hide().parent.blur();
     textarea.bind('cut paste', false)
     .focus(function() { ctrlr.blurred = false; }).blur(function() {
       if (cursor.selection) cursor.selection.clear();


### PR DESCRIPTION
We were experiencing an issue where Mathquill fields
were not flowing correctly.  The width of the element
was not calculated correctly, so in Chrome they would
sometimes render in vertically offset locations, as it tried
to reconcile the flow.  Bizarrely, clicking on the StaticMath
block would cause the Mathquill to snap back into place.

It turned out this was happening because even unfocused
StaticMath blocks had a virtual cursor created and
rendered.

@haydn and I read through the code to try to figure out why
the cursor is being rendered at all in StaticMath blocks.
It seems that the code replaces the focus blur event
handlers with just the initialisation code from that handler,
but omits the line which initialises the cursor, so it gets
rendered into the HTML in a weird state.

Here we just include the extra initialisation line which
resolves our issues.