### PR TITLE
Make sure npm devDependencies get installed during make.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ $(BASIC_CSS): $(CSS_SOURCES) $(NODE_MODULES_INSTALLED) $(BUILD_DIR_EXISTS)
 	$(LESSC) --modify-var="basic=true" $(LESS_OPTS) $(CSS_MAIN) > $@
 
 $(NODE_MODULES_INSTALLED): package.json
-	npm install
+	NODE_ENV=development npm install
 	touch $(NODE_MODULES_INSTALLED)
 
 $(BUILD_DIR_EXISTS):


### PR DESCRIPTION
By forcing `NODE_ENV=development` for `npm install`.

Fixes #597.