### PR TITLE
Fix sin^2 x spacing (worsened by #602)

### DIFF
--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -103,7 +103,7 @@ var Letter = P(Variable, function(_, super_) {
     // removeClass and delete flags from all letters before figuring out
     // which, if any, are part of an operator name
     Fragment(l[R] || this.parent.ends[L], r[L] || this.parent.ends[R]).each(function(el) {
-      el.italicize(true).jQ.removeClass('mq-first mq-last');
+      el.italicize(true).jQ.removeClass('mq-first mq-last mq-followed-by-supsub');
       el.ctrlSeq = el.letter;
     });
 
@@ -126,6 +126,9 @@ var Letter = P(Variable, function(_, super_) {
           if (!shouldOmitPadding(last[R]) && !(last[R] instanceof Bracket)) {
             // also omit space between operator name and paren like in sin(x)
             last.jQ.addClass('mq-last');
+            if (last[R] instanceof SupSub) {
+              last.jQ.addClass('mq-followed-by-supsub');
+            }
           }
 
           i += len - 1;

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -218,6 +218,14 @@
   }
   var.mq-operator-name.mq-last {
     padding-right: .2em;
+
+    &.mq-followed-by-supsub {
+      padding-right: 0;
+
+      + .mq-supsub {
+        padding-right: .2em;
+      }
+    }
   }
 
   ////

--- a/test/visual.html
+++ b/test/visual.html
@@ -187,6 +187,7 @@ $(function() {
 <tr><td><span class="mathquill-static-math">^{\frac{as}{ }df}</span><td><span>^{\frac{as}{ }df}</span>
 <tr><td><span class="mathquill-static-math">e^{i\pi}+1=0</span><td><span>e^{i\pi}+1=0</span>
 <tr><td><span class="mathquill-static-math">\sqrt[n]{1}</span><td><span>\sqrt[n]{1}</span>
+<tr><td><span class="mathquill-static-math">\sin^2 x</span></td><td><span>\sin^2 x</span>
 <tr><td><span class="mathquill-static-math">12a\sin b</span></td><td><span>12a\sin b</span>
 <tr><td><span class="mathquill-static-math">1a^2 \sin b</span></td><td><span>1a^2 \sin b</span>
 <tr><td><span class="mathquill-static-math">a + \sin b</span></td><td><span>a + \sin b</span>


### PR DESCRIPTION
Thanks @eluberoff for reporting

Before: <img width="37" alt="before" src="https://cloud.githubusercontent.com/assets/225809/14342447/9208b69a-fc4e-11e5-9fd8-8cf37768a9fb.png">
After: <img width="40" alt="after" src="https://cloud.githubusercontent.com/assets/225809/14342448/920953de-fc4e-11e5-8059-afe363e50e2a.png">
KaTeX: <img width="54" align="middle" alt="katex" src="https://cloud.githubusercontent.com/assets/225809/14342445/92087018-fc4e-11e5-9f89-c466bb71d987.png">
[MathJax](http://mathb.in/55109): <img width="46" align="middle" alt="mathjax" src="https://cloud.githubusercontent.com/assets/225809/14342446/920895e8-fc4e-11e5-9b77-bcd5da1142ae.png">
LaTeXiT: <img width="54" alt="latexit" align="middle" src="https://cloud.githubusercontent.com/assets/225809/14342324/a85871de-fc4d-11e5-86c0-8c25e73e14d5.png">

Christ we really need tooling to automatically create these