### PR TITLE
Strawman: Custom symbols option via ENV_VAR

### DIFF
--- a/src/commands/math/LatexCommandInput.js
+++ b/src/commands/math/LatexCommandInput.js
@@ -74,7 +74,7 @@ CharCmds['\\'] = P(MathCommand, function(_, super_) {
 
     var latex = this.ends[L].latex();
     if (!latex) latex = ' ';
-    var cmd = LatexCmds[latex];
+    var cmd = cursor.options.customSymbols[latex];
     if (cmd) {
       cmd = cmd(latex);
       if (this._replacedFragment) cmd.replaces(this._replacedFragment);

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -363,7 +363,7 @@ LatexCmds.forall = P(VanillaSymbol, function(_, super_) {
 var LatexFragment = P(MathCommand, function(_) {
   _.init = function(latex) { this.latex = latex; };
   _.createLeftOf = function(cursor) {
-    var block = latexMathParser.parse(this.latex);
+    var block = latexMathParser.parse(this.latex, LatexCmds);
     block.children().adopt(cursor.parent, cursor[L], cursor[R]);
     cursor[L] = block.ends[R];
     block.jQize().insertBefore(cursor.jQ);
@@ -373,7 +373,7 @@ var LatexFragment = P(MathCommand, function(_) {
     cursor.parent.bubble('reflow');
   };
   _.parser = function() {
-    var frag = latexMathParser.parse(this.latex).children();
+    var frag = latexMathParser.parse(this.latex, LatexCmds).children();
     return Parser.succeed(frag);
   };
 });

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -328,11 +328,12 @@ LatexCmds.lowercase =
 
 
 var RootMathCommand = P(MathCommand, function(_, super_) {
-  _.init = function(cursor) {
-    super_.init.call(this, '$');
-    this.cursor = cursor;
-  };
+  _.ctrlSeq = '$';
   _.htmlTemplate = '<span class="mq-math-mode">&0</span>';
+  _.createLeftOf = function(cursor) {
+    this.cursor = cursor;
+    return super_.createLeftOf.apply(this, arguments);
+  };
   _.createBlocks = function() {
     super_.createBlocks.call(this);
 
@@ -366,7 +367,7 @@ var RootTextBlock = P(RootMathBlock, function(_, super_) {
   _.write = function(cursor, ch) {
     cursor.show().deleteSelection();
     if (ch === '$')
-      RootMathCommand(cursor).createLeftOf(cursor);
+      RootMathCommand().createLeftOf(cursor);
     else {
       var html;
       if (ch === '<') html = '&lt;';

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -96,6 +96,9 @@ var latexMathParser = (function() {
   });
   latexMath.latexText = mathMode.or(textChar).many();
 
+  latexMath.parse =
+  latexMath.latexText.parse = Parser.p._parse;
+
   return latexMath;
 })();
 
@@ -106,10 +109,7 @@ Controller.open(function(_, super_) {
   _.writeLatex = function(latex) {
     var cursor = this.notify('edit').cursor;
 
-    var all = Parser.all;
-    var eof = Parser.eof;
-
-    var block = latexMathParser.skip(eof).or(all.result(false)).parse(latex);
+    var block = latexMathParser.parse(latex);
 
     if (block && !block.isEmpty()) {
       block.children().adopt(cursor.parent, cursor[L], cursor[R]);
@@ -127,10 +127,7 @@ Controller.open(function(_, super_) {
   _.renderLatexMath = function(latex) {
     var root = this.root, cursor = this.cursor;
 
-    var all = Parser.all;
-    var eof = Parser.eof;
-
-    var block = latexMathParser.skip(eof).or(all.result(false)).parse(latex);
+    var block = latexMathParser.parse(latex);
 
     root.eachChild('postOrder', 'dispose');
     root.ends[L] = root.ends[R] = 0;
@@ -163,7 +160,7 @@ Controller.open(function(_, super_) {
     delete cursor.selection;
     cursor.show().insAtRightEnd(root);
 
-    var commands = latexMathParser.latexText.skip(eof).or(all.result(false)).parse(latex);
+    var commands = latexMathParser.latexText.parse(latex);
 
     if (commands) {
       for (var i = 0; i < commands.length; i += 1) {

--- a/src/services/parser.util.js
+++ b/src/services/parser.util.js
@@ -1,26 +1,30 @@
 var Parser = P(function(_, super_, Parser) {
   // The Parser object is a wrapper for a parser function.
-  // Externally, you use one to parse a string by calling
-  //   var result = SomeParser.parse('Me Me Me! Parse Me!');
+  //
   // You should never call the constructor, rather you should
   // construct your Parser from the base parsers and the
   // parser combinator methods.
-
-  function parseError(stream, message) {
-    if (stream) {
-      stream = "'"+stream+"'";
-    }
-    else {
-      stream = 'EOF';
-    }
-
-    throw 'Parse Error: '+message+' at '+stream;
-  }
+  //
+  // This was a precursor to Parsimmon, its API was still rough.
+  // (TODO: Pull in upstream improvements to Parsimmon.)
+  //
+  // The base parsers and the parser combinator methods are great
+  // for general use throughout the containing project (which is
+  // key to commands being able to do custom parsing, like \left
+  // does, for example). However, the API to actually parse stuff
+  // is expected to be hidden from the containing project by an
+  // adapter layer (in MathQuill's case, latex.js), because it's
+  // so rough:
+  //
+  //   var result = SomeParser._parse('Me Me Me! Parse Me!');
+  //
+  // If parsing failed, `undefined` is returned.
+  // (TODO: failure handling)
 
   _.init = function(body) { this._ = body; };
 
-  _.parse = function(stream) {
-    return this.skip(eof)._(''+stream, success, parseError);
+  _._parse = function(stream) {
+    return this.skip(eof)._(''+stream, success, noop);
 
     function success(stream, result) { return result; }
   };

--- a/src/tree.js
+++ b/src/tree.js
@@ -367,4 +367,4 @@ var Fragment = P(function(_) {
  *
  * (Commands are all subclasses of Node.)
  */
-var LatexCmds = {}, CharCmds = {};
+var mkLatexCmds = P(), LatexCmds = mkLatexCmds.p, CharCmds = {};

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -2,7 +2,7 @@ suite('latex', function() {
   function assertParsesLatex(str, latex) {
     if (arguments.length < 2) latex = str;
 
-    var result = latexMathParser.parse(str).postOrder('finalizeTree', Options.p).join('latex');
+    var result = latexMathParser.parse(str, LatexCmds).postOrder('finalizeTree', Options.p).join('latex');
     assert.equal(result, latex,
       'parsing \''+str+'\', got \''+result+'\', expected \''+latex+'\''
     );
@@ -67,7 +67,7 @@ suite('latex', function() {
     assertParsesLatex('\\frac{1} 2', '\\frac{1}{2}');
     assertParsesLatex('\\frac{ 1 } 2', '\\frac{1}{2}');
 
-    assert.equal(latexMathParser.parse('\\frac'), undefined);
+    assert.equal(latexMathParser.parse('\\frac', LatexCmds), undefined);
   });
 
   test('whitespace', function() {
@@ -77,7 +77,7 @@ suite('latex', function() {
   });
 
   test('parens', function() {
-    var tree = latexMathParser.parse('\\left(123\\right)');
+    var tree = latexMathParser.parse('\\left(123\\right)', LatexCmds);
 
     assert.ok(tree.ends[L] instanceof Bracket);
     var contents = tree.ends[L].ends[L].join('latex');

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -67,7 +67,7 @@ suite('latex', function() {
     assertParsesLatex('\\frac{1} 2', '\\frac{1}{2}');
     assertParsesLatex('\\frac{ 1 } 2', '\\frac{1}{2}');
 
-    assert.throws(function() { latexMathParser.parse('\\frac'); });
+    assert.equal(latexMathParser.parse('\\frac'), undefined);
   });
 
   test('whitespace', function() {

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -836,4 +836,25 @@ suite('Public API', function() {
 
     $(mq.el()).remove();
   });
+
+  test('customSymbols', function() {
+    var mq = MQ.MathField($('<span>\\snowman\\biohazard</span>').appendTo('#mock')[0], {
+      customSymbols: {
+        snowman: { ch: '☃', kind: 'ord', italic: true },
+        biohazard: { ch:'☣', kind: 'bin' }
+      }
+    });
+    assert.equal(mq.latex(), '\\snowman\\biohazard');
+
+    mq.write('+asdf+\\biohazard');
+    assert.equal(mq.latex(), '\\snowman\\biohazard+asdf+\\biohazard');
+
+    mq.typedText('\\snowman').keystroke('Spacebar');
+    assert.equal(mq.latex(), '\\snowman\\biohazard+asdf+\\biohazard\\snowman');
+
+    var mq2 = MQ.MathField($('<span>\\biohazard</span>').appendTo('#mock')[0]);
+    assert.equal(mq2.latex(), '');
+
+    $('#mock').empty();
+  });
 });

--- a/test/unit/text.test.js
+++ b/test/unit/text.test.js
@@ -1,12 +1,5 @@
 suite('text', function() {
 
-  function fromLatex(latex) {
-    var block = latexMathParser.parse(latex);
-    block.jQize();
-
-    return block;
-  }
-
   function assertSplit(jQ, prev, next) {
     var dom = jQ[0];
 
@@ -28,9 +21,9 @@ suite('text', function() {
   }
 
   test('changes the text nodes as the cursor moves around', function() {
-    var block = fromLatex('\\text{abc}');
-    var ctrlr = Controller(block, 0, 0);
-    var cursor = ctrlr.cursor.insAtRightEnd(block);
+    var ctrlr = Controller(MathBlock(), 0, Options()), cursor = ctrlr.cursor;
+    ctrlr.renderLatexMath('\\text{abc}');
+    ctrlr.root.jQize();
 
     ctrlr.moveLeft();
     assertSplit(cursor.jQ, 'abc', null);
@@ -55,15 +48,15 @@ suite('text', function() {
   });
 
   test('does not change latex as the cursor moves around', function() {
-    var block = fromLatex('\\text{x}');
-    var ctrlr = Controller(block, 0, 0);
-    var cursor = ctrlr.cursor.insAtRightEnd(block);
+    var ctrlr = Controller(MathBlock(), 0, Options()), cursor = ctrlr.cursor;
+    ctrlr.renderLatexMath('\\text{x}');
+    ctrlr.root.jQize();
 
     ctrlr.moveLeft();
     ctrlr.moveLeft();
     ctrlr.moveLeft();
 
-    assert.equal(block.latex(), '\\text{x}');
+    assert.equal(ctrlr.root.latex(), '\\text{x}');
   });
 
   test('stepping out of an empty block deletes it', function() {

--- a/test/visual.html
+++ b/test/visual.html
@@ -2,6 +2,7 @@
 <html>
 <head>
 
+<meta charset="UTF-8">
 <meta name="viewport" content="width=624">
 
 <title>MathQuill Test Page</title>
@@ -103,7 +104,7 @@ td {
 
 <h3>Behavior Options</h3>
 
-<p><span id="custom-behavior">x_a^b + \frac{\sqrt[n]{x}}{\frac{1}{2}}</span></p>
+<p><span id="custom-behavior">x_a^b + \frac{\sqrt[n]{x}}{\frac{1}{2}} + \biohazard</span></p>
 <p>Space should behave like Tab, left and right should go through the upper block, sums should start with <code>n=</code>, exponents should require an base, any of <code>+-=&lt;&gt;</code> should break out of an exponent, <code>pi</code>, <code>theta</code>, <code>sqrt</code>, and <code>sum</code> should all be auto-commands, but <code>only</code> should be the only auto-operator name (so <code>sin</code> etc. shouldn't automatically become non-italicized).</p>
 
 <script>
@@ -117,7 +118,11 @@ $(function() {
     charsThatBreakOutOfSupSub: '+-=<>',
     autoSubscriptNumerals: true,
     autoCommands: 'pi theta sqrt sum',
-    autoOperatorNames: 'only'
+    autoOperatorNames: 'only',
+      customSymbols: {
+        snowman: { ch: '☃', kind: 'ord', italic: true },
+        biohazard: { ch:'☣', kind: 'bin' }
+      }
   });
 });
 </script>


### PR DESCRIPTION
Alternative to #538, allows specifying a `customSymbols` option on a per-field basis.

Because use of the parser now requires the `localLatexCmds` `ENV_VAR` to have a value, we have to make sure no one ever does like `latexMathParser.block.parse()` or anything, so we rename `Parser::parse` to `Parser::_parse` to ensure we're not using it anywhere. This constitutes a large fraction of the changes.

Upon further thought I'm not sure either this or #538 is a good idea at all because it encourages a proliferation of similar-looking dialects of TeX by MathQuill API consumers; instead, perhaps `\embed{}` could be extended to support this use case?