### PR TITLE
API to enable "fast clicks" on touch devices

### DIFF
--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -139,7 +139,7 @@ function getInterface(v) {
       this.__controller.root.postOrder('reflow');
       return this;
     };
-  _.fastClick = function(target, clientX, clientY) {
+  _.clickAt = function(target, clientX, clientY) {
     var ctrlr = this.__controller, root = ctrlr.root;
     var el = document.elementFromPoint(clientX, clientY);
     if (!jQuery.contains(root.jQ[0], el)) el = root.jQ[0];

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -139,19 +139,6 @@ function getInterface(v) {
       this.__controller.root.postOrder('reflow');
       return this;
     };
-  _.clickAt = function(clientX, clientY, target) {
-    target = target || document.elementFromPoint(clientX, clientY);
-
-    var ctrlr = this.__controller, root = ctrlr.root;
-    if (!jQuery.contains(root.jQ[0], target)) target = root.jQ[0];
-    ctrlr.seek($(target), clientX + pageXOffset, clientY + pageYOffset);
-    if (ctrlr.blurred) this.focus();
-    return this;
-  };
-  _.ignoreNextMousedown = function(fn) {
-    this.__controller.cursor.options.ignoreNextMousedown = fn;
-    return this;
-  };
   });
   MQ.prototype = AbstractMathQuill.prototype;
 
@@ -225,6 +212,19 @@ function getInterface(v) {
       this.__controller.seek($(el), pageX, pageY);
       var cmd = Embed().setOptions(options);
       cmd.createLeftOf(this.__controller.cursor);
+    };
+    _.clickAt = function(clientX, clientY, target) {
+      target = target || document.elementFromPoint(clientX, clientY);
+
+      var ctrlr = this.__controller, root = ctrlr.root;
+      if (!jQuery.contains(root.jQ[0], target)) target = root.jQ[0];
+      ctrlr.seek($(target), clientX + pageXOffset, clientY + pageYOffset);
+      if (ctrlr.blurred) this.focus();
+      return this;
+    };
+    _.ignoreNextMousedown = function(fn) {
+      this.__controller.cursor.options.ignoreNextMousedown = fn;
+      return this;
     };
   });
   MQ.EditableField = function() { throw "wtf don't call me, I'm 'abstract'"; };

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -145,6 +145,7 @@ function getInterface(v) {
     var ctrlr = this.__controller, root = ctrlr.root;
     if (!jQuery.contains(root.jQ[0], target)) target = root.jQ[0];
     ctrlr.seek($(target), clientX + pageXOffset, clientY + pageYOffset);
+    if (ctrlr.blurred) this.focus();
     return this;
   };
   _.ignoreNextMousedown = function(fn) {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -145,9 +145,11 @@ function getInterface(v) {
     var ctrlr = this.__controller, root = ctrlr.root;
     if (!jQuery.contains(root.jQ[0], target)) target = root.jQ[0];
     ctrlr.seek($(target), clientX + pageXOffset, clientY + pageYOffset);
+    return this;
   };
   _.ignoreNextMousedown = function(fn) {
     this.__controller.cursor.options.ignoreNextMousedown = fn;
+    return this;
   };
   });
   MQ.prototype = AbstractMathQuill.prototype;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -139,11 +139,12 @@ function getInterface(v) {
       this.__controller.root.postOrder('reflow');
       return this;
     };
-  _.clickAt = function(target, clientX, clientY) {
+  _.clickAt = function(clientX, clientY, target) {
+    target = target || document.elementFromPoint(clientX, clientY);
+
     var ctrlr = this.__controller, root = ctrlr.root;
-    var el = document.elementFromPoint(clientX, clientY);
-    if (!jQuery.contains(root.jQ[0], el)) el = root.jQ[0];
-    ctrlr.seek($(el), clientX + pageXOffset, clientY + pageYOffset);
+    if (!jQuery.contains(root.jQ[0], target)) target = root.jQ[0];
+    ctrlr.seek($(target), clientX + pageXOffset, clientY + pageYOffset);
   };
   _.ignoreNextMousedown = function(fn) {
     this.__controller.cursor.options.ignoreNextMousedown = fn;

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -139,6 +139,15 @@ function getInterface(v) {
       this.__controller.root.postOrder('reflow');
       return this;
     };
+  _.fastClick = function(target, clientX, clientY) {
+    var ctrlr = this.__controller, root = ctrlr.root;
+    var el = document.elementFromPoint(clientX, clientY);
+    if (!jQuery.contains(root.jQ[0], el)) el = root.jQ[0];
+    ctrlr.seek($(el), clientX + pageXOffset, clientY + pageYOffset);
+  };
+  _.ignoreNextMousedown = function(fn) {
+    this.__controller.cursor.options.ignoreNextMousedown = fn;
+  };
   });
   MQ.prototype = AbstractMathQuill.prototype;
 

--- a/src/services/mouse.js
+++ b/src/services/mouse.js
@@ -3,6 +3,7 @@
  *******************************************************/
 
 Controller.open(function(_) {
+  Options.p.ignoreNextMousedown = noop;
   _.delegateMouseEvents = function() {
     var ultimateRootjQ = this.root.jQ;
     //drag-to-select event handling
@@ -11,6 +12,9 @@ Controller.open(function(_) {
       var root = Node.byId[rootjQ.attr(mqBlockId) || ultimateRootjQ.attr(mqBlockId)];
       var ctrlr = root.controller, cursor = ctrlr.cursor, blink = cursor.blink;
       var textareaSpan = ctrlr.textareaSpan, textarea = ctrlr.textarea;
+
+      if (cursor.options.ignoreNextMousedown(e)) return;
+      else cursor.options.ignoreNextMousedown = noop;
 
       var target;
       function mousemove(e) { target = $(e.target); }

--- a/src/services/mouse.js
+++ b/src/services/mouse.js
@@ -13,6 +13,9 @@ Controller.open(function(_) {
       var ctrlr = root.controller, cursor = ctrlr.cursor, blink = cursor.blink;
       var textareaSpan = ctrlr.textareaSpan, textarea = ctrlr.textarea;
 
+      e.preventDefault(); // doesn't work in IE≤8, but it's a one-line fix:
+      e.target.unselectable = true; // http://jsbin.com/yagekiji/1
+
       if (cursor.options.ignoreNextMousedown(e)) return;
       else cursor.options.ignoreNextMousedown = noop;
 
@@ -46,8 +49,6 @@ Controller.open(function(_) {
         if (!ctrlr.editable) rootjQ.prepend(textareaSpan);
         textarea.focus();
       }
-      e.preventDefault(); // doesn't work in IE≤8, but it's a one-line fix:
-      e.target.unselectable = true; // http://jsbin.com/yagekiji/1
 
       cursor.blink = noop;
       ctrlr.seek($(e.target), e.pageX, e.pageY).cursor.startSelection();

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -762,6 +762,54 @@ suite('Public API', function() {
     });
   });
 
+  suite('clickAt', function() {
+    test('inserts at coordinates', function() {
+      // Insert filler so that the page is taller than the window so this test is deterministic
+      // Test that we use clientY instead of pageY
+      var windowHeight = $(window).height();
+      var filler = $('<div>').height(windowHeight);
+      filler.insertBefore('#mock');
+
+      var mq = MQ.MathField($('<span>').appendTo('#mock')[0]);
+      mq.typedText("mmmm/mmmm");
+      mq.el().scrollIntoView();
+
+      var box = mq.el().getBoundingClientRect();
+      var clientX = box.left + 30;
+      var clientY = box.top + 40;
+      var target = document.elementFromPoint(clientX, clientY);
+
+      mq.clickAt(clientX, clientY, target).write('x');
+
+      assert.equal(mq.latex(), "\\frac{mmmm}{mmxmm}");
+
+      filler.remove();
+      $(mq.el()).remove();
+    });
+    test('target is optional', function() {
+      // Insert filler so that the page is taller than the window so this test is deterministic
+      // Test that we use clientY instead of pageY
+      var windowHeight = $(window).height();
+      var filler = $('<div>').height(windowHeight);
+      filler.insertBefore('#mock');
+
+      var mq = MQ.MathField($('<span>').appendTo('#mock')[0]);
+      mq.typedText("mmmm/mmmm");
+      mq.el().scrollIntoView();
+
+      var box = mq.el().getBoundingClientRect();
+      var clientX = box.left + 30;
+      var clientY = box.top + 40;
+
+      mq.clickAt(clientX, clientY).write('x');
+
+      assert.equal(mq.latex(), "\\frac{mmmm}{mmxmm}");
+
+      filler.remove();
+      $(mq.el()).remove();
+    });
+  });
+
   suite('dropEmbedded', function() {
     test('inserts into empty', function() {
       var mq = MQ.MathField($('<span>').appendTo('#mock')[0]);

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -779,7 +779,9 @@ suite('Public API', function() {
       var clientY = box.top + 40;
       var target = document.elementFromPoint(clientX, clientY);
 
+      assert.equal(document.activeElement, document.body);
       mq.clickAt(clientX, clientY, target).write('x');
+      assert.equal(document.activeElement, $(mq.el()).find('textarea')[0]);
 
       assert.equal(mq.latex(), "\\frac{mmmm}{mmxmm}");
 
@@ -801,7 +803,9 @@ suite('Public API', function() {
       var clientX = box.left + 30;
       var clientY = box.top + 40;
 
+      assert.equal(document.activeElement, document.body);
       mq.clickAt(clientX, clientY).write('x');
+      assert.equal(document.activeElement, $(mq.el()).find('textarea')[0]);
 
       assert.equal(mq.latex(), "\\frac{mmmm}{mmxmm}");
 

--- a/test/visual.html
+++ b/test/visual.html
@@ -77,7 +77,7 @@ td {
   <td><span class="mathquill-static-math">\sqrt{\MathQuillMathField{x^2+y^2}}</span>
 </table>
 
-<p>Clicks/mousedown to drag should work anywhere in the blue box: <div class="math-container" style="border: solid 1px lightblue; height: 5em; width: 15em; line-height: 5em; text-align: center"><span class="mathquill-math-field">x_{very\ long\ thing}^2 + a_0 = 0</span></div>
+<p>Touch taps/clicks/mousedown to drag should work anywhere in the blue box: <div class="math-container" style="border: solid 1px lightblue; height: 5em; width: 15em; line-height: 5em; text-align: center; -webkit-tap-highlight-color: rgba(0,0,0,0)"><span class="mathquill-math-field">a_2 x^2 + a_1 x + a_0 = 0</span></div>
 
 <h3>Redrawing</h3>
 <p>
@@ -296,8 +296,21 @@ $(function() {
 
 // test selecting from outside the mathquill editable
 var $mq = $('.math-container .mathquill-math-field');
-$('.math-container').mousedown(function(e) {
-  if (!jQuery.contains($mq[0], e.target)) $mq.triggerHandler(e);
+$('.math-container').on('touchstart', function() {
+  var moved = false;
+  $(this).on('touchmove.tmp', function() { moved = true; })
+  .on('touchend.tmp', function(e) {
+    $(this).off('.tmp');
+    MathQuill($mq[0]).ignoreNextMousedown(function() {
+      return Date.now() < e.timeStamp + 1000;
+    });
+    if (moved) return;
+    var touch = e.originalEvent.changedTouches[0];
+    MathQuill($mq[0]).fastClick(touch.target, touch.clientX, touch.clientY);
+  });
+}).mousedown(function(e) {
+  if (e.target === $mq[0] || $.contains($mq[0], e.target)) return;
+  $mq.triggerHandler(e);
 });
 
 // Selection Tests

--- a/test/visual.html
+++ b/test/visual.html
@@ -306,7 +306,7 @@ $('.math-container').on('touchstart', function() {
     });
     if (moved) return;
     var touch = e.originalEvent.changedTouches[0];
-    MathQuill($mq[0]).clickAt(touch.target, touch.clientX, touch.clientY);
+    MathQuill($mq[0]).clickAt(touch.clientX, touch.clientY, touch.target);
   });
 }).mousedown(function(e) {
   if (e.target === $mq[0] || $.contains($mq[0], e.target)) return;

--- a/test/visual.html
+++ b/test/visual.html
@@ -306,7 +306,7 @@ $('.math-container').on('touchstart', function() {
     });
     if (moved) return;
     var touch = e.originalEvent.changedTouches[0];
-    MathQuill($mq[0]).fastClick(touch.target, touch.clientX, touch.clientY);
+    MathQuill($mq[0]).clickAt(touch.target, touch.clientX, touch.clientY);
   });
 }).mousedown(function(e) {
   if (e.target === $mq[0] || $.contains($mq[0], e.target)) return;

--- a/test/visual.html
+++ b/test/visual.html
@@ -296,7 +296,12 @@ $(function() {
 
 // test selecting from outside the mathquill editable
 var $mq = $('.math-container .mathquill-math-field');
-$('.math-container').on('touchstart', function() {
+$('.math-container').mousedown(function(e) {
+  if (e.target === $mq[0] || $.contains($mq[0], e.target)) return;
+  $mq.triggerHandler(e);
+})
+// test API for "fast touch taps" #622 & #403
+.on('touchstart', function() {
   var moved = false;
   $(this).on('touchmove.tmp', function() { moved = true; })
   .on('touchend.tmp', function(e) {
@@ -304,13 +309,13 @@ $('.math-container').on('touchstart', function() {
     MathQuill($mq[0]).ignoreNextMousedown(function() {
       return Date.now() < e.timeStamp + 1000;
     });
-    if (moved) return;
+    if (moved) return; // note that this happens after .ignoreNextMousedown()
+      // because even if the touch gesture doesn't 'count' as a tap to us,
+      // we still want to suppress the legacy mouse events, else we'd react
+      // fast to some taps and slow to others, that'd be weird
     var touch = e.originalEvent.changedTouches[0];
     MathQuill($mq[0]).clickAt(touch.clientX, touch.clientY, touch.target);
   });
-}).mousedown(function(e) {
-  if (e.target === $mq[0] || $.contains($mq[0], e.target)) return;
-  $mq.triggerHandler(e);
 });
 
 // Selection Tests


### PR DESCRIPTION
Argghhhhh. Want touch swipes to scroll the page, even if they start in
MathQuill (so that it's possible to scroll an expression list filled to
the brim with nothing but MathQuills), but touch taps to place the
cursor. Now, with mouse events, if all you care about is a logical
"click" on the current platform, you just listen for the click event and
the browser will take care of whether a particular sequence of
mousedown-mousemoves-mouseup is a click or not. With touch events,
there's no equivalent logical "tap" event, and while legacy mouse events
do fire if you don't preventDefault() on touchstart, Safari on iOS waits
a glacial ~360ms [1] after a tap in case you're actually doing the
double-tap gesture to zoom in.

[1]: Videos: http://developer.telerik.com/featured/300-ms-click-delay-ios-8/

It get's better. Not only are the legacy mouse events unhelpful, they're
misleading, because there is no way to directly tell them apart from
real mouse events and no way to get them not to fire except calling
preventDefault(), which breaks touch-swipe-to-scroll.

As a result, across the Web there are dozens of blog posts about, and
shitty JS libraries for, "fast clicks", that all disagree on what counts
as a "tap", and also when to ignore a mouse event because it's probably
a legacy one 300ms after a touch event that's already been dealt with.
By far the 2 most-cited "fast click" solutions are Google Developer's
["Fast Buttons"][2] article and FT Labs' [FastClick][3] library; only the
latter ignores taps that are to stop scrolling after a fling, taps where
touchend is >700ms after touchstart, or taps with more than one finger,
but only the former appears to put a time and distance limit on mouse
events to ignore (FastClick just ignores the next one).

[2]: https://web.archive.org/web/20150406091222/https://developers.google.com/mobile/articles/fast_buttons
[3]: https://github.com/ftlabs/fastclick

(Google seems to have lost the original widely-cited "Fast Buttons" article: https://developers.google.com/mobile/articles/fast_buttons )

MathQuill's sponsor, Desmos, has a custom touch events library whose
definition of "tap", and whose strategy for ignoring delayed mouse
events, is different from either of the above. Clearly, this stuff needs
to be decided by the parent application using MathQuill.

So, with heart-wrenching despair, here are 2 new API calls:

- .fastClick(target, clientX, clientY) takes in the touch event info
  and places the cursor like there was a click there

- .ignoreNextMousedown(fn) takes a function that is called on subsequent
  mousedown events, which MathQuill will ignore if true is returned.
  MathQuill stops calling the function once it returns false.
  Meant to be called on touchend before every expected legacy mousedown,
  regardless of whether there was a logical "tap".

--

The test case has a trivial notion of logical "tap", which is if no
touchmoves happen between the touchstart and touchend. Note that it
calls .ignoreNextMousedown() after every touchend, or else sometimes if
you wiggle your finger a little but not much, the logical "tap" won't
happen but Safari on iOS will still fire a legacy mousedown event.

Test case also gained -webkit-tap-highlight-color to to hide the gray
tap highlight box.