### PR TITLE
[Build System] CircleCI + Sauce Labs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -101,4 +101,4 @@ test:
     - |-
       [ "$(node -p 'require("./status.json")["js tests"][0].result.failures')" == 0 ]
   post:
-    - killall --wait sc; :  # wait for Sauce Connect to close the tunnel; ignore errors since it's just cleanup
+    - killall --wait sc; true  # wait for Sauce Connect to close the tunnel; ignore errors since it's just cleanup

--- a/circle.yml
+++ b/circle.yml
@@ -87,6 +87,7 @@ test:
         [ "$(node -p 'require("./status.json").completed')" != false ] && break
       done
     # finally, complain to Circle CI if there were nonzero test failures
-    - [ "$(node -p 'require("./status.json")["js tests"][0].result.failures')" == 0 ]
+    - |-
+      [ "$(node -p 'require("./status.json")["js tests"][0].result.failures')" == 0 ]
   post:
     - killall --wait sc  # wait for Sauce Connect to close the tunnel

--- a/circle.yml
+++ b/circle.yml
@@ -52,6 +52,9 @@ test:
     - make server:
         background: true
 
+    - node -e 'require("http").createServer(function(req, res) { res.setHeader("Access-Control-Allow-Origin", "*"); req.pipe(require("fs").createWriteStream("xunit")); req.on("end", res.end.bind(res)); }).listen(9000);':
+        background: true
+
     # Wait for tunnel to be ready (`make server` is much faster, no need to wait)
     - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done
 
@@ -96,6 +99,10 @@ test:
         # because unexpected values should break rather than infinite loop
         [ "$(node -p 'require("./status.json").completed')" != false ] && break
       done
+
+    - mkdir -p $CIRCLE_TEST_REPORTS/mocha
+
+    - cat xunit > $CIRCLE_TEST_REPORTS/mocha/xunit.xml
 
     # finally, complain to Circle CI if there were nonzero test failures
     - |-

--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,92 @@
+# Okay so maybe everyone else already knows all this, but it took some time
+# for Michael and I [Han] to really see how everything fits together.
+#
+# Basically, what we're doing here is automated browser testing, so CircleCI
+# handles the automation, and Sauce Labs handles the browser testing.
+# Specifically, Sauce Labs offers a REST API to run tests in browsers in VMs,
+# and CircleCI can be configured to listen for git pushes and run local
+# servers and call out to REST APIs to test against these local servers.
+#
+# The flow goes like this:
+#   - CircleCI notices/is notified of a git push
+#   - they pull and checkout and magically know to install dependencies and shit
+#       + https://circleci.com/docs/manually/
+#   - their magic works fine for MathQuill's dependencies but to run the tests,
+#     it foolishly runs `make test`, what an inconceivable mistake
+#   - that's where we come in: `circle.yml` lets us override the test script.
+#       + https://circleci.com/docs/configuration/
+#   - our `circle.yml` first installs and runs a tunnel to Sauce Labs
+#   - and runs `make server`
+#   - then it calls out to Sauce Labs' REST API to open a browser that reaches
+#     back through the tunnel to access the unit test page on the local server
+#       + > Sauce Connect allows you to run a test server within the CircleCI
+#         > build container and expose it it (using a URL like `localhost:8080`)
+#         > to Sauce Labs’ browsers.
+#
+#         https://circleci.com/docs/browser-testing-with-sauce-labs/
+#
+#   - boom testing boom
+
+
+# this file is based on https://github.com/circleci/sauce-connect/blob/a65e41c91e02550ce56c75740a422bebc4acbf6f/circle.yml
+# via https://circleci.com/docs/browser-testing-with-sauce-labs/
+
+dependencies:
+  post:
+    - wget https://saucelabs.com/downloads/sc-latest-linux.tar.gz
+    - tar -xzf sc-latest-linux.tar.gz
+
+test:
+  override:
+    - cd sc-*-linux && ./bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY --readyfile ~/sauce_is_ready:
+        background: true
+    - make server:
+        background: true
+    # Wait for tunnel to be ready (`make server` is much faster, no need to wait)
+    - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done
+
+    # Run in-browser unit tests, based on:
+    #   https://wiki.saucelabs.com/display/DOCS/JavaScript+Unit+Testing+Methods
+    # "build" and "tag" parameters from:
+    #   https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-TestAnnotation
+    - |-
+      curl -i https://saucelabs.com/rest/v1/mathquill/js-tests \
+           -X POST \
+           -u $SAUCE_USERNAME:$SAUCE_ACCESS_KEY \
+           -H 'Content-Type: application/json' \
+           -d '{
+                 "build": "'$(git rev-parse HEAD)'",
+                 "tags": [
+                   "after-v'$(node -p 'require("./package.json").version')'",
+                   "circle-ci"
+                 ],
+                 "framework": "mocha",
+                 "url": "http://localhost:9292/test/unit.html",
+                 "platforms": [["", "Chrome", ""]]
+      }' | tee js-tests
+
+    # Wait for tests to finish:
+    #
+    #   > Make the request multiple times as the tests run until the response
+    #   > contains `completed: true` to the get the final results.
+    #
+    #   https://wiki.saucelabs.com/display/DOCS/JavaScript+Unit+Testing+Methods
+    - |-
+      while true  # Bash has no do...while >:(
+      do
+        sleep 5
+        curl -i https://saucelabs.com/rest/v1/mathquill/js-tests/status \
+             -X POST \
+             -u $SAUCE_USERNAME:$SAUCE_ACCESS_KEY \
+             -H 'Content-Type: application/json' \
+             -d "$(tail -1 js-tests)" \
+        | tee status
+        tail -1 status > status.json
+        # deliberately do `... != false` rather than `... == true`
+        # because unexpected values should break rather than infinite loop
+        [ "$(node -p 'require("./status.json").completed')" != false ] && break
+      done
+    # finally, complain to Circle CI if there were nonzero test failures
+    - [ "$(node -p 'require("./status.json")["js tests"][0].result.failures')" == 0 ]
+  post:
+    - killall --wait sc  # wait for Sauce Connect to close the tunnel

--- a/circle.yml
+++ b/circle.yml
@@ -93,7 +93,7 @@ test:
                    "circle-ci"
                  ],
                  "framework": "mocha",
-                 "url": "http://localhost:9292/test/unit.html",
+                 "url": "http://localhost:9292/test/unit.html?post_xunit_to=http://localhost:9000",
                  "platforms": [["", "Chrome", ""]]
       }' | tee js-tests
 

--- a/circle.yml
+++ b/circle.yml
@@ -52,10 +52,29 @@ test:
     - make server:
         background: true
 
-    - node -e 'require("http").createServer(function(req, res) { res.setHeader("Access-Control-Allow-Origin", "*"); req.pipe(require("fs").createWriteStream("xunit")); req.on("end", res.end.bind(res)); }).listen(9000);':
+    # CircleCI expects test results to be reported in an JUnit/xUnit-style XML
+    # file:
+    #   https://circleci.com/docs/test-metadata/
+    # Our unit tests are in a browser, so they can't write to a file, and Sauce
+    # apparently truncates custom data in their test result reports, so instead
+    # we POST to this trivial Node server on localhost:9000 that writes the
+    # body of any POST request to $CIRCLE_TEST_REPORTS/mocha/xunit.xml
+    - ? |-
+        mkdir -p $CIRCLE_TEST_REPORTS/mocha
+        node << 'EOF' | tee $CIRCLE_TEST_REPORTS/mocha/xunit.xml
+        require('http').createServer(function(req, res) {
+          res.setHeader('Access-Control-Allow-Origin', '*');
+          req.pipe(process.stdout);
+          req.on('end', res.end.bind(res));
+        })
+        .listen(9000);
+        console.log('Listening on localhost:9000');
+        EOF
+      :
         background: true
 
-    # Wait for tunnel to be ready (`make server` is much faster, no need to wait)
+    # Wait for tunnel to be ready (`make server` and the trivial Node server
+    # are much faster, no need to wait for them)
     - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done
 
     # Run in-browser unit tests, based on:
@@ -99,10 +118,6 @@ test:
         # because unexpected values should break rather than infinite loop
         [ "$(node -p 'require("./status.json").completed')" != false ] && break
       done
-
-    - mkdir -p $CIRCLE_TEST_REPORTS/mocha
-
-    - cat xunit > $CIRCLE_TEST_REPORTS/mocha/xunit.xml
 
     # finally, complain to Circle CI if there were nonzero test failures
     - |-

--- a/circle.yml
+++ b/circle.yml
@@ -36,6 +36,7 @@ dependencies:
     - ~/sauce-connect
   pre:
     - ? |-
+        mkdir -p ~/sauce-connect
         cd ~/sauce-connect
         if [ ! -x sc-*-linux/bin/sc ]
         then
@@ -100,4 +101,4 @@ test:
     - |-
       [ "$(node -p 'require("./status.json")["js tests"][0].result.failures')" == 0 ]
   post:
-    - killall --wait sc  # wait for Sauce Connect to close the tunnel
+    - killall --wait sc; :  # wait for Sauce Connect to close the tunnel; ignore errors since it's just cleanup

--- a/circle.yml
+++ b/circle.yml
@@ -68,7 +68,6 @@ test:
           req.on('end', res.end.bind(res));
         })
         .listen(9000);
-        console.log('Listening on localhost:9000');
         EOF
       :
         background: true

--- a/circle.yml
+++ b/circle.yml
@@ -32,16 +32,25 @@
 # via https://circleci.com/docs/browser-testing-with-sauce-labs/
 
 dependencies:
-  post:
-    - wget https://saucelabs.com/downloads/sc-latest-linux.tar.gz
-    - tar -xzf sc-latest-linux.tar.gz
+  cache_directories:
+    - ~/sauce-connect
+  pre:
+    - ? |-
+        cd ~/sauce-connect
+        if [ ! -x sc-*-linux/bin/sc ]
+        then
+          wget https://saucelabs.com/downloads/sc-latest-linux.tar.gz
+          tar -xzf sc-latest-linux.tar.gz
+        fi
+        sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY --readyfile ~/sauce_is_ready
+      :
+        background: true
 
 test:
   override:
-    - cd sc-*-linux && ./bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY --readyfile ~/sauce_is_ready:
-        background: true
     - make server:
         background: true
+
     # Wait for tunnel to be ready (`make server` is much faster, no need to wait)
     - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done
 
@@ -86,6 +95,7 @@ test:
         # because unexpected values should break rather than infinite loop
         [ "$(node -p 'require("./status.json").completed')" != false ] && break
       done
+
     # finally, complain to Circle CI if there were nonzero test failures
     - |-
       [ "$(node -p 'require("./status.json")["js tests"][0].result.failures')" == 0 ]

--- a/test/unit.html
+++ b/test/unit.html
@@ -49,6 +49,27 @@
 
     <div id="mock"></div>
 
-    <script type="text/javascript"> mocha.run(); </script>
+    <script type="text/javascript">
+      var runner = mocha.run();
+
+      // the following is based on https://github.com/saucelabs-sample-scripts/JavaScript/blob/4946c5cf0ab7325dce5562881dba7c28e30989e5/reporting_mocha.js
+      var failedTests = [];
+      runner.on('fail', function(test, err) {
+        function flattenTitles(test) {
+          var titles = [];
+          while (test.parent.title) {
+            titles.push(test.parent.title);
+            test = test.parent;
+          }
+          return titles.reverse();
+        }
+
+        failedTests.push({name: test.title, result: false, message: err.message, stack: err.stack, titles: flattenTitles(test) });
+      });
+      runner.on('end', function() {
+        window.mochaResults = runner.stats;
+        window.mochaResults.reports = failedTests;
+      });
+    </script>
   </body>
 </html>

--- a/test/unit.html
+++ b/test/unit.html
@@ -29,18 +29,8 @@
         reporter: 'xunit'
       });
 
-      var console_log = console.log;
-      var xunit = "";
-      console.log = function() {
-        var str = arguments[0];
-
-        if (str === 'stdout:') {
-          xunit += arguments[1];
-        }
-
-        return console_log.apply(console, arguments);
-      };
-
+      var xunit = '';
+      Mocha.process.stdout.write = function(line) { xunit += line; };
     </script>
 
     <!-- include the library with the tests inlined -->

--- a/test/unit.html
+++ b/test/unit.html
@@ -24,7 +24,23 @@
 
     <!-- configure mocha and chai -->
     <script type="text/javascript">
-      mocha.setup('tdd');
+      mocha.setup({
+        ui: 'tdd',
+        reporter: 'xunit'
+      });
+
+      var console_log = console.log;
+      var xunit = "";
+      console.log = function() {
+        var str = arguments[0];
+
+        if (str === 'stdout:') {
+          xunit += arguments[1];
+        }
+
+        return console_log.apply(console, arguments);
+      };
+
     </script>
 
     <!-- include the library with the tests inlined -->
@@ -66,9 +82,45 @@
 
         failedTests.push({name: test.title, result: false, message: err.message, stack: err.stack, titles: flattenTitles(test) });
       });
+
       runner.on('end', function() {
-        window.mochaResults = runner.stats;
-        window.mochaResults.reports = failedTests;
+        setTimeout(function(){
+          //var data = {
+          //  "description": "Mathquill test",
+          //  "public": true,
+          //  "files": {
+          //    "file1.txt": {
+          //      "content": xunit
+          //    }
+          //  }
+          //};
+
+          //$.ajax({
+          //  url: "https://localhost:9000/",
+          //  data: xunit,
+          //  type: 'POST',
+          //  headers: {Connection: 'close'}
+          //})
+          //  .then(function(gist) {
+          //    window.mochaResults = runner.stats;
+          //    window.mochaResults.reports = failedTests;
+          //  });
+
+          $.post("http://localhost:9000/", xunit)
+            .then(function(gist) {
+              window.mochaResults = runner.stats;
+              window.mochaResults.reports = failedTests;
+            });
+
+          //$.post("https://api.github.com/gists", JSON.stringify(data))
+          //  .then(function(gist) {
+          //    runner.stats.xunitURL = gist.files["file1.txt"].raw_url
+          //      console.log(runner.stats.xunitURL)
+          //      window.mochaResults = runner.stats;
+          //    window.mochaResults.reports = failedTests;
+          //  });
+        });
+
       });
     </script>
   </body>

--- a/test/unit.html
+++ b/test/unit.html
@@ -24,9 +24,11 @@
 
     <!-- configure mocha and chai -->
     <script type="text/javascript">
+      var post_xunit_to = Mocha.utils.parseQuery(location.search).post_xunit_to;
+
       mocha.setup({
         ui: 'tdd',
-        reporter: 'xunit'
+        reporter: post_xunit_to ? 'xunit' : 'html'
       });
 
       var xunit = '';
@@ -58,60 +60,31 @@
     <script type="text/javascript">
       var runner = mocha.run();
 
-      // the following is based on https://github.com/saucelabs-sample-scripts/JavaScript/blob/4946c5cf0ab7325dce5562881dba7c28e30989e5/reporting_mocha.js
-      var failedTests = [];
-      runner.on('fail', function(test, err) {
-        function flattenTitles(test) {
-          var titles = [];
-          while (test.parent.title) {
-            titles.push(test.parent.title);
-            test = test.parent;
+      if (post_xunit_to) {
+        // the following is based on https://github.com/saucelabs-sample-scripts/JavaScript/blob/4946c5cf0ab7325dce5562881dba7c28e30989e5/reporting_mocha.js
+        var failedTests = [];
+        runner.on('fail', function(test, err) {
+          function flattenTitles(test) {
+            var titles = [];
+            while (test.parent.title) {
+              titles.push(test.parent.title);
+              test = test.parent;
+            }
+            return titles.reverse();
           }
-          return titles.reverse();
-        }
 
-        failedTests.push({name: test.title, result: false, message: err.message, stack: err.stack, titles: flattenTitles(test) });
-      });
+          failedTests.push({name: test.title, result: false, message: err.message, stack: err.stack, titles: flattenTitles(test) });
+        });
 
-      runner.on('end', function() {
-        setTimeout(function(){
-          //var data = {
-          //  "description": "Mathquill test",
-          //  "public": true,
-          //  "files": {
-          //    "file1.txt": {
-          //      "content": xunit
-          //    }
-          //  }
-          //};
-
-          //$.ajax({
-          //  url: "https://localhost:9000/",
-          //  data: xunit,
-          //  type: 'POST',
-          //  headers: {Connection: 'close'}
-          //})
-          //  .then(function(gist) {
-          //    window.mochaResults = runner.stats;
-          //    window.mochaResults.reports = failedTests;
-          //  });
-
-          $.post("http://localhost:9000/", xunit)
-            .then(function(gist) {
+        runner.on('end', function() {
+          setTimeout(function() {
+            $.post(post_xunit_to, xunit, function() {
               window.mochaResults = runner.stats;
               window.mochaResults.reports = failedTests;
             });
-
-          //$.post("https://api.github.com/gists", JSON.stringify(data))
-          //  .then(function(gist) {
-          //    runner.stats.xunitURL = gist.files["file1.txt"].raw_url
-          //      console.log(runner.stats.xunitURL)
-          //      window.mochaResults = runner.stats;
-          //    window.mochaResults.reports = failedTests;
-          //  });
+          });
         });
-
-      });
+      }
     </script>
   </body>
 </html>


### PR DESCRIPTION
With this patch to our unit test page reports the Mocha test results in a way that Sauce understands, and with `circle.yml` CircleCI is able to run in-browser unit tests on Sauce.

TODO:
  - [x] report test results from Sauce to Circle (maybe this? https://circleci.com/docs/test-metadata/#js )

Future:
  - make sure artifacts like screenshots are public and accessible from the PR
  - something about PRs from forks? https://circleci.com/docs/fork-pr-builds/
  - parallelism