### PR TITLE
Provide a way to add/override commands

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -416,7 +416,7 @@ CharCmds['/'] = P(Fraction, function(_, super_) {
           leftward instanceof (LatexCmds.text || noop) ||
           leftward instanceof SummationNotation ||
           leftward.ctrlSeq === '\\ ' ||
-          /^[,;:]$/.test(leftward.ctrlSeq)
+          /^[;:]$/.test(leftward.ctrlSeq) // https://github.com/mathquill/mathquill/issues/156#issuecomment-182923989
         ) //lookbehind for operator
       ) leftward = leftward[L];
 

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -94,6 +94,9 @@ function getInterface(v) {
     }
     EMBEDS[name] = options;
   };
+  MQ.bindVanillaSymbol = function(name, cmd, hex) {
+    LatexCmds[name] = bind(VanillaSymbol, cmd, hex);
+  };
 
   var AbstractMathQuill = APIClasses.AbstractMathQuill = P(Progenote, function(_) {
     _.init = function(ctrlr) {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -94,8 +94,15 @@ function getInterface(v) {
     }
     EMBEDS[name] = options;
   };
-  MQ.bindVanillaSymbol = function(name, cmd, hex) {
-    LatexCmds[name] = bind(VanillaSymbol, cmd, hex);
+  MQ.bindVanillaSymbol = function(name, hex) {
+    LatexCmds[name] = bind(VanillaSymbol, '\\' + name, hex);
+  };
+  MQ.bindMathCommand = function(name, htmlTemplate) {
+    LatexCmds[name] = P(MathCommand, function(_, _super) {
+      _.ctrlSeq = '\\' + name;
+      _.htmlTemplate = htmlTemplate;
+      _.textTemplate = [name + '(', ')'];
+    });
   };
 
   var AbstractMathQuill = APIClasses.AbstractMathQuill = P(Progenote, function(_) {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -95,7 +95,7 @@ function getInterface(v) {
     EMBEDS[name] = options;
   };
   MQ.bindBinaryOperator = function(name, ctrlSeq, hex) {
-    LatexCmds[name] = find(BinaryOperator, ctrlSeq, hex)
+    LatexCmds[name] = bind(BinaryOperator, ctrlSeq, hex)
   };
   MQ.bindVanillaSymbol = function(name, ctrlSeq, hex) {
     LatexCmds[name] = bind(VanillaSymbol, ctrlSeq, hex);

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -94,12 +94,15 @@ function getInterface(v) {
     }
     EMBEDS[name] = options;
   };
-  MQ.bindVanillaSymbol = function(name, hex) {
-    LatexCmds[name] = bind(VanillaSymbol, '\\' + name, hex);
+  MQ.bindBinaryOperator = function(name, ctrlSeq, hex) {
+    LatexCmds[name] = find(BinaryOperator, ctrlSeq, hex)
   };
-  MQ.bindMathCommand = function(name, htmlTemplate) {
+  MQ.bindVanillaSymbol = function(name, ctrlSeq, hex) {
+    LatexCmds[name] = bind(VanillaSymbol, ctrlSeq, hex);
+  };
+  MQ.bindMathCommand = function(name, ctrlSeq, htmlTemplate) {
     LatexCmds[name] = P(MathCommand, function(_, _super) {
-      _.ctrlSeq = '\\' + name;
+      _.ctrlSeq = ctrlSeq;
       _.htmlTemplate = htmlTemplate;
       _.textTemplate = [name + '(', ')'];
     });


### PR DESCRIPTION
Not only to add custom functionality, but also to override the output.
For example when `\N` is entered, Mathquill always outputs `\mathbb{N}`, we would like this to remain `\N`.
We're doing something like this:

```
MathQuill.bindVanillaSymbol('nmid', '\\nmid', '&#8740;');

MathQuill.bindMathCommand('hat', '\\hat', '<span class="mq-non-leaf" style="font-size: 90%">' +
    '<span style="display: block; text-align: center; line-height: .2em; margin-bottom: -.2em;">^</span>' +
    '<span style="display: block;">&0</span>' +
    '</span>');

MathQuill.bindBinaryOperator('nsub', '\\notsubset', '&#8836;');
MathQuill.bindBinaryOperator('notsub', '\\notsubset', '&#8836;');
MathQuill.bindBinaryOperator('nsubset', '\\notsubset', '&#8836;');
MathQuill.bindBinaryOperator('notsubset', '\\notsubset', '&#8836;');

MathQuill.bindVanillaSymbol('N', '\\N', '&#8469;');
MathQuill.bindVanillaSymbol('naturals', '\\N', '&#8469;');
MathQuill.bindVanillaSymbol('Naturals', '\\N', '&#8469;');

MathQuill.bindVanillaSymbol('P', '\\P', '&#8473;');
MathQuill.bindVanillaSymbol('primes', '\\P', '&#8473;');
MathQuill.bindVanillaSymbol('Primes', '\\P', '&#8473;');
MathQuill.bindVanillaSymbol('projective', '\\P', '&#8473;');
MathQuill.bindVanillaSymbol('Projective', '\\P', '&#8473;');
MathQuill.bindVanillaSymbol('probability', '\\P', '&#8473;');
MathQuill.bindVanillaSymbol('Probability', '\\P', '&#8473;');

MathQuill.bindVanillaSymbol('Z', '\\Z', '&#8484;');
MathQuill.bindVanillaSymbol('integers', '\\Z', '&#8484;');
MathQuill.bindVanillaSymbol('Integers', '\\Z', '&#8484;');

MathQuill.bindVanillaSymbol('Q', '\\Q', '&#8474;');
MathQuill.bindVanillaSymbol('rationals', '\\Q', '&#8474;');
MathQuill.bindVanillaSymbol('Rationals', '\\Q', '&#8474;');

MathQuill.bindVanillaSymbol('R', '\\R', '&#8477;');
MathQuill.bindVanillaSymbol('reals', '\\R', '&#8477;');
MathQuill.bindVanillaSymbol('Reals', '\\R', '&#8477;');
```
