### PR TITLE
Pin pjs to less >=3.1.0 <5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/mathquill/mathquill.git"
   },
   "dependencies": {
-    "pjs": ">=3.1.0"
+    "pjs": ">=3.1.0 <5.0.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
PJs 5.0.0+ is currently incompatible with MathQuill.

PJs 5.0.0 introduced a new behavior for this.constructor(...) in order
to be compatible with coffeescript classes. The new behavior means
that, if you don't use `new` when you call `this.constructor`, the
object returned from the constructor is an alias of `this` instead of a new object.

This behavior interacts badly with MathQuill's use of PJs to subclass
jQuery, and jQuery's use of `this.constructor` inside `pushStack`:

https://github.com/jquery/jquery/blob/305f193aa57014dc7d8fa0739a3fefd47166cd44/src/core.js#L72-L84