### PR TITLE
Fix ReadTheDocs sidebar and code blocks styling

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -1,0 +1,8 @@
+/* default ReadTheDocs MkDocs theme's <code> font-size
+   much too small at 75%, override */
+body code {
+  font-size: 90%;
+}
+body pre code {
+  font-size: 100%;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,7 +16,7 @@ pages:
 
 markdown_extensions:
   - toc:
-    - permalink: True
+      permalink: True
 
 extra_css:
   - extra.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,15 @@
+site_name: MathQuill
+site_url: http://docs.mathquill.com
+repo_url: https://github.com/mathquill/mathquill
+site_description: Easily type math in your webapp
+site_author: Han, Jeanine, Mary
+site_favicon: http://mathquill.com/favicon.ico
+google_analytics: ['UA-73742753-3', 'docs.mathquill.com']
+
+pages:
+  - index.md
+  - Getting_Started.md
+  - 'API Methods': Api_Methods.md
+  - 'Config Options': Config.md
+  - 'Under the Hood': Contributing.md
+  - Code_of_Conduct.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,5 +14,9 @@ pages:
   - 'Under the Hood': Contributing.md
   - Code_of_Conduct.md
 
+markdown_extensions:
+  - toc:
+    - permalink: True
+
 extra_css:
   - extra.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,3 +13,6 @@ pages:
   - 'Config Options': Config.md
   - 'Under the Hood': Contributing.md
   - Code_of_Conduct.md
+
+extra_css:
+  - extra.css


### PR DESCRIPTION
Code blocks now a reasonable size, and section headers now have little permalink icons when you hover over them, see it here: http://docs.mathquill.com/en/docs.readthedocs/