### PR TITLE
Take screenshots of visual.html during unit tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -127,6 +127,13 @@ test:
     - while [ ! -e ~/screenshots ]; do sleep 1; done:
         timeout: 300
 
+    - |-
+      dir=$CIRCLE_ARTIFACTS/imgs
+      for x in $(ls $dir)
+      do
+        convert $dir/$x/*.png -append $dir/$x.png
+      done
+
     # finally, complain to Circle CI if there were nonzero test failures
     - |-
       [ "$(node -p 'require("./status.json")["js tests"][0].result.failures')" == 0 ]

--- a/circle.yml
+++ b/circle.yml
@@ -35,6 +35,8 @@ dependencies:
   cache_directories:
     - ~/sauce-connect
   pre:
+    # imagemagick is installed to give us access to the
+    # `convert` tool to stitch together the screenshots.
     - sudo apt-get update; sudo apt-get install imagemagick
     - ? |-
         mkdir -p ~/sauce-connect
@@ -80,7 +82,7 @@ test:
     - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done
 
     # Start taking screenshots in the background while the unit tests are running
-    - npm install wd && node script/screenshots.js http://localhost:3000/test/visual.html && touch ~/screenshots:
+    - npm install wd && node script/screenshots.js http://localhost:3000/test/visual.html && touch ~/screenshots_are_ready:
         background: true
 
     # Run in-browser unit tests, based on:
@@ -126,7 +128,7 @@ test:
       done
 
     # Wait for screenshots to be ready
-    - while [ ! -e ~/screenshots ]; do sleep 1; done:
+    - while [ ! -e ~/screenshots_are_ready ]; do sleep 1; done:
         timeout: 300
 
     - |-

--- a/circle.yml
+++ b/circle.yml
@@ -35,6 +35,7 @@ dependencies:
   cache_directories:
     - ~/sauce-connect
   pre:
+    - sudo apt-get update; sudo apt-get install imagemagick
     - ? |-
         mkdir -p ~/sauce-connect
         cd ~/sauce-connect

--- a/circle.yml
+++ b/circle.yml
@@ -50,7 +50,9 @@ dependencies:
 
 test:
   override:
-    - make server:
+    # Sauce cant connect to Safari unless the server is ran on port 3000 or 4000
+    # https://david263a.wordpress.com/2015/04/18/fixing-safari-cant-connect-to-localhost-issue-when-using-sauce-labs-connect-tunnel/
+    - PORT=3000 make server:
         background: true
 
     # CircleCI expects test results to be reported in an JUnit/xUnit-style XML
@@ -78,7 +80,7 @@ test:
     - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done
 
     # Start taking screenshots in the background while the unit tests are running
-    - npm install wd && node script/screenshots.js http://localhost:9292/test/visual.html && touch ~/screenshots:
+    - npm install wd && node script/screenshots.js http://localhost:3000/test/visual.html && touch ~/screenshots:
         background: true
 
     # Run in-browser unit tests, based on:
@@ -97,7 +99,7 @@ test:
                    "circle-ci"
                  ],
                  "framework": "mocha",
-                 "url": "http://localhost:9292/test/unit.html?post_xunit_to=http://localhost:9000",
+                 "url": "http://localhost:3000/test/unit.html?post_xunit_to=http://localhost:9000",
                  "platforms": [["", "Chrome", ""]]
       }' | tee js-tests
 

--- a/circle.yml
+++ b/circle.yml
@@ -76,6 +76,10 @@ test:
     # are much faster, no need to wait for them)
     - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done
 
+    # Start taking screenshots in the background while the unit tests are running
+    - npm install wd && node script/screenshots.js http://localhost:9292/test/visual.html && touch ~/screenshots:
+        background: true
+
     # Run in-browser unit tests, based on:
     #   https://wiki.saucelabs.com/display/DOCS/JavaScript+Unit+Testing+Methods
     # "build" and "tag" parameters from:
@@ -117,6 +121,10 @@ test:
         # because unexpected values should break rather than infinite loop
         [ "$(node -p 'require("./status.json").completed')" != false ] && break
       done
+
+    # Wait for screenshots to be ready
+    - while [ ! -e ~/screenshots ]; do sleep 1; done:
+        timeout: 300
 
     # finally, complain to Circle CI if there were nonzero test failures
     - |-

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -30,6 +30,11 @@ var browserVersions = [
   }
 ];
 
+
+var widthScript  = 'return Math.max(document.body.scrollWidth, document.body.offsetWidth, document.documentElement.clientWidth, document.documentElement.scrollWidth, document.documentElement.offsetWidth);'
+var heightScript = 'return Math.max(document.body.scrollHeight, document.body.offsetHeight, document.documentElement.clientHeight, document.documentElement.scrollHeight, document.documentElement.offsetHeight);'
+
+
 browserVersions.forEach(function(cfg) {
   var browserDriver = wd.remote('ondemand.saucelabs.com', 80, username, accessKey);
   // The following is in the style of
@@ -39,15 +44,26 @@ browserVersions.forEach(function(cfg) {
 
     browserDriver.get(url, function(err) {
       if (err) console.log(err);
-
-      var browser = cfg.browserName+(!!cap ? '_'+cap.version : '');
-      var platform = cap.platform.replace(/\s/g, '_');
-
-      // saves file in the file `dir/browser_version_platform.png`
-      var filename = dir+'/'+browser+'_'+platform+'.png';
-      browserDriver.saveScreenshot(filename, function(err) {
+      browserDriver.safeExecute(widthScript, function(err,width) {
         if (err) console.log(err);
-        browserDriver.quit()
+        browserDriver.safeExecute(heightScript, function(err,height) {
+          if (err) console.log(err);
+
+          browserDriver.setWindowSize(width,height,function(err) {
+            if (err) console.log(err);
+
+            var browser = cfg.browserName+(!!cap ? '_'+cap.version : '');
+            var platform = cap.platform.replace(/\s/g, '_');
+
+            // saves file in the file `dir/browser_version_platform.png`
+            var filename = dir+'/'+browser+'_'+platform+'.png';
+            browserDriver.saveScreenshot(filename, function(err) {
+              if (err) console.log(err);
+              browserDriver.quit()
+            });
+          });
+
+        });
       });
     });
   });

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -3,6 +3,9 @@
 //   2. You've set the environment variables $SAUCE_USERNAME and $SAUCE_ACCESS_KEY.
 //   3. If the environment variable $CIRCLE_ARTIFACTS is not set imanges will be saved in /tmp
 //
+// This scripts creates following files for each browser in browserVersions:
+//    $CIRCLE_ARTIFACTS/imgs/{browser_version_platform}/#.png
+//
 // The intention of this script is that it will be ran from CircleCI
 //
 // Example usage:
@@ -15,15 +18,17 @@ var username = process.env['SAUCE_USERNAME'];
 var accessKey = process.env['SAUCE_ACCESS_KEY'];
 var baseDir = process.env['CIRCLE_ARTIFACTS'] || '/tmp';
 var url = process.argv[2];
-var dir = baseDir+'/imgs'
-fs.mkdirSync(dir)
+var allImgsDir = baseDir+'/imgs';
+fs.mkdirSync(allImgsDir);
 
 var browserVersions = [
   {
+    // Expecting IE 8
     'browserName': 'Internet Explorer',
     'platform': 'Windows XP'
   },
   {
+    // Expecting IE 11
     'browserName': 'Internet Explorer',
     'platform': 'Windows 7'
   },
@@ -54,13 +59,13 @@ browserVersions.forEach(function(cfg) {
   var browserDriver = wd.remote('ondemand.saucelabs.com', 80, username, accessKey);
   // The following is in the style of
   // https://github.com/admc/wd/blob/62f2b0060d36a402de5634477b26a5ed4c051967/examples/async/chrome.js#L25-L40
-  browserDriver.init(cfg, function(err, _, cap) {
-    var browser = cfg.browserName.replace(/\s/g, '_')+(!!cap ? '_'+cap.version : '');
-    var platform = (cap ? cap : cfg).platform.replace(/\s/g, '_');
-    var subDir = dir+'/'+browser+'_'+platform;
-    fs.mkdirSync(subDir)
-
+  browserDriver.init(cfg, function(err, _, capabilities) {
     if (err) console.log(err);
+
+    var browser = cfg.browserName.replace(/\s/g, '_')+(capabilities ? '_'+capabilities.version : '');
+    var platform = (capabilities || cfg).platform.replace(/\s/g, '_');
+    var piecesDir = allImgsDir+'/'+browser+'_'+platform;
+    fs.mkdirSync(piecesDir);
 
     browserDriver.get(url, function(err) {
       if (err) console.log(err);
@@ -69,46 +74,61 @@ browserVersions.forEach(function(cfg) {
         browserDriver.safeExecute('document.documentElement.clientHeight', function(err,viewportHeight) {
           if (err) console.log(err);
 
-          var position = 0;
-          // loop generates the image(s). Firefox and Internet Explorer will take
-          // a screenshot of the entire webpage, but Opera, Safari, and Chrome
-          // do not. For those browsers we scroll through the page and take
-          // incremental screenshots.
-          (function loop() {
-            var shot = (position/viewportHeight) + 1;
+          // Firefox and Internet Explorer will take a screenshot of the entire webpage,
+          if (cfg.browserName != 'Safari' && cfg.browserName != 'Chrome' && cfg.browserName != 'MicrosoftEdge') {
+            // saves file in the file `piecesDir/browser_version_platform/*.png`
+            var filename = piecesDir+'/'+browser+'_'+platform+'.png';
+            browserDriver.saveScreenshot(filename, function(err) {
+              if (err) console.log(err);
 
-            if (cfg.browserName != 'Safari' && cfg.browserName != 'Chrome' && cfg.browserName != 'MicrosoftEdge') {
-              // saves file in the file `subDir/browser_version_platform.png`
-              var filename = subDir+'/'+browser+'_'+platform+'.png';
-              browserDriver.saveScreenshot(filename, function(err) {
+              browserDriver.log('browser', function(err,logs) {
                 if (err) console.log(err);
 
-                browserDriver.quit();
+                var logfile = baseDir+'/'+browser+'_'+platform+'.log'
+                logs = logs || [];
+                fs.writeFile(logfile,logs.join('\n'), function(err) {
+                  if (err) console.log(err);
+
+                  browserDriver.quit();
+                });
               });
-            } else {
+
+            });
+          } else {
+            var scrollTop = 0;
+
+            // loop generates the images. Firefox and Internet Explorer will take
+            // a screenshot of the entire webpage, but Opera, Safari, and Chrome
+            // do not. For those browsers we scroll through the page and take
+            // incremental screenshots.
+            (function loop() {
+              var index = (scrollTop/viewportHeight) + 1;
+
               // Use `window.scrollTo` because thats what jQuery does
               // https://github.com/jquery/jquery/blob/1.12.3/src/offset.js#L186
-              browserDriver.safeEval('window.scrollTo(0,'+position+');', function(err) {
+              // `window.scrollTo` was used instead of jQuery because jQuery was
+              // causing a stackoverflow in Safari.
+              browserDriver.safeEval('window.scrollTo(0,'+scrollTop+');', function(err) {
                 if (err) console.log(JSON.stringify(err));
 
-                // saves file in the file `subDir/browser_version_platform/#.png`
-                var filename = subDir+'/'+shot+'.png';
+                // saves file in the file `piecesDir/browser_version_platform/#.png`
+                var filename = piecesDir+'/'+index+'.png';
                 browserDriver.saveScreenshot(filename, function(err) {
                   if (err) console.log(err);
 
-                  position += viewportHeight;
-                  if (position + viewportHeight > scrollHeight) {
+                  scrollTop += viewportHeight;
+                  if (scrollTop + viewportHeight > scrollHeight) {
                     browserDriver.getWindowSize(function(err,size) {
                       // account for the viewport offset
                       var extra = size.height - viewportHeight;
-                      browserDriver.setWindowSize(size.width, (scrollHeight-position)+extra, function(err) {
+                      browserDriver.setWindowSize(size.width, (scrollHeight-scrollTop)+extra, function(err) {
                         if (err) console.log(err);
 
                         browserDriver.safeEval('window.scrollTo(0,'+scrollHeight+');', function(err) {
                           if (err) console.log(JSON.stringify(err));
 
-                          shot++;
-                          var filename = subDir+'/'+shot+'.png';
+                          index++;
+                          var filename = piecesDir+'/'+index+'.png';
                           browserDriver.saveScreenshot(filename, function(err) {
                             if (err) console.log(err);
 
@@ -116,7 +136,7 @@ browserVersions.forEach(function(cfg) {
                               if (err) console.log(err);
 
                               var logfile = baseDir+'/'+browser+'_'+platform+'.log'
-                              logs = logs ? logs : [];
+                              logs = logs || [];
                               fs.writeFile(logfile,logs.join('\n'), function(err) {
                                 if (err) console.log(err);
 
@@ -133,8 +153,8 @@ browserVersions.forEach(function(cfg) {
                   }
                 });
               });
-            }
-          })();
+            })();
+          }
         });
       });
     });

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -17,8 +17,8 @@ var url = process.argv[2];
 
 var browserVersions = [
   {
-    'browserName': 'chrome',
-    'platform': 'OS X 10.11'
+    'browserName': 'Internet Explorer',
+    'platform': 'Windows XP'
   },
   {
     'browserName': 'firefox',
@@ -26,7 +26,11 @@ var browserVersions = [
   },
   {
     'browserName': 'safari'
-    // Adding platform here makes tests hang.
+    //'platform': 'OS X 10.10'
+  },
+  {
+    'browserName': 'chrome',
+    'platform': 'OS X 10.11'
   }
 ];
 

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -31,10 +31,6 @@ var browserVersions = [
 ];
 
 
-var widthScript  = 'return Math.max(document.body.scrollWidth, document.body.offsetWidth, document.documentElement.clientWidth, document.documentElement.scrollWidth, document.documentElement.offsetWidth);'
-var heightScript = 'return Math.max(document.body.scrollHeight, document.body.offsetHeight, document.documentElement.clientHeight, document.documentElement.scrollHeight, document.documentElement.offsetHeight);'
-
-
 browserVersions.forEach(function(cfg) {
   var browserDriver = wd.remote('ondemand.saucelabs.com', 80, username, accessKey);
   // The following is in the style of

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -63,7 +63,7 @@ browserVersions.forEach(function(cfg) {
             var shot = (position/viewportHeight) + 1;
 
             if (cfg.browserName == 'firefox' || cfg.browserName == 'Internet Explorer') {
-              // saves file in the file `dir/browser_version_platform.png`
+              // saves file in the file `subDir/browser_version_platform.png`
               var filename = subDir+'/'+browser+'_'+platform+'.png';
               browserDriver.saveScreenshot(filename, function(err) {
                 if (err) console.log(err);
@@ -76,7 +76,7 @@ browserVersions.forEach(function(cfg) {
               browserDriver.safeEval('window.scrollTo(0,'+position+');', function(err) {
                 if (err) console.log(JSON.stringify(err));
 
-                // saves file in the file `dir/browser_version_platform_#.png`
+                // saves file in the file `subDir/browser_version_platform/#.png`
                 var filename = subDir+'/'+shot+'.png';
                 browserDriver.saveScreenshot(filename, function(err) {
                   if (err) console.log(err);

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -1,7 +1,7 @@
 // This script assumes the following:
 //   1. You've installed wd with `npm install wd'.
 //   2. You've set the environment variables $SAUCE_USERNAME and $SAUCE_ACCESS_KEY.
-//   3. If the environment variable $CIRCLE_ARTIFACTS is not set imanges will be saved in /tmp
+//   3. If the environment variable $CIRCLE_ARTIFACTS is not set images will be saved in /tmp
 //
 // This scripts creates following files for each browser in browserVersions:
 //    $CIRCLE_ARTIFACTS/imgs/{browser_version_platform}/#.png
@@ -9,8 +9,8 @@
 // The intention of this script is that it will be ran from CircleCI
 //
 // Example usage:
-// node screenshots.js http://localhost:9292/test/visual.html
-// node screenshots.js http://google.com
+//   node screenshots.js http://localhost:9292/test/visual.html
+//   node screenshots.js http://google.com
 
 var wd = require('wd');
 var fs = require('fs');

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -24,17 +24,29 @@ var browserVersions = [
     'platform': 'Windows XP'
   },
   {
-    'browserName': 'firefox',
+    'browserName': 'Internet Explorer',
+    'platform': 'Windows 7'
+  },
+  {
+    'browserName': 'MicrosoftEdge',
+    'platform': 'Windows 10'
+  },
+  {
+    'browserName': 'Firefox',
     'platform': 'OS X 10.11'
   },
   {
-    'browserName': 'safari',
+    'browserName': 'Safari',
     'platform': 'OS X 10.11'
   },
   {
-    'browserName': 'chrome',
+    'browserName': 'Chrome',
     'platform': 'OS X 10.11'
-  }
+  },
+  {
+    'browserName': 'Firefox',
+    'platform': 'Linux'
+  },
 ];
 
 
@@ -65,7 +77,7 @@ browserVersions.forEach(function(cfg) {
           (function loop() {
             var shot = (position/viewportHeight) + 1;
 
-            if (cfg.browserName == 'firefox' || cfg.browserName == 'Internet Explorer') {
+            if (cfg.browserName != 'Safari' && cfg.browserName != 'Chrome' && cfg.browserName != 'MicrosoftEdge') {
               // saves file in the file `subDir/browser_version_platform.png`
               var filename = subDir+'/'+browser+'_'+platform+'.png';
               browserDriver.saveScreenshot(filename, function(err) {
@@ -103,8 +115,8 @@ browserVersions.forEach(function(cfg) {
                             browserDriver.log('browser', function(err,logs) {
                               if (err) console.log(err);
 
-
                               var logfile = baseDir+'/'+browser+'_'+platform+'.log'
+                              logs = logs ? logs : [];
                               fs.writeFile(logfile,logs.join('\n'), function(err) {
                                 if (err) console.log(err);
 

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -29,6 +29,10 @@ var browserVersions = [
     'platform': 'OS X 10.11'
   },
   {
+    'browserName': 'safari',
+    'platform': 'OS X 10.11'
+  },
+  {
     'browserName': 'chrome',
     'platform': 'OS X 10.11'
   }

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -60,8 +60,6 @@ browserVersions.forEach(function(cfg) {
           // do not. For those browsers we scroll through the page and take
           // incremental screenshots.
           (function loop() {
-            //var browser = cfg.browserName.replace(/\s/g, '_')+(!!cap ? '_'+cap.version : '');
-            //var platform = (cap ? cap : cfg).platform.replace(/\s/g, '_');
             var shot = (position/viewportHeight) + 1;
 
             if (cfg.browserName == 'firefox' || cfg.browserName == 'Internet Explorer') {
@@ -107,12 +105,6 @@ browserVersions.forEach(function(cfg) {
                   } else {
                     loop();
                   }
-
-                  //if (position >= scrollHeight) {
-                  //  browserDriver.quit();
-                  //} else {
-                  //  loop();
-                  //}
                 });
               });
             }

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -25,14 +25,13 @@ var browserVersions = [
     'platform': 'OS X 10.11'
   },
   {
-    'browserName': 'safari',
-    'platform': 'OS X 10.11'
+    'browserName': 'safari'
+    // Adding platform here makes tests hang.
   }
 ];
 
-var browserDriver = wd.remote('ondemand.saucelabs.com', 80, username, accessKey);
-
 browserVersions.forEach(function(cfg) {
+  var browserDriver = wd.remote('ondemand.saucelabs.com', 80, username, accessKey);
   // The following is in the style of
   // https://github.com/admc/wd/blob/62f2b0060d36a402de5634477b26a5ed4c051967/examples/async/chrome.js#L25-L40
   browserDriver.init(cfg, function(err, _, cap) {
@@ -41,13 +40,14 @@ browserVersions.forEach(function(cfg) {
     browserDriver.get(url, function(err) {
       if (err) console.log(err);
 
-      var browser = cfg.browserName+'_'+cap.version
-      var platform = cap.platform.replace(/\s/g, '_')
+      var browser = cfg.browserName+(!!cap ? '_'+cap.version : '');
+      var platform = cap.platform.replace(/\s/g, '_');
 
       // saves file in the file `dir/browser_version_platform.png`
-      var filename = dir+'/'+browser+'_'+platform+'.png'
+      var filename = dir+'/'+browser+'_'+platform+'.png';
       browserDriver.saveScreenshot(filename, function(err) {
         if (err) console.log(err);
+        browserDriver.quit()
       });
     });
   });

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -1,0 +1,54 @@
+// This script assumes the following:
+//   1. You've installed wd with `npm install wd'.
+//   2. You've set the environment variables $SAUCE_USERNAME and $SAUCE_ACCESS_KEY.
+//   3. If the environment variable $CIRCLE_ARTIFACTS is not set imanges will be saved in /tmp
+//
+// The intention of this script is that it will be ran from CircleCI
+//
+// Example usage:
+// node screenshots.js http://localhost:9292/test/visual.html
+// node screenshots.js http://google.com
+
+var wd = require('wd');
+var username = process.env['SAUCE_USERNAME'];
+var accessKey = process.env['SAUCE_ACCESS_KEY'];
+var dir = process.env['CIRCLE_ARTIFACTS'] || '/tmp';
+var url = process.argv[2];
+
+var browserVersions = [
+  {
+    'browserName': 'chrome',
+    'platform': 'OS X 10.11'
+  },
+  {
+    'browserName': 'firefox',
+    'platform': 'OS X 10.11'
+  },
+  {
+    'browserName': 'safari',
+    'platform': 'OS X 10.11'
+  }
+];
+
+var browserDriver = wd.remote('ondemand.saucelabs.com', 80, username, accessKey);
+
+browserVersions.forEach(function(cfg) {
+  // The following is in the style of
+  // https://github.com/admc/wd/blob/62f2b0060d36a402de5634477b26a5ed4c051967/examples/async/chrome.js#L25-L40
+  browserDriver.init(cfg, function(err, _, cap) {
+    if (err) console.log(err);
+
+    browserDriver.get(url, function(err) {
+      if (err) console.log(err);
+
+      var browser = cfg.browserName+'_'+cap.version
+      var platform = cap.platform.replace(/\s/g, '_')
+
+      // saves file in the file `dir/browser_version_platform.png`
+      var filename = dir+'/'+browser+'_'+platform+'.png'
+      browserDriver.saveScreenshot(filename, function(err) {
+        if (err) console.log(err);
+      });
+    });
+  });
+});

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -28,10 +28,6 @@ var browserVersions = [
     'browserName': 'firefox',
     'platform': 'OS X 10.11'
   },
-//  {
-//    'browserName': 'safari',
-//    'platform': ''
-//  },
   {
     'browserName': 'chrome',
     'platform': 'OS X 10.11'

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -100,7 +100,16 @@ browserVersions.forEach(function(cfg) {
                           var filename = subDir+'/'+shot+'.png';
                           browserDriver.saveScreenshot(filename, function(err) {
                             if (err) console.log(err);
-                            browserDriver.quit();
+
+                            browserDriver.log('browser', function(err,logs) {
+                              if (err) console.log(err);
+
+                              fs.writeFile(subDir+'.log',logs.join('\n'), function(err) {
+                                if (err) console.log(err);
+
+                                browserDriver.quit();
+                              });
+                            });
                           });
                         });
 

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -10,10 +10,14 @@
 // node screenshots.js http://google.com
 
 var wd = require('wd');
+var fs = require('fs');
 var username = process.env['SAUCE_USERNAME'];
 var accessKey = process.env['SAUCE_ACCESS_KEY'];
 var dir = process.env['CIRCLE_ARTIFACTS'] || '/tmp';
 var url = process.argv[2];
+
+dir = dir+'/imgs'
+fs.mkdirSync(dir)
 
 var browserVersions = [
   {
@@ -24,10 +28,10 @@ var browserVersions = [
     'browserName': 'firefox',
     'platform': 'OS X 10.11'
   },
-  {
-    'browserName': 'safari'
-    //'platform': 'OS X 10.10'
-  },
+//  {
+//    'browserName': 'safari',
+//    'platform': ''
+//  },
   {
     'browserName': 'chrome',
     'platform': 'OS X 10.11'
@@ -40,13 +44,18 @@ browserVersions.forEach(function(cfg) {
   // The following is in the style of
   // https://github.com/admc/wd/blob/62f2b0060d36a402de5634477b26a5ed4c051967/examples/async/chrome.js#L25-L40
   browserDriver.init(cfg, function(err, _, cap) {
+    var browser = cfg.browserName.replace(/\s/g, '_')+(!!cap ? '_'+cap.version : '');
+    var platform = (cap ? cap : cfg).platform.replace(/\s/g, '_');
+    var subDir = dir+'/'+browser+'_'+platform;
+    fs.mkdirSync(subDir)
+
     if (err) console.log(err);
 
     browserDriver.get(url, function(err) {
       if (err) console.log(err);
       browserDriver.safeExecute('document.documentElement.scrollHeight', function(err,scrollHeight) {
         if (err) console.log(err);
-        browserDriver.safeExecute('document.documentElement.clientHeight', function(err,windowHeight) {
+        browserDriver.safeExecute('document.documentElement.clientHeight', function(err,viewportHeight) {
           if (err) console.log(err);
 
           var position = 0;
@@ -55,13 +64,13 @@ browserVersions.forEach(function(cfg) {
           // do not. For those browsers we scroll through the page and take
           // incremental screenshots.
           (function loop() {
-            var browser = cfg.browserName.replace(/\s/g, '_')+(!!cap ? '_'+cap.version : '');
-            var platform = (cap ? cap : cfg).platform.replace(/\s/g, '_');
-            var shot = (position/windowHeight) + 1;
+            //var browser = cfg.browserName.replace(/\s/g, '_')+(!!cap ? '_'+cap.version : '');
+            //var platform = (cap ? cap : cfg).platform.replace(/\s/g, '_');
+            var shot = (position/viewportHeight) + 1;
 
             if (cfg.browserName == 'firefox' || cfg.browserName == 'Internet Explorer') {
               // saves file in the file `dir/browser_version_platform.png`
-              var filename = dir+'/'+browser+'_'+platform+'.png';
+              var filename = subDir+'/'+browser+'_'+platform+'.png';
               browserDriver.saveScreenshot(filename, function(err) {
                 if (err) console.log(err);
 
@@ -74,16 +83,40 @@ browserVersions.forEach(function(cfg) {
                 if (err) console.log(JSON.stringify(err));
 
                 // saves file in the file `dir/browser_version_platform_#.png`
-                var filename = dir+'/'+browser+'_'+platform+'_'+shot+'.png';
+                var filename = subDir+'/'+shot+'.png';
                 browserDriver.saveScreenshot(filename, function(err) {
                   if (err) console.log(err);
 
-                  position += windowHeight;
-                  if (position >= scrollHeight) {
-                    browserDriver.quit();
+                  position += viewportHeight;
+                  if (position + viewportHeight > scrollHeight) {
+                    browserDriver.getWindowSize(function(err,size) {
+                      // account for the viewport offset
+                      var extra = size.height - viewportHeight;
+                      browserDriver.setWindowSize(size.width, (scrollHeight-position)+extra, function(err) {
+                        if (err) console.log(err);
+
+                        browserDriver.safeEval('window.scrollTo(0,'+scrollHeight+');', function(err) {
+                          if (err) console.log(JSON.stringify(err));
+
+                          shot++;
+                          var filename = subDir+'/'+shot+'.png';
+                          browserDriver.saveScreenshot(filename, function(err) {
+                            if (err) console.log(err);
+                            browserDriver.quit();
+                          });
+                        });
+
+                      });
+                    });
                   } else {
                     loop();
                   }
+
+                  //if (position >= scrollHeight) {
+                  //  browserDriver.quit();
+                  //} else {
+                  //  loop();
+                  //}
                 });
               });
             }

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -13,10 +13,9 @@ var wd = require('wd');
 var fs = require('fs');
 var username = process.env['SAUCE_USERNAME'];
 var accessKey = process.env['SAUCE_ACCESS_KEY'];
-var dir = process.env['CIRCLE_ARTIFACTS'] || '/tmp';
+var baseDir = process.env['CIRCLE_ARTIFACTS'] || '/tmp';
 var url = process.argv[2];
-
-dir = dir+'/imgs'
+var dir = baseDir+'/imgs'
 fs.mkdirSync(dir)
 
 var browserVersions = [
@@ -104,7 +103,9 @@ browserVersions.forEach(function(cfg) {
                             browserDriver.log('browser', function(err,logs) {
                               if (err) console.log(err);
 
-                              fs.writeFile(subDir+'.log',logs.join('\n'), function(err) {
+
+                              var logfile = baseDir+'/'+browser+'_'+platform+'.log'
+                              fs.writeFile(logfile,logs.join('\n'), function(err) {
                                 if (err) console.log(err);
 
                                 browserDriver.quit();

--- a/script/test_server.js
+++ b/script/test_server.js
@@ -35,12 +35,14 @@ function serveRequest(req, res) {
         }
       }
       else {
+        var ext = filepath.match(/\.[^.]+$/);
+        if (ext) res.setHeader('Content-Type', 'text/' + ext[0].slice(1));
         res.end(data);
       }
 
       console.log('[%s] %s %s /%s - %s%sms',
-        reqTime.toISOString(), res.statusCode, req.method, filepath,
-        (data ? (data.length >> 10) + 'kb, ' : ''), Date.now() - reqTime);
+                  reqTime.toISOString(), res.statusCode, req.method, filepath,
+                  (data ? (data.length >> 10) + 'kb, ' : ''), Date.now() - reqTime);
     });
   });
 }

--- a/script/test_server.js
+++ b/script/test_server.js
@@ -41,8 +41,8 @@ function serveRequest(req, res) {
       }
 
       console.log('[%s] %s %s /%s - %s%sms',
-                  reqTime.toISOString(), res.statusCode, req.method, filepath,
-                  (data ? (data.length >> 10) + 'kb, ' : ''), Date.now() - reqTime);
+        reqTime.toISOString(), res.statusCode, req.method, filepath,
+        (data ? (data.length >> 10) + 'kb, ' : ''), Date.now() - reqTime);
     });
   });
 }

--- a/test/unit/focusBlur.test.js
+++ b/test/unit/focusBlur.test.js
@@ -80,7 +80,7 @@ suite('focusBlur', function() {
           $(mq.el()).remove();
           done();
         });
-      }, 10);
+      }, 100);
     });
   });
 });

--- a/test/visual.html
+++ b/test/visual.html
@@ -280,7 +280,7 @@ x+\class{testclass}{y}+z
 </div>
 <script type="text/javascript">
 window.onerror = function(err) {
-  console.log(err);
+  console.log(err); // to show up in Selenium WebDriver logs
   $('html').css('background', 'red');
 };
 </script>

--- a/test/visual.html
+++ b/test/visual.html
@@ -279,7 +279,8 @@ x+\class{testclass}{y}+z
 
 </div>
 <script type="text/javascript">
-window.onerror = function() {
+window.onerror = function(err) {
+  console.log(err);
   $('html').css('background', 'red');
 };
 </script>


### PR DESCRIPTION
This script is used to connect to Selenium on Sauce using `wd` (a
webdriver for Selenium). This was the first webdriver that we came
across it seems to be feature complete, but the standard webdriver for
Selenium is http://webdriver.io/. The variable `browserVersions` is the list of browsers that screenshots will be taken for.

This script assumes the following:
  1. You've installed wd with `npm install wd'.
  2. You've set the environment variables `$SAUCE_USERNAME` and `$SAUCE_ACCESS_KEY`.
  3. If the environment variable `$CIRCLE_ARTIFACTS` is not set imanges will be saved in /tmp

The intention of this script is that it will be ran from CircleCI

Example usage:
`node screenshots.js http://localhost:9292/test/visual.html`
`node screenshots.js http://google.com`

Todo:
* [x] Use image-magick to make a single screenshot. `convert chrome_50.0.2661.94_Mac_OS_X_*.png -append chrome.png`.
* [x] Figure out why Safari doesn't work with `sc` for `localhost`.
* [x] Decide on a small but comprehensive set of browsers to try.