### PR TITLE
Fix CircleCI for forks

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -81,7 +81,7 @@ test:
     # "build" and "tag" parameters from:
     #   https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-TestAnnotation
     - |-
-      curl -i https://saucelabs.com/rest/v1/mathquill/js-tests \
+      curl -i https://saucelabs.com/rest/v1/$SAUCE_USERNAME/js-tests \
            -X POST \
            -u $SAUCE_USERNAME:$SAUCE_ACCESS_KEY \
            -H 'Content-Type: application/json' \
@@ -106,7 +106,7 @@ test:
       while true  # Bash has no do...while >:(
       do
         sleep 5
-        curl -i https://saucelabs.com/rest/v1/mathquill/js-tests/status \
+        curl -i https://saucelabs.com/rest/v1/$SAUCE_USERNAME/js-tests/status \
              -X POST \
              -u $SAUCE_USERNAME:$SAUCE_ACCESS_KEY \
              -H 'Content-Type: application/json' \


### PR DESCRIPTION
People may want to sign up for Circle and Sauce for their public, open
source forks (which I've done for my laughinghan/mathquill fork),
`circle.yml` should be general and work if they do that.

(Instead, it was showing a
```
{"error": "Not found"}
```
in `status.json`.)