### PR TITLE
Inset diacritics; fix size and position; add many more

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -489,20 +489,54 @@ LatexCmds.nthroot = P(SquareRoot, function(_, super_) {
   };
 });
 
+// the Short Math Guide to LaTeX calls these "Accents"
+//   (Section 3.17: http://tinyurl.com/gq4c4od )
+// but Wikipedia says only some diacritical marks like acute and grave are accents
 var DiacriticAbove = P(MathCommand, function(_, super_) {
   _.init = function(ctrlSeq, symbol, textTemplate) {
     var htmlTemplate =
-      '<span class="mq-non-leaf">'
-      +   '<span class="mq-diacritic-above">'+symbol+'</span>'
-      +   '<span class="mq-diacritic-stem mq-inset">&0</span>'
+        '<span class="mq-diacritic mq-non-leaf">'
+      +   '<span class="mq-diacritic-above">'+symbol+'&nbsp;</span>'
+      +   '<span class="mq-non-leaf mq-inset">&0</span>'
       + '</span>'
     ;
 
     super_.init.call(this, ctrlSeq, htmlTemplate, textTemplate);
   };
+  _.reflow = function() {
+    var block = this.ends[L], allLow = !block.isEmpty(), anyTs = false;
+    if (allLow) block.eachChild(function(cmd) {
+      if (!(cmd.ctrlSeq in LOW_LETTERS)) allLow = false;
+      if (cmd.ctrlSeq === 't') anyTs = true;
+    });
+    this.jQ.toggleClass('mq-diacritic-low', allLow)
+           .toggleClass('mq-diacritic-t', anyTs);
+  };
+  var LOW_ROMAN_LETTERS = 'acegmnopqrstuvwxyz';
+  var LOW_GREEK_LETTERS = 'alpha gamma eta iota kappa mu nu rho sigma tau chi omega varphi epsilon varepsilon pi varpi varsigma upsilon digamma varkappa varrho psi'.split(' ');
+
+  var LOW_LETTERS = {};
+  for (var i = 0; i < LOW_ROMAN_LETTERS.length; i += 1) {
+    LOW_LETTERS[LOW_ROMAN_LETTERS.charAt(i)] = 1;
+  }
+  for (var i = 0; i < LOW_GREEK_LETTERS.length; i += 1) {
+    LOW_LETTERS['\\'+LOW_GREEK_LETTERS[i]+' '] = 1;
+  }
 });
-LatexCmds.vec = bind(DiacriticAbove, '\\vec', '&rarr;', ['vec(', ')']);
-LatexCmds.tilde = bind(DiacriticAbove, '\\tilde', '~', ['tilde(', ')']);
+// Unicode "Combining Diacritical Marks"
+LatexCmds.grave = bind(DiacriticAbove, '\\grave', '&#x0300;', ['grave(', ')']);
+LatexCmds.acute = bind(DiacriticAbove, '\\acute', '&#x0301;', ['acute(', ')']);
+LatexCmds.hat = bind(DiacriticAbove, '\\hat', '&#x0302;', ['hat(', ')']); // aka circumflex
+LatexCmds.tilde = bind(DiacriticAbove, '\\tilde', '&#x0303;', ['tilde(', ')']);
+LatexCmds.bar = bind(DiacriticAbove, '\\bar', '&#x0304;', ['bar(', ')']); // aka macron/overline
+LatexCmds.breve = bind(DiacriticAbove, '\\breve', '&#x0306;', ['breve(', ')']);
+LatexCmds.dot = bind(DiacriticAbove, '\\dot', '&#x0307;', ['dot(', ')']);
+LatexCmds.ddot = bind(DiacriticAbove, '\\ddot', '&#x0307;', ['ddot(', ')']); // aka diaeresis/umlaut
+LatexCmds.check = bind(DiacriticAbove, '\\check', '&#x030C', ['check(', ')']); // aka caron/hacek
+// Unicode "Combining Diacritical Marks for Symbols"
+LatexCmds.vec = bind(DiacriticAbove, '\\vec', '&#x20D7;', ['vec(', ')']);
+LatexCmds.dddot = bind(DiacriticAbove, '\\dddots', '&#x20DB;', ['dddot(', ')']);
+LatexCmds.ddddot = bind(DiacriticAbove, '\\dddots', '&#x20DC;', ['ddddot(', ')']);
 
 function DelimsMixin(_, super_) {
   _.jQadd = function() {

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -494,7 +494,7 @@ var DiacriticAbove = P(MathCommand, function(_, super_) {
     var htmlTemplate =
       '<span class="mq-non-leaf">'
       +   '<span class="mq-diacritic-above">'+symbol+'</span>'
-      +   '<span class="mq-diacritic-stem">&0</span>'
+      +   '<span class="mq-diacritic-stem mq-inset">&0</span>'
       + '</span>'
     ;
 

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -69,7 +69,7 @@ var TextBlock = P(Node, function(_, super_) {
   };
   _.html = function() {
     return (
-        '<span class="mq-text-mode" mathquill-command-id='+this.id+'>'
+        '<span class="mq-text-mode mq-inset" mathquill-command-id='+this.id+'>'
       +   this.textContents()
       + '</span>'
     );

--- a/src/css/editable.less
+++ b/src/css/editable.less
@@ -46,6 +46,16 @@
       border-color: ActiveBorder;
     }
   }
+
+  ////
+  // text blocks, diacritics, etc that otherwise have no visible boundary
+  .mq-inset.mq-hasCursor {
+    box-shadow: inset darkgray 0 .1em .2em;
+    padding: 0 .1em;
+    margin: 0 -.1em;
+
+    min-width: 1ex;
+  }
 }
 
 // Keeps blocks from collapsing to zero width/height

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -286,15 +286,29 @@
     padding-top: 1px;
   }
 
-  .mq-diacritic-above {
-    display: block;
-    text-align: center;
-    line-height: .4em;
-  }
+  .mq-diacritic {
+    position: relative;
 
-  .mq-diacritic-stem {
-    display: block;
+    padding-top: .2em;
+    &.mq-diacritic-low {
+      padding-top: 0;
+      &.mq-diacritic-t {
+        padding: .1em;
+      }
+    }
+  }
+  .mq-diacritic-above {
+    position: absolute;
+    left: 0;
+    right: 0;
     text-align: center;
+
+    top: .06em; // yes, really, .05em isn't low enough in Chrome,
+                             // .07em is too low in Firefox & Safari
+  }
+  .mq-diacritic-low > .mq-diacritic-above {
+    left: -.1em;
+    right: .1em;
   }
 
   .mq-large-operator {

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -47,16 +47,8 @@
     background: transparent;
   }
 
-
   .mq-text-mode {
     display: inline-block;
-  }
-  .mq-text-mode.mq-hasCursor {
-    box-shadow: inset darkgray 0 .1em .2em;
-    padding: 0 .1em;
-    margin: 0 -.1em;
-
-    min-width: 1ex;
   }
 
   .mq-font {

--- a/test/visual.html
+++ b/test/visual.html
@@ -211,10 +211,13 @@ $(function() {
 <tr><td><span class="mathquill-static-math">1+\sum_0^n+\sum_{i=0123}^n+\sum_0^{wordiness}</span><td><span>1+\sum_0^n+\sum_{i=0123}^n+\sum_0^{wordiness}</span>^M
 <tr><td><span class="mathquill-static-math">x\ \ \ +\ \ \ y</span><td><span>x\ \ \ +\ \ \ y</span>^M
 <tr><td><span class="mathquill-static-math">\sum _{n=0}^3\cos x</span><td><span>\sum _{n=0}^3\cos x</span>^M
-<tr><td><span class="mathquill-static-math">\vec x + \tilde x + \vec A + \tilde A + \vec{abcd} + \tilde{abcd}</span><td><span>\vec x + \tilde x + \vec A + \tilde A + \vec{abcd} + \tilde{abcd}</span>^M
+<tr><td><span class="mathquill-static-math">\dot a \dot c \dot e \dot g \dot m \dot n \dot o \dot p \dot q \dot r \dot s \dot u \dot v \dot w \dot x \dot y \dot z \dot t  \dot A \dot B \dot C \dot i \dot j \dot b \dot d \dot f \dot h \dot k \dot l</span><td><span>\dot a \dot c \dot e \dot g \dot m \dot n \dot o \dot p \dot q \dot r \dot s \dot u \dot v \dot w \dot x \dot y \dot z \dot t  \dot A \dot B \dot C \dot i \dot j \dot b \dot d \dot f \dot h \dot k \dot l</span>^M
+<tr><td><span class="mathquill-static-math">\dot \alpha \dot \gamma \dot \eta \dot \iota \dot  \kappa \dot \mu \dot \nu \dot \rho \dot \sigma \dot \tau \dot \chi \dot \omega \dot \varphi \dot \epsilon \dot \varepsilon \dot \pi \dot \varpi \dot \varsigma \dot \upsilon \dot \digamma \dot \varkappa \dot \varrho \dot \psi \dot t \dot A \dot \delta \dot \Delta \dot \Sigma \dot \Psi \dot \beta \dot \zeta \dot \theta \dot \xi \dot \phi \dot \lambda \dot \vartheta</span><td><span>\dot \alpha \dot \gamma \dot \eta \dot \iota \dot  \kappa \dot \mu \dot \nu \dot \rho \dot \sigma \dot \tau \dot \chi \dot \omega \dot \varphi \dot \epsilon \dot \varepsilon \dot \pi \dot \varpi \dot \varsigma \dot \upsilon \dot \digamma \dot \varkappa \dot \varrho \dot \psi \dot t \dot A \dot \delta \dot \Delta \dot \Sigma \dot \Psi \dot \beta \dot \zeta \dot \theta \dot \xi \dot \phi \dot \lambda \dot \vartheta</span>^M
+<tr><td><span class="mathquill-static-math">\sqrt{a\vec x} + \tilde x + \sqrt{\vec A B \vec X} + \tilde A + \vec{abcd} + \tilde{abcd}</span><td><span>\sqrt{a\vec x} + \tilde x + \sqrt{\vec A B \vec X} + \tilde A + \vec{abcd} + \tilde{abcd}</span>^M
 <tr><td><span class="mathquill-static-math">\int _{\phi =0}^{2\pi }\int _{\theta =0}^{\pi }\int _{r=0}^{\infty }f(r,\theta ,\phi )r^2\sin \theta drd\theta d\phi </span><td><span>\int _{\phi =0}^{2\pi }\int _{\theta =0}^{\pi }\int _{r=0}^{\infty }f(r,\theta ,\phi )r^2\sin \theta drd\theta d\phi </span>
 <tr><td><span class="mathquill-static-math">\int_0^{\frac{\frac{1}{2}}{3}} \int_0^{\frac{1}{\frac{2}{3}}} \int_0^{\frac{1}{\frac{2}{\frac{3}{\frac{4}{5}}}}}</span><td><span>\int_0^{\frac{\frac{1}{2}}{3}} \int_0^{\frac{1}{\frac{2}{3}}} \int_0^{\frac{1}{\frac{2}{\frac{3}{\frac{4}{5}}}}}</span>
 <tr><td colspan=2><span id="sixes"></span>
+<tr><td colspan=2><span id="diacritics"></span>
 <script>
 $(function() {
     var i,
@@ -226,6 +229,17 @@ $(function() {
     }
     $('#sixes').html(sixes);
     $('#sixes .mathquill-math-field').each(function() { MQ.MathField(this); });
+
+    var i,
+        diacritics = '',
+        start = 12,
+        end = 20;
+    for (i = start; i <= end; i++) {
+        var fontSize = (i+'').slice(0,-1) + '.' + (i+'').slice(-1);
+        diacritics += '<span style="font-size: ' + fontSize + 'em" class="mathquill-math-field">\\sqrt{A\\vec X}</span>';
+    }
+    $('#diacritics').html(diacritics);
+    $('#diacritics .mathquill-math-field').each(function() { MQ.MathField(this); });
 });
 </script>
 </table>


### PR DESCRIPTION
## Inset diacritics

Before, there was no visual indication whether the cursor is "under" a
diacritic (i.e., inside a diacritic block):
![Before](https://git.io/votJ1)

After, the diacritic block gets a `box-shadow` that makes it look inset
when the cursor is inside, just like text blocks:
![After](https://git.io/votJy)

## Fix size and position, add many more

| Renderer | Screenshot |
|---|---|
| MathQuill (before) | <img width="264" alt="screen shot 2016-06-09 at 20 58 06" src="https://cloud.githubusercontent.com/assets/225809/15953871/f52b8028-2e84-11e6-99a0-bcf89096e403.png"> |
| MathQuill (after) | <img width="245" alt="screen shot 2016-06-09 at 21 00 01" src="https://cloud.githubusercontent.com/assets/225809/15953885/243ac84c-2e85-11e6-904b-1c738cc3bcb9.png"> |
| MathJax ([MathB.in](http://mathb.in/63306)) | <img width="240" alt="screen shot 2016-06-09 at 21 03 53" src="https://cloud.githubusercontent.com/assets/225809/15953948/cb95ed2e-2e85-11e6-836f-d12c2703ff83.png"> |
| KaTeX | <img width="250" alt="screen shot 2016-06-09 at 21 02 36" src="https://cloud.githubusercontent.com/assets/225809/15953924/88701f06-2e85-11e6-8bd3-8eb0f210ad98.png"> |
| `pdflatex` (LaTeXiT) | <img width="245" alt="screenshot LaTeXiT" src="https://cloud.githubusercontent.com/assets/225809/15980275/3dee0048-2f1f-11e6-9899-62e4c29da9e4.png"> |

Compared to other math renderers (including the official (?) `pdflatex`) the
arrow of `\vec` and wavy-waggly symbol of `\tilde` were too big and, for
lowercase letters, too high.

By using the actual Unicode characters for diacritics, they're the right
size and weight (if you try shrinking the arrow so it's the same size as
`\vec` in other renderers, it's too thin; the glyph for the diacritic is
bolded by comparison), and it means diacritics can all use the same CSS
and HTML template.(If we'd continued down the route we were on and used
`.` for `\dot`, it would've been much too low without special-cased
`\dot`-specific CSS.)

With this generic implementation, we add support for all non-stretchy
diacritics mentioned in the Short Math Guide to LaTeX, plus quadruple
dot `\ddddot`. (This actually brings us to parity with the first time I
tried to implement diacritics, on a now dead branch: https://github.com/laughinghan/mathquill/commit/1cadb70a1e053e6efe5415a926882aa5e4ee8d67#diff-239c238d8c090904fa1a9261bf2ef674R112 )

### Replacing `display: block` with `position: absolute`

To vertically stack the diacritical mark above the diacritic block, we
had been using the "two `display: block` elements inside a
`display: inline-block` element" technique that's also used for
fractions. However, when I tried to ensure that the diacritical mark
would take up some space (so as not to overlap with the overline of a
containing square root, for example), the diacritic block became
misaligned from adjacent text in Chrome and Safari (at most but not all
`font-size`s (?!)), see how `A` and `X` don't line up in so many of these:

- Chrome 50 with diacritics implemented using `display: block` and
  `margin`s:
  <img width="522" alt="Chrome 50 with diacritics implemented using `display: block` and `margin`s" src="https://git.io/votU1">
- Safari 9.1.1 with diacritics implemented using `display: block` and
  `margin`s:
  <img width="522" alt="Safari 9.1.1 with diacritics implemented using `display: block` and `margin`s" src="https://git.io/votUo">

This happens in both Chrome and Safari when using a `margin`, `padding`,
or `height` CSS property on the diacritical mark to take up space.
Using a transparent border actually works around the problem in
Chrome, but alas not in Safari:

- Safari 9.1.1 with diacritics implemented using `display: block` and
  `border-top: solid transparent .Xem`:
  <img width="522" alt="Safari 9.1.1 with diacritics implemented using `display: block` and `border-top: solid transparent .Xem`" src="https://git.io/votUi">

To reproduce, checkout this commit and apply the following patch:
https://gist.github.com/laughinghan/811933e6920980df5dc06fb35b3d6b2b

(This has been isolated into a [minimal testcase] and reported to both
[Chromium] and [WebKit].)

[minimal testcase]: http://output.jsbin.com/tivuvov
[Chromium]: https://bugs.chromium.org/p/chromium/issues/detail?id=617763
[WebKit]: https://bugs.webkit.org/show_bug.cgi?id=158441

So that sucks.

Instead I chose to use `position: absolute` on the diacritical mark,
which is actually what I did the first time I tried to implement
diacritics: https://github.com/laughinghan/mathquill/commit/220caffffda374fd89bb7a66ccc6f7b4a5600684

Who knows why, but without any block-level elements inside the diacritic
inline-block, and the right choice of padding (more on this in a moment),
the misalignment is gone in Chrome and much reduced in Safari:

- Safari 9.1.1 with this PR's diacritics implementation:
  <img width="522" alt="Safari 9.1.1 with this PR's diacritics implementation" src="https://git.io/votUP">

It's not all unicorns and disruption. With `.25em` instead of `.2em` of padding,
Chrome becomes misaligned again, though like Safari it's much reduced:

- Chrome 50 with this PR's diacritics implementation except with
  `padding-top: .25em`:
  <img width="522" alt="Chrome 50 with this PR's diacritics implementation except with `padding-top: .25em`" src="https://git.io/voZEo">

So this may be brittle, hence the new testcase in test/visual.html.

Besides less severe misalignment, another advantage of this
`position: absolute` technique over the `display: block` technique is
that we just have to change the one CSS property, `padding-top`, to both
lower the diacritic and reduce the space that it takes up, which we want
to do because...

### Lowercase letters

After shrinking the arrow and tilde, the fact that the diacritical marks
are too high above lowercase letters becomes especially pronounced.
Unfortunately, CSS/JS/DOM offer no good way to find the height in pixels
of a particular character in a particular font, the only techniques on
the Internet that work at all involve drawing the letter to a `<canvas>`
and examining the pixels ([StackOverflow][1], [StackOverflow again][2]),
which, um, no. KaTeX actually [hardcodes a JSON literal in their source][3]
with metrics for each character (?) in each of their fonts. (No idea what
MathJax does.)

[1]: http://stackoverflow.com/q/16816071/362030
[2]: http://stackoverflow.com/q/1134586/362030
[3]: https://github.com/Khan/KaTeX/blob/v0.6.0/src/fontMetricsData.js

You can see that KaTeX, MathJax, and pdflatex (LaTeXiT) do place
diacritics at heights carefully tailored to each character, with
diacritics above uppercase letters not quite the same height as above
tall lowercase letters (`b`, `d`, etc), nor quite the same height as
`i` and `j`:

| Renderer | Screenshot |
|---|---|
| MathQuill | <img width="264" src="https://git.io/voZrh"> |
| MathJax ([MathB.in](http://mathb.in/62706)) | <img width="287" src="https://git.io/voZrc"> |
| KaTeX | <img width="350" src="https://git.io/voZrC"> |
| `pdflatex` (LaTeXiT) | <img width="300" src="https://git.io/voZrW"> |

And, diacritics above capital Roman letters are slightly higher than
above capital Greek letters:

| Renderer | Screenshot |
|---|---|
| MathQuill | <img width="336" src="https://git.io/voZoq"> |
| MathJax ([MathB.in](http://mathb.in/62707)) | <img width="394" src="https://git.io/voZom"> |
| KaTeX | <img width="440" src="https://git.io/voZoY"> |
|`pdflatex` (LaTeXiT) | <img width="400" src="https://git.io/voZoO"> |

Overall, though, the height of diacritics above uppercase letters and
above tall lowercase letters is basically the same, and the height above
short lowercase letters is basically all the same; the only other height
significantly different from those two typical heights is above `t`,
which is somewhere in the middle, annoyingly.

So, I chose to simply use a hashset of all short lowercase Roman and
Greek letters (created at load time from hardcoded lists), and have a
special case for `t`, and assume anything else is tall. This does the
right thing for uppercase Roman and Greek letters, and is the right
height for `1`,`2`, `&`, `%` etc, but it doesn't take into account that
non-letter symbols aren't slanted, so the diacritic looks too far to
the right, and it's also the wrong height for comma `,` and other short,
non-letter symbols.

Anyway, way better-looking and more faithful to real LaTeX than before
for letters, which is what matters.