### PR TITLE
Overarrows and underarrows

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -79,8 +79,19 @@ LatexCmds.mathtt = bind(Style, '\\mathtt', 'span', 'class="mq-monospace mq-font"
 //text-decoration
 LatexCmds.underline = bind(Style, '\\underline', 'span', 'class="mq-non-leaf mq-underline"');
 LatexCmds.overline = LatexCmds.bar = bind(Style, '\\overline', 'span', 'class="mq-non-leaf mq-overline"');
-LatexCmds.overrightarrow = bind(Style, '\\overrightarrow', 'span', 'class="mq-non-leaf mq-overarrow mq-arrow-right"');
-LatexCmds.overleftarrow = bind(Style, '\\overleftarrow', 'span', 'class="mq-non-leaf mq-overarrow mq-arrow-left"');
+
+var OverArrow = P(MathCommand, function(_, super_) {
+  _.init = function(ctrlSeq, attrs) {
+    super_.init.call(
+      this,
+      ctrlSeq,
+      '<span '+attrs+'><span class="mq-arrow-inner">&0</span></span>'
+    );
+  };
+});
+
+LatexCmds.overrightarrow = bind(OverArrow, '\\overrightarrow', 'class="mq-non-leaf mq-overarrow mq-arrow-right"');
+LatexCmds.overleftarrow = bind(OverArrow, '\\overleftarrow', 'class="mq-non-leaf mq-overarrow mq-arrow-left"');
 
 // `\textcolor{color}{math}` will apply a color to the given math content, where
 // `color` is any valid CSS Color Value (see [SitePoint docs][] (recommended),

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -80,7 +80,7 @@ LatexCmds.mathtt = bind(Style, '\\mathtt', 'span', 'class="mq-monospace mq-font"
 LatexCmds.underline = bind(Style, '\\underline', 'span', 'class="mq-non-leaf mq-underline"');
 LatexCmds.overline = LatexCmds.bar = bind(Style, '\\overline', 'span', 'class="mq-non-leaf mq-overline"');
 
-var OverArrow = P(MathCommand, function(_, super_) {
+var OverUnderArrow = P(MathCommand, function(_, super_) {
   _.init = function(ctrlSeq, attrs) {
     super_.init.call(
       this,
@@ -90,9 +90,12 @@ var OverArrow = P(MathCommand, function(_, super_) {
   };
 });
 
-LatexCmds.overrightarrow = bind(OverArrow, '\\overrightarrow', 'class="mq-non-leaf mq-overarrow mq-arrow-right"');
-LatexCmds.overleftarrow = bind(OverArrow, '\\overleftarrow', 'class="mq-non-leaf mq-overarrow mq-arrow-left"');
-LatexCmds.overleftrightarrow = bind(OverArrow, '\\overleftrightarrow', 'class="mq-non-leaf mq-overarrow mq-arrow-leftright"');
+LatexCmds.overrightarrow = bind(OverUnderArrow, '\\overrightarrow', 'class="mq-non-leaf mq-overarrow mq-arrow-right"');
+LatexCmds.overleftarrow = bind(OverUnderArrow, '\\overleftarrow', 'class="mq-non-leaf mq-overarrow mq-arrow-left"');
+LatexCmds.overleftrightarrow = bind(OverUnderArrow, '\\overleftrightarrow', 'class="mq-non-leaf mq-overarrow mq-arrow-leftright"');
+LatexCmds.underrightarrow = bind(OverUnderArrow, '\\underrightarrow', 'class="mq-non-leaf mq-underarrow mq-arrow-right"');
+LatexCmds.underleftarrow = bind(OverUnderArrow, '\\underleftarrow', 'class="mq-non-leaf mq-underarrow mq-arrow-left"');
+LatexCmds.underleftrightarrow = bind(OverUnderArrow, '\\underleftrightarrow', 'class="mq-non-leaf mq-underarrow mq-arrow-leftright"');
 
 
 // `\textcolor{color}{math}` will apply a color to the given math content, where

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -92,6 +92,8 @@ var OverArrow = P(MathCommand, function(_, super_) {
 
 LatexCmds.overrightarrow = bind(OverArrow, '\\overrightarrow', 'class="mq-non-leaf mq-overarrow mq-arrow-right"');
 LatexCmds.overleftarrow = bind(OverArrow, '\\overleftarrow', 'class="mq-non-leaf mq-overarrow mq-arrow-left"');
+LatexCmds.overleftrightarrow = bind(OverArrow, '\\overleftrightarrow', 'class="mq-non-leaf mq-overarrow mq-arrow-leftright"');
+
 
 // `\textcolor{color}{math}` will apply a color to the given math content, where
 // `color` is any valid CSS Color Value (see [SitePoint docs][] (recommended),

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -124,7 +124,8 @@
     font-family: monospace, Symbola, serif;
   }
 
-  .mq-overline {
+  .mq-overline,
+  .mq-overarrow {
     border-top: 1px solid black;
     margin-top: 1px;
   }
@@ -329,26 +330,40 @@
   }
 
   .mq-overarrow {
-    border-top: 1px solid black;
-    margin-top: 1px;
-    padding-top: 0.2em;
+    text-align: center;
+    position: relative;
 
-    &:before {
+    &:before,
+    &:after {
       display: block;
-      position: relative;
-      top: -0.34em;
-      font-size: 0.5em;
-      line-height: 0em;
-      content: '\27A4';
-      text-align: right;
+      line-height: 1px;
+      font-size: 0.8em;
     }
     &.mq-arrow-left:before {
-      -moz-transform: scaleX(-1);
-      -o-transform: scaleX(-1);
-      -webkit-transform: scaleX(-1);
-      transform: scaleX(-1);
-      filter: FlipH;
-      -ms-filter: "FlipH";
+      content: '\2190';
+      text-align: left;
+      left: -1px;
+    }
+    &.mq-arrow-right:before {
+      content: '\2192';
+      text-align: right;
+      right: -1px;
+    }
+    &.mq-empty .mq-inner:before {
+      content: 'c';
+      visibility: hidden;
+    }
+  }
+
+  // @supports hack for Firefox ≥ 30
+  // from http://browserhacks.com/
+  @supports (-moz-appearance:meterbar) and (background-blend-mode:difference,normal) {
+    .mq-overarrow {
+      &:before,
+      &:after {
+        line-height: 0;
+        top: 0;
+      }
     }
   }
 }

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -339,15 +339,21 @@
       line-height: 1px;
       font-size: 0.8em;
     }
-    &.mq-arrow-left:before {
+    &.mq-arrow-left:before,
+    &.mq-arrow-leftright:before {
       content: '\2190';
       text-align: left;
       left: -1px;
     }
-    &.mq-arrow-right:before {
+    &.mq-arrow-right:before,
+    &.mq-arrow-leftright:after {
       content: '\2192';
       text-align: right;
       right: -1px;
+    }
+    &.mq-arrow-leftright:after {
+      position: absolute;
+      top: 0;
     }
     &.mq-empty .mq-inner:before {
       content: 'c';

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -129,7 +129,8 @@
     border-top: 1px solid black;
     margin-top: 1px;
   }
-  .mq-underline {
+  .mq-underline,
+  .mq-underarrow {
     border-bottom: 1px solid black;
     margin-bottom: 1px;
   }
@@ -329,15 +330,18 @@
     font-family: @symbola;
   }
 
-  .mq-overarrow {
+  .mq-overarrow,
+  .mq-underarrow {
     text-align: center;
     position: relative;
 
     &:before,
     &:after {
+      position: absolute;
       display: block;
       line-height: 1px;
       font-size: 0.8em;
+      min-width: 0.8em;
     }
     &.mq-arrow-left:before,
     &.mq-arrow-leftright:before {
@@ -351,23 +355,37 @@
       text-align: right;
       right: -1px;
     }
-    &.mq-arrow-leftright:after {
-      position: absolute;
-      top: 0;
-    }
     &.mq-empty .mq-inner:before {
       content: 'c';
       visibility: hidden;
+    }
+  }
+  .mq-overarrow {
+    &:before,
+    &:after {
+      top: -1px;
+    }
+  }
+  .mq-underarrow {
+    &:before,
+    &:after {
+      bottom: -1px;
     }
   }
 
   // @supports hack for Firefox ≥ 30
   // from http://browserhacks.com/
   @supports (-moz-appearance:meterbar) and (background-blend-mode:difference,normal) {
-    .mq-overarrow {
+    .mq-overarrow,
+    .mq-underarrow {
       &:before,
       &:after {
         line-height: 0;
+      }
+    }
+    .mq-overarrow {
+      &:before,
+      &:after {
         top: 0;
       }
     }


### PR DESCRIPTION
Hey @stufflebear and @laughinghan, you guys mentioned you were intererested in `overleftrightarrow`...

I've added this, as well as some cleanups to the existing `overleftarrow` and `overrightarrow` from c268c81. I changed the arrow symbol from ➤ to → (which looks better in Symbola) and simplified the styling a bit. The top border is now aligned with `overline` and the text is aligned properly.

I also threw in `underleftarrow` etc.

Tested on latest Chrome, Firefox and Safari under OSX - also IE8, IE9 and IE10 on various versions of Windows. I had to use a CSS hack for Firefox (please let me know your thoughts on this - it's a bit ugly, maybe there's a better way).

Thanks 😀 