### PR TITLE
Add `maxDepth` option to limit nesting level

### DIFF
--- a/docs/Config.md
+++ b/docs/Config.md
@@ -12,6 +12,7 @@ The configuration options object is of the following form:
   autoSubscriptNumerals: true,
   autoCommands: 'pi theta sqrt sum',
   autoOperatorNames: 'sin cos',
+  maxDepth: 10,
   substituteTextarea: function() {
     return document.createElement('textarea');
   },
@@ -80,6 +81,12 @@ For example, with `autoCommands` set to `'pi theta'`, the word 'pi' automaticall
 This defaults to the LaTeX built-in operator names ([Section 3.17 of the Short Math Guide](http://tinyurl.com/jm9okjc)) with additional trig operators like `sech`, `arcsec`, `arsinh`, etc. If you want some of these italicized after setting this property, you will have to add them to the list.
 
 Just like [`autoCommands`](#autocommands) above, this takes a string formatted as a space-delimited list of LaTeX commands.
+
+## maxDepth
+
+`maxDepth` specifies the maximum number of nested MathBlocks. When `maxDepth` is set to 1, the user can type simple math symbols directly into the editor but not into nested MathBlocks, e.g. the numerator and denominator of a fraction.
+
+Nested content in latex rendered during initialization or pasted into mathquill is truncated to avoid violating `maxDepth`. When `maxDepth` is not set, no depth limit is applied by default.
 
 ## substituteTextarea
 

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -467,7 +467,7 @@ CharCmds['/'] = P(Fraction, function(_, super_) {
           leftward = leftward[R];
       }
 
-      if (leftward !== cursor[L]) {
+      if (leftward !== cursor[L] && !cursor.isTooDeep(1)) {
         this.replaces(Fragment(leftward[R] || cursor.parent.ends[L], cursor[L]));
         cursor[L] = leftward;
       }

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -259,6 +259,19 @@ var Cursor = P(Point, function(_) {
     }
     return seln;
   };
+  _.depth = function() {
+    var node = this;
+    var depth = 0;
+    while (node = node.parent) {
+      depth += (node instanceof MathBlock) ? 1 : 0;
+    }
+    return depth;
+  };
+  _.isTooDeep = function(offset) {
+    if (this.options.maxDepth !== undefined) {
+      return this.depth() + (offset || 0) > this.options.maxDepth;
+    }
+  };
 });
 
 var Selection = P(Fragment, function(_, super_) {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -171,7 +171,7 @@ function getInterface(v) {
     };
     _.cmd = function(cmd) {
       var ctrlr = this.__controller.notify(), cursor = ctrlr.cursor;
-      if (/^\\[a-z]+$/i.test(cmd)) {
+      if (/^\\[a-z]+$/i.test(cmd) && !cursor.isTooDeep()) {
         cmd = cmd.slice(1);
         var klass = LatexCmds[cmd];
         if (klass) {

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -77,6 +77,10 @@ Controller.open(function(_, super_) {
   _.exportLatex = function() {
     return this.root.latex().replace(/(\\[a-z]+) (?![a-z])/ig,'$1');
   };
+
+  optionProcessors.maxDepth = function(depth) {
+    return (typeof depth === 'number') ? depth : undefined;
+  };
   _.writeLatex = function(latex) {
     var cursor = this.notify('edit').cursor;
 
@@ -85,7 +89,7 @@ Controller.open(function(_, super_) {
 
     var block = latexMathParser.skip(eof).or(all.result(false)).parse(latex);
 
-    if (block && !block.isEmpty()) {
+    if (block && !block.isEmpty() && block.prepareInsertionAt(cursor)) {
       block.children().adopt(cursor.parent, cursor[L], cursor[R]);
       var jQ = block.jQize();
       jQ.insertBefore(cursor.jQ);
@@ -99,7 +103,10 @@ Controller.open(function(_, super_) {
     return this;
   };
   _.renderLatexMath = function(latex) {
-    var root = this.root, cursor = this.cursor;
+    var root = this.root;
+    var cursor = this.cursor;
+    var options = cursor.options;
+    var jQ = root.jQ;
 
     var all = Parser.all;
     var eof = Parser.eof;
@@ -109,13 +116,8 @@ Controller.open(function(_, super_) {
     root.eachChild('postOrder', 'dispose');
     root.ends[L] = root.ends[R] = 0;
 
-    if (block) {
+    if (block && block.prepareInsertionAt(cursor)) {
       block.children().adopt(root, 0, 0);
-    }
-
-    var jQ = root.jQ;
-
-    if (block) {
       var html = block.join('html');
       jQ.html(html);
       root.jQize(jQ.children());

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -453,6 +453,37 @@ suite('Public API', function() {
     });
   });
 
+  suite('maxDepth option', function() {
+    setup(function() {
+      mq = MQ.MathField($('<span></span>').appendTo('#mock')[0], {
+        maxDepth: 1
+      });
+    });
+    teardown(function() {
+      $(mq.el()).remove();
+    });
+
+    test('prevents nested math input via .write() method', function() {
+      mq.write('1\\frac{\\frac{3}{3}}{2}');
+      assert.equal(mq.latex(), '1\\frac{ }{ }');
+    });
+
+    test('prevents nested math input via keyboard input', function() {
+      mq.cmd('/').write('x');
+      assert.equal(mq.latex(), '\\frac{ }{ }');
+    });
+
+    test('stops new fraction moving content into numerator', function() {
+      mq.write('x').cmd('/');
+      assert.equal(mq.latex(), 'x\\frac{ }{ }');
+    });
+
+    test('prevents nested math input via replacedFragment', function() {
+      mq.cmd('(').keystroke('Left').cmd('(')
+      assert.equal(mq.latex(), '\\left(\\right)');
+    });
+  });
+
   suite('statelessClipboard option', function() {
     suite('default', function() {
       var mq, textarea;


### PR DESCRIPTION
Applies to latex added via keyboard input, pasting, public methods
and initialization. When this option is set, math cannot be added more
than `maxDepth` MathBlocks deep in the math tree.
