### PR TITLE
[Mathspace] Reflow when closing brackets (Fixes #655)

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -558,8 +558,8 @@ var Bracket = P(P(MathCommand, DelimsMixin), function(_, super_) {
         Fragment(cursor[side], cursor.parent.ends[side], -side) // me and ghost outside
           .disown().withDirAdopt(-side, brack.parent, brack, brack[side])
           .jQ.insDirOf(side, brack.jQ);
-        brack.bubble('reflow');
       }
+      brack.bubble('reflow');
     }
     else {
       brack = this, side = brack.side;

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -304,6 +304,23 @@ suite('Public API', function() {
       });
     }
   });
+  
+  suite('edit handler', function() {
+    test('fires when closing a bracket expression', function() {
+      var count = 0;
+      var mq = MQ.MathField($('<span>').appendTo('#mock')[0], {
+        handlers: {
+          edit: function() {
+            count += 1;
+          }
+        }
+      });
+      mq.typedText('(3, 4');
+      var countBeforeClosingBracket = count;
+      mq.typedText(']');
+      assert.equal(count, countBeforeClosingBracket + 1);
+    });
+  });
 
   suite('.cmd(...)', function() {
     var mq;


### PR DESCRIPTION
Trigger a reflow event when closing a bracketed expression

If this doesn't happen, an edit event won't be triggered when we write an
unmatched expression like `(3, 4]`.  This means that our handler won't
know about the mismatched bracket until we type something else.

Fixes #655 