### PR TITLE
Fix the output of latex() for \class commands.

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -134,9 +134,6 @@ var Class = LatexCmds['class'] = P(MathCommand, function(_, super_) {
       })
     ;
   };
-  _.isStyleBlock = function() {
-    return true;
-  };
   _.latex = function() {
     return '\\class{' + this.cls + '}{' + this.blocks[0].latex() + '}';
   };

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -128,10 +128,17 @@ var Class = LatexCmds['class'] = P(MathCommand, function(_, super_) {
       .then(regex(/^[-\w\s\\\xA0-\xFF]*/))
       .skip(string('}'))
       .then(function(cls) {
+        self.cls = cls || '';
         self.htmlTemplate = '<span class="mq-class '+cls+'">&0</span>';
         return super_.parser.call(self);
       })
     ;
+  };
+  _.isStyleBlock = function() {
+    return true;
+  };
+  _.latex = function() {
+    return '\\class{' + this.cls + '}{' + this.blocks[0].latex() + '}';
   };
 });
 

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -121,6 +121,15 @@ suite('latex', function() {
     assertParsesLatex('\\text{}', '');
   });
 
+  test('\\textcolor', function() {
+    assertParsesLatex('\\textcolor{blue}{8}', '\\textcolor{blue}{8}');
+  });
+
+  test('\\class', function() {
+    assertParsesLatex('\\class{name}{8}', '\\class{name}{8}');
+    assertParsesLatex('\\class{name}{8-4}', '\\class{name}{8-4}');
+  });
+
   test('not real LaTex commands, but valid symbols', function() {
     assertParsesLatex('\\parallelogram ');
     assertParsesLatex('\\circledot ', '\\odot ');


### PR DESCRIPTION
Used the \textcolor command as a template for correcting the \class
output.  Added tests to latex for \class to prove correctness and for
\textcolor because it was missing.
