### PR TITLE
CI: imagemagick is actually pre-installed

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -35,9 +35,6 @@ dependencies:
   cache_directories:
     - ~/sauce-connect
   pre:
-    # imagemagick is installed to give us access to the
-    # `convert` tool to stitch together the screenshots.
-    - sudo apt-get update; sudo apt-get install imagemagick
     - "test $SAUCE_USERNAME && test $SAUCE_ACCESS_KEY
        # Sauce Labs credentials required. Sign up here: https://saucelabs.com/opensauce/"
     - ? |-


### PR DESCRIPTION
It's on both possible Linux build images:

  - imagemagick: 8:6.6.9.7-5ubuntu3.3
  - imagemagick-common: 8:6.6.9.7-5ubuntu3.3

https://circleci.com/docs/build-image-precise/

  - imagemagick8:6.7.7.10-6ubuntu3.1
  - imagemagick-common8:6.7.7.10-6ubuntu3.1

https://circleci.com/docs/build-image-trusty/

However, if in the future we decide we need to figure out how to install
it ourselves, this might be helpful:
https://discuss.circleci.com/t/error-installing-imagemagick/2963