### PR TITLE
Handle missing keypress event

### DIFF
--- a/src/services/saneKeyboardEvents.util.js
+++ b/src/services/saneKeyboardEvents.util.js
@@ -177,6 +177,10 @@ var saneKeyboardEvents = (function() {
 
       checkTextareaFor(typedText);
     }
+    function onKeyup(e) {
+      // Handle case of no keypress event being sent
+      if (!!keydown && !keypress) checkTextareaFor(typedText);
+    }
     function typedText() {
       // If there is a selection, the contents of the textarea couldn't
       // possibly have just been typed in.
@@ -235,6 +239,7 @@ var saneKeyboardEvents = (function() {
     target.bind({
       keydown: onKeydown,
       keypress: onKeypress,
+      keyup: onKeyup,
       focusout: onBlur,
       cut: function() { checkTextareaOnce(function() { handlers.cut(); }); },
       copy: function() { checkTextareaOnce(function() { handlers.copy(); }); },

--- a/test/unit/saneKeyboardEvents.test.js
+++ b/test/unit/saneKeyboardEvents.test.js
@@ -33,6 +33,25 @@ suite('saneKeyboardEvents', function() {
     el.val('a');
   });
 
+  test('normal keys without keypress', function(done) {
+    var counter = 0;
+    saneKeyboardEvents(el, {
+      keystroke: noop,
+      typedText: function(text) {
+        counter += 1;
+        assert.ok(counter <= 1, 'callback is only called once');
+        assert.equal(text, 'a', 'text comes back as a');
+        assert.equal(el.val(), '', 'the textarea remains empty');
+
+        done();
+      }
+    });
+
+    el.trigger(Event('keydown', { which: 97 }));
+    el.trigger(Event('keyup', { which: 97 }));
+    el.val('a');
+  });
+
   test('one keydown only', function(done) {
     var counter = 0;
 


### PR DESCRIPTION
I was butting heads with #65 and related issues, and found [evidence](http://stackoverflow.com/questions/21055270/javascript-keypress-event-not-raised-on-android-browser) that the keypress event isn't sent on some mobile browsers. I tested listening for it, and true enough, it wasn't.

Here I've added a listener for the `keyup` event in case `keypress` is missing. I'm not sure if this is a good solution to the problem, but it fixed it in my case.