### PR TITLE
Configure inner math field with options

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -431,7 +431,10 @@ var MathBlock = P(MathElement, function(_, super_) {
 API.StaticMath = function(APIClasses) {
   return P(APIClasses.AbstractMathQuill, function(_, super_) {
     this.RootBlock = MathBlock;
-    _.__mathquillify = function() {
+    _.__mathquillify = function(opts, interfaceVersion) {
+      if (interfaceVersion > 1) {
+        this.config(opts);
+      }
       super_.__mathquillify.call(this, 'mq-math-mode');
       this.__controller.delegateMouseEvents();
       this.__controller.staticMathTextareaEvents();

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -782,8 +782,8 @@ LatexCmds.MathQuillMathField = P(MathCommand, function(_, super_) {
       .map(function(name) { self.name = name; }).or(succeed())
       .then(super_.parser.call(self));
   };
-  _.finalizeTree = function() {
-    var ctrlr = Controller(this.ends[L], this.jQ, Options());
+  _.finalizeTree = function(options) {
+    var ctrlr = Controller(this.ends[L], this.jQ, options);
     ctrlr.KIND_OF_MQ = 'MathField';
     ctrlr.editable = true;
     ctrlr.createTextarea();

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -200,11 +200,17 @@ suite('Public API', function() {
     testHandlers('MQ.MathField() constructor', function(options) {
       return MQ.MathField($('<span></span>').appendTo('#mock')[0], options);
     });
+    testHandlers('MQ.StaticMath() constructor', function(options) {
+      return MQ.StaticMath($('<span>\\MathQuillMathField{}</span>').appendTo('#mock')[0], options).innerFields[0];
+    });
     testHandlers('MQ.MathField::config()', function(options) {
       return MQ.MathField($('<span></span>').appendTo('#mock')[0]).config(options);
     });
-    testHandlers('.config() on \\MathQuillMathField{} in a MQ.StaticMath', function(options) {
-      return MQ.MathField($('<span></span>').appendTo('#mock')[0]).config(options);
+    testHandlers('MQ.StaticMath::config() for \\MathQuillMathField{} inner field', function(options) {
+      return MQ.StaticMath($('<span>\\MathQuillMathField{}</span>').appendTo('#mock')[0]).config(options).innerFields[0];
+    });
+    testHandlers('\\MathQuillMathField{}::config()', function(options) {
+      return MQ.StaticMath($('<span>\\MathQuillMathField{}</span>').appendTo('#mock')[0]).innerFields[0].config(options);
     });
     suite('global MQ.config()', function() {
       testHandlers('a MQ.MathField', function(options) {


### PR DESCRIPTION
When finalizeTree() is called for inner math fields, it takes an
options object as a parameter. This object was not actually used to
configure the inner math field. This change ensures inner math fields
are configured correctly with the passed options.

Supersedes #510.