### PR TITLE
Modify Symbol to fix text() output for functions

### DIFF
--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -29,7 +29,7 @@ var Variable = P(Symbol, function(_, super_) {
         text = text.slice(1, text.length);
       }
       else if (text[text.length-1] == ' ') {
-        text = text.slice (0, text.length-1);
+        text = text.slice (0, -1);
       }
     } else {
       if (this[L] && !(this[L] instanceof Variable)

--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -24,13 +24,22 @@ var Variable = P(Symbol, function(_, super_) {
   };
   _.text = function() {
     var text = this.ctrlSeq;
-    if (this[L] && !(this[L] instanceof Variable)
-        && !(this[L] instanceof BinaryOperator)
-        && this[L].ctrlSeq !== "\\ ")
-      text = '*' + text;
-    if (this[R] && !(this[R] instanceof BinaryOperator)
-        && !(this[R] instanceof SupSub))
-      text += '*';
+    if (this.isPartOfOperator) {
+      if (text[0] == '\\') {
+        text = text.slice(1, text.length);
+      }
+      else if (text[text.length-1] == ' ') {
+        text = text.slice (0, text.length-1);
+      }
+    } else {
+      if (this[L] && !(this[L] instanceof Variable)
+          && !(this[L] instanceof BinaryOperator)
+          && this[L].ctrlSeq !== '\\ ')
+        text = '*' + text;
+      if (this[R] && !(this[R] instanceof BinaryOperator)
+          && !(this[R] instanceof SupSub))
+        text += '*';
+    }
     return text;
   };
 });
@@ -83,6 +92,7 @@ var Letter = P(Variable, function(_, super_) {
   };
   _.italicize = function(bool) {
     this.isItalic = bool;
+    this.isPartOfOperator = !bool;
     this.jQ.toggleClass('mq-operator-name', !bool);
     return this;
   };

--- a/test/unit/autoOperatorNames.test.js
+++ b/test/unit/autoOperatorNames.test.js
@@ -14,6 +14,13 @@ suite('autoOperatorNames', function() {
     );
   }
 
+  function assertText(input, expected) {
+    var result = mq.text();
+    assert.equal(result, expected,
+      input+', got \''+result+'\', expected \''+expected+'\''
+    );
+  }
+
   test('simple LaTeX parsing, typing', function() {
     function assertAutoOperatorNamesWork(str, latex) {
       var count = 0;
@@ -45,6 +52,16 @@ suite('autoOperatorNames', function() {
     assertAutoOperatorNamesWork('arcosecant', 'ar\\operatorname{cosec}ant');
     assertAutoOperatorNamesWork('cscscscscscsc', '\\csc s\\csc s\\csc sc');
     assertAutoOperatorNamesWork('scscscscscsc', 's\\csc s\\csc s\\csc');
+  });
+
+  test('text() output', function(){
+    function assertTranslatedCorrectly(latexStr, text) {
+      mq.latex(latexStr);
+      assertText('outputting ' + latexStr, text);
+    }
+
+    assertTranslatedCorrectly('\\sin', 'sin');
+    assertTranslatedCorrectly('\\sin\\left(xy\\right)', 'sin(x*y)');
   });
 
   test('deleting', function() {


### PR DESCRIPTION
In autoUnitalicize, we keep track of which SymbolCommands are functions (sin, log, etc) and make sure that they produce proper .text() output. There are lots of pathological cases, but this is a good temporary fix. 

This works for \left( and \right), but fails for normal parentheses. If we decide to not fix #699 , then this should be modified to work for normal parentheses.

Closes #537.