### PR TITLE
Fix some broken unit tests.

### DIFF
--- a/test/unit/autoOperatorNames.test.js
+++ b/test/unit/autoOperatorNames.test.js
@@ -76,7 +76,7 @@ suite('autoOperatorNames', function() {
 
   suite('override autoOperatorNames', function() {
     test('basic', function() {
-      MQ.config({ autoOperatorNames: 'sin lol' });
+      mq.config({ autoOperatorNames: 'sin lol' });
       mq.typedText('arcsintrololol');
       assert.equal(mq.latex(), 'arc\\sin tro\\operatorname{lol}ol');
     });

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -813,7 +813,7 @@ suite('typing with auto-replaces', function() {
 
   suite('autoCommands', function() {
     setup(function() {
-      MQ.config({
+      mq.config({
         autoOperatorNames: 'sin pp',
         autoCommands: 'pi tau phi theta Gamma sum prod sqrt nthroot'
       });


### PR DESCRIPTION
In typing and autoOperatorNames tests, the global MQ.config was being overwritten instead of the local mq.config. This caused breakage down the line in other tests that needed to use operators.