### PR TITLE
Reflect the custom classes back to the latex to preserve original input

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -131,6 +131,7 @@ var Class = LatexCmds['class'] = P(MathCommand, function(_, super_) {
       .then(regex(/^[-\w\s\\\xA0-\xFF]*/))
       .skip(string('}'))
       .then(function(cls) {
+        self.ctrlSeq = '\\class{'+ cls + '}';
         self.htmlTemplate = '<span class="mq-class '+cls+'">&0</span>';
         return super_.parser.call(self);
       })


### PR DESCRIPTION
Using custom classes works excellently, but the `latex()` command executed as a getter returns the latex with the class'es escape and the content in the curly braces missing: 

field.latex('\\class{my-class-name}{\\fraq{}{}}'); // visualized correctly.
field.latex(); // returns 'class\fraq{}{}'

This commit fixes the reflection and the returned result from the getter is the same as the input.