### PR TITLE
Added AMD module compatibility

### DIFF
--- a/src/outro.js
+++ b/src/outro.js
@@ -9,5 +9,7 @@ for (var key in MQ1) (function(key, val) {
   }
   else MathQuill[key] = val;
 }(key, MQ1[key]));
-
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = MathQuill;
+}
 }());


### PR DESCRIPTION
This is a simple fix that makes MathQuill usable as AMD dependency.

Without this MathQuill appears to be an empty Object when you want to use it in something like webpack.