### PR TITLE
Makefile: Wipe node_modules if not properly installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,7 @@ $(BASIC_CSS): $(CSS_SOURCES) $(NODE_MODULES_INSTALLED) $(BUILD_DIR_EXISTS)
 	$(SED_IN_PLACE) s/{VERSION}/v$(VERSION)/ $@
 
 $(NODE_MODULES_INSTALLED): package.json
+	test -e $(NODE_MODULES_INSTALLED) || rm -rf ./node_modules/ # robust against previous botched npm install
 	NODE_ENV=development npm install
 	touch $(NODE_MODULES_INSTALLED)
 


### PR DESCRIPTION
If `make server` is already running (or port 9292 is someotherhow already in use), and I run `make server` in a fresh clone, the test server gets an EADDRINUSE and quits. However, it first starts up `make test` in parallel, which does an `npm install`, which gets aborted partway through. On my machine, this race condition results in the packages seemingly all installed under `node_modules/*`, but not the executables like `node_modules/.bin/lessc`.

The problem arises when subsequently building again (e.g. `PORT=9393 make server`), which runs `npm install` again, this time to completion. `npm` sees all the packages and installed under `node_modules/*` and doesn't try to complete the installation and install the `node_modules/.bin/*` executables (it probably doesn't want to do a full integrity check: https://github.com/npm/npm/issues/15562 ), instead quitting and reports success, but the Makefile then fails when it tries to do `node_modules/.bin/lessc`.

https://mathquill.slack.com/archives/mathquill/p1482616486000235