### PR TITLE
Added Euro 🇪🇺 symbol

### DIFF
--- a/src/commands/math/basicSymbols.js
+++ b/src/commands/math/basicSymbols.js
@@ -352,6 +352,9 @@ LatexCmds.varrho = //AMS and LaTeX
 LatexCmds.pi = LatexCmds['π'] = bind(NonSymbolaSymbol,'\\pi ','&pi;');
 LatexCmds.lambda = bind(NonSymbolaSymbol,'\\lambda ','&lambda;');
 
+// Currency symbols
+LatexCmds.euro = LatexCmds['\u20AC'] = bind(NonSymbolaSymbol,'\\euro ','&#8364;');
+
 //uppercase greek letters
 
 LatexCmds.Upsilon = //LaTeX


### PR DESCRIPTION
While possible to type, I noticed it was impossible to save a Euro symbol. I solved this by adding the exact unicode index and html entity to the list of basic symbols.