### PR TITLE
Ci.cleanup

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -39,69 +39,74 @@ dependencies:
   cache_directories:
     - ~/sauce-connect
   pre:
-    - "test $SAUCE_USERNAME && test $SAUCE_ACCESS_KEY
-       # Sauce Labs credentials required. Sign up here: https://saucelabs.com/opensauce/"
     - ? |-
-        {
-          mkdir -p ~/sauce-connect
-          cd ~/sauce-connect
-          if [ -x sc-*-linux/bin/sc ]; then
-            echo Using cached sc-*-linux/bin/sc
-          else
-            time wget https://saucelabs.com/downloads/sc-latest-linux.tar.gz
-            time tar -xzf sc-latest-linux.tar.gz
-          fi
-          # Sauce Connect randomly fails so try twice https://git.io/vPN8v
-          time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY \
-            --readyfile ~/sauce_is_ready
-          test -e ~/sauce_was_ready && exit
-          time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY \
-            --readyfile ~/sauce_is_ready
-          test -e ~/sauce_was_ready && exit
-          echo 'ERROR: Exited twice without creating readyfile' \
-            | tee /dev/stderr > ~/sauce_is_ready
+        # SauceConnect: download if not cached, and launch with retry
+        test $SAUCE_USERNAME && test $SAUCE_ACCESS_KEY || {
+          echo 'Sauce Labs credentials required. Sign up here: https://saucelabs.com/opensauce/'
           exit 1
-        } >$CIRCLE_ARTIFACTS/sauce-connect.log 2>&1
+        }
+
+        mkdir -p ~/sauce-connect
+        cd ~/sauce-connect
+        if [ -x sc-*-linux/bin/sc ]; then
+          echo Using cached sc-*-linux/bin/sc
+        else
+          time wget https://saucelabs.com/downloads/sc-latest-linux.tar.gz
+          time tar -xzf sc-latest-linux.tar.gz
+        fi
+        # Sauce Connect randomly fails so try twice https://git.io/vPN8v
+        time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY \
+          --readyfile ~/sauce_is_ready
+        test -e ~/sauce_was_ready && exit
+        time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY \
+          --readyfile ~/sauce_is_ready
+        test -e ~/sauce_was_ready && exit
+        echo 'ERROR: Exited twice without creating readyfile' \
+          | tee /dev/stderr > ~/sauce_is_ready
+        exit 1
       :
         background: true
     - test -x $json || npm install json
 
 test:
-  override:
+  pre:
     # Safari on Sauce can only connect to port 3000, 4000, 7000, or 8000. Edge needs port 7000 or 8000.
     # https://david263a.wordpress.com/2015/04/18/fixing-safari-cant-connect-to-localhost-issue-when-using-sauce-labs-connect-tunnel/
     # https://support.saucelabs.com/customer/portal/questions/14368823-requests-to-localhost-on-microsoft-edge-are-failing-over-sauce-connect
-    - PORT=8000 make server >$CIRCLE_ARTIFACTS/make_server.log 2>&1:
+    - PORT=8000 make server:
         background: true
 
-    # CircleCI expects test results to be reported in an JUnit/xUnit-style XML file:
-    #   https://circleci.com/docs/test-metadata/
-    # Our unit tests are in a browser, so they can't write to a file, and Sauce
-    # apparently truncates custom data in their test result reports, so instead we
-    # POST to this trivial Node server on localhost:9000 that writes the body of
-    # any POST request to $CIRCLE_TEST_REPORTS/mocha/xunit.xml
-    - mkdir -p $CIRCLE_TEST_REPORTS/mocha
-    - ? |-
-        node << 'EOF' >$CIRCLE_TEST_REPORTS/mocha/xunit.xml \
-                      2>$CIRCLE_ARTIFACTS/mocha-test-report.log
-          require('http').createServer(function(req, res) {
-            res.setHeader('Access-Control-Allow-Origin', '*');
-            req.pipe(process.stdout);
-            req.on('end', res.end.bind(res));
-          })
-          .listen(9000);
-          console.error('listening on http://0.0.0.0:9000/');
-        EOF
-      :
-        background: true
-
-    # Wait for tunnel to be ready (`make server` and the trivial Node server
-    # are much faster, no need to wait for them)
+    # Wait for tunnel to be ready (`make server` is much faster, no need to wait for it)
     - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done; touch ~/sauce_was_ready; test -z "$(<~/sauce_is_ready)"
 
-    # Start taking screenshots in the background while the unit tests are running
+  override:
     - ? |-
-        {
+        # Screenshots: capture in the background while running unit tests
+        mkdir -p $CIRCLE_TEST_REPORTS/mocha
+
+        # CircleCI expects test results to be reported in an JUnit/xUnit-style XML file:
+        #   https://circleci.com/docs/test-metadata/
+        # Our unit tests are in a browser, so they can't write to a file, and Sauce
+        # apparently truncates custom data in their test result reports, so instead we
+        # POST to this trivial Node server on localhost:9000 that writes the body of
+        # any POST request to $CIRCLE_TEST_REPORTS/mocha/xunit.xml
+        node -e '
+          require("http").createServer(function(req, res) {
+            res.setHeader("Access-Control-Allow-Origin", "*");
+            req.pipe(process.stdout);
+            req.on("end", res.end.bind(res));
+          })
+          .listen(9000);
+          console.error("listening on http://0.0.0.0:9000/");
+        ' 2>&1 >$CIRCLE_TEST_REPORTS/mocha/xunit.xml | {
+          # ^ note: `2>&1` must precede `>$CIRCLE_TEST_REPORTS/...` because
+          # shell redirect is like assignment; if it came after, then both
+          # stdout and stderr would be written to `xunit.xml` and nothing
+          # would be  piped into here
+
+          head -1 # wait for "listening on ..." to be logged
+
+          # https://circleci.com/docs/environment-variables/
           build_name="CircleCI build #$CIRCLE_BUILD_NUM"
           if [ $CIRCLE_PR_NUMBER ]; then
             build_name="$build_name: PR #$CIRCLE_PR_NUMBER"
@@ -115,17 +120,17 @@ test:
           time { test -d node_modules/wd || npm install wd; }
           time node script/screenshots.js http://localhost:8000/test/visual.html \
             && touch ~/screenshots_are_ready || echo EXIT STATUS $? | tee /dev/stderr > ~/screenshots_are_ready:
-        } >$CIRCLE_ARTIFACTS/screenshots.log 2>&1
+        }
       :
         background: true
 
-    # Run in-browser unit tests, based on:
-    #   https://wiki.saucelabs.com/display/DOCS/JavaScript+Unit+Testing+Methods
-    # "build" and "customData" parameters from:
-    #   https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-TestAnnotation
-    # CircleCI environment variables from:
-    #   https://circleci.com/docs/environment-variables/
     - |-
+      # Unit tests in the browser
+
+      echo '1. Launch tests'
+      echo
+
+      # https://circleci.com/docs/environment-variables/
       build_name="CircleCI build #$CIRCLE_BUILD_NUM"
       if [ $CIRCLE_PR_NUMBER ]; then
         build_name="$build_name: PR #$CIRCLE_PR_NUMBER"
@@ -135,6 +140,8 @@ test:
       fi
       build_name="$build_name @ ${CIRCLE_SHA1:0:7}"
 
+      # "build" and "customData" parameters from:
+      #   https://wiki.saucelabs.com/display/DOCS/Test+Configuration+Options#TestConfigurationOptions-TestAnnotation
       set -o pipefail
       curl -i -X POST https://saucelabs.com/rest/v1/$SAUCE_USERNAME/js-tests \
            -u $SAUCE_USERNAME:$SAUCE_ACCESS_KEY \
@@ -148,13 +155,11 @@ test:
                  "platforms": [["", "Chrome", ""]]
       }' | tee /dev/stderr | tail -1 > js-tests.json
 
-    # Wait for tests to finish:
-    #
-    #   > Make the request multiple times as the tests run until the response
-    #   > contains `completed: true` to the get the final results.
-    #
-    #   https://wiki.saucelabs.com/display/DOCS/JavaScript+Unit+Testing+Methods
-    - |-
+      echo '2. Wait for tests to finish:'
+      echo
+      #   > Make the request multiple times as the tests run until the response
+      #   > contains `completed: true` to the get the final results.
+      # https://wiki.saucelabs.com/display/DOCS/JavaScript+Unit+Testing+Methods
       while true  # Bash has no do...while >:(
       do
         sleep 5
@@ -169,21 +174,26 @@ test:
         [ "$($json completed <status.json)" != false ] && break
       done
 
-    # Complain to Circle CI if any unit tests failed
-    - test "$($json 'js tests'.0.result.failures <status.json)" = 0
+      echo '3. Exit with non-zero status code if any unit tests failed'
+      exit "$($json 'js tests'.0.result.failures <status.json)"
 
-    # Wait for screenshots to be ready
-    - while [ ! -e ~/screenshots_are_ready ]; do sleep 1; done; test -z "$(<~/screenshots_are_ready)":
-        timeout: 300
-
-    # Stitch together images
     - |-
+      # Stitch together screenshots and diff against master
+
+      echo '0. Wait for screenshots to be ready'
+      echo
+      while [ ! -e ~/screenshots_are_ready ]; do sleep 1; done
+      test -z "$(<~/screenshots_are_ready)" || exit 1
+
+      echo '1. Stitch together pieces'
+      echo
       for img in $(ls $CIRCLE_ARTIFACTS/imgs/pieces/); do
         convert $(ls -1 $CIRCLE_ARTIFACTS/imgs/pieces/$img/*.png | sort -n) -append $CIRCLE_ARTIFACTS/imgs/$img.png
       done
 
-    # Download the latest screenshots from master.
-    - |-
+      echo '2. Download the latest screenshots from master'
+      echo
+
       artifacts_json="$(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts?branch=ci.cleanup)"
       #when done testing, restore: artifacts_json="$(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts?branch=master)"
       echo
@@ -205,10 +215,11 @@ test:
       echo "$baseline_imgs"
       echo
 
-      test -z "$baseline_imgs" || curl $baseline_imgs
+      test -z "$baseline_imgs" && { echo 'No baseline images to download'; exit; }
+      curl $baseline_imgs
 
-    # Generate image diffs.
-    - |-
+      echo '3.  Generate image diffs'
+      echo
       cd $CIRCLE_ARTIFACTS/imgs/
       for file in $(ls *.png); do
         # if evergreen browser, browser version of previous screenshot may not match,
@@ -218,5 +229,6 @@ test:
         compare -metric AE $baseline $file ${file/%.png/_DIFF.png}
       done
       true  # ignore errors like "image widths or heights differ"
+
   post:
     - killall --wait sc; true  # wait for Sauce Connect to close the tunnel; ignore errors since it's just cleanup

--- a/circle.yml
+++ b/circle.yml
@@ -50,7 +50,7 @@ dependencies:
           # Sauce Connect randomly fails so try twice https://git.io/vPN8v
           time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY --readyfile ~/sauce_is_ready \
             || time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY --readyfile ~/sauce_is_ready \
-            || echo ERROR > ~/sauce_is_ready
+            || echo EXIT STATUS $? | tee /dev/stderr > ~/sauce_is_ready
         } >$CIRCLE_ARTIFACTS/sauce-connect.log 2>&1
       :
         background: true
@@ -86,14 +86,14 @@ test:
 
     # Wait for tunnel to be ready (`make server` and the trivial Node server
     # are much faster, no need to wait for them)
-    - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done; test "$(<~/sauce_is_ready)" != ERROR
+    - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done; test -z "$(<~/sauce_is_ready)"
 
     # Start taking screenshots in the background while the unit tests are running
     - ? |-
         {
           time { test -d node_modules/wd || npm install wd; }
           time node script/screenshots.js http://localhost:8000/test/visual.html \
-            && touch ~/screenshots_are_ready || echo ERROR > ~/screenshots_are_ready:
+            && touch ~/screenshots_are_ready || echo EXIT STATUS $? | tee /dev/stderr > ~/screenshots_are_ready:
         } >$CIRCLE_ARTIFACTS/screenshots.log 2>&1
       :
         background: true
@@ -152,7 +152,7 @@ test:
       [ "$(node -p 'require("./status.json")["js tests"][0].result.failures')" == 0 ]
 
     # Wait for screenshots to be ready
-    - while [ ! -e ~/screenshots_are_ready ]; do sleep 1; done; test "$(<~/screenshots_are_ready)" != ERROR:
+    - while [ ! -e ~/screenshots_are_ready ]; do sleep 1; done; test -z "$(<~/screenshots_are_ready)":
         timeout: 300
 
     # Stitch together images

--- a/circle.yml
+++ b/circle.yml
@@ -191,30 +191,32 @@ test:
       echo "$artifacts_json"
       echo
 
-      prev_imgs="$(echo "$artifacts_json" \
+      mkdir $CIRCLE_ARTIFACTS/imgs/baseline/
+      baseline_imgs="$(echo "$artifacts_json" \
                     | $json -a url pretty_path -d '\n\t' \
                     | grep '\.png$' \
-                    | grep -v '/PREV_' \
-                    | grep -v '/DIFF_' \
                     | grep -v '/pieces/' \
-                    | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/PREV_:")"
+                    | grep -v '/baseline/' \
+                    | grep -v '/raw_diffs/' \
+                    | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/baseline/:")"
       echo 'Baseline image URLs and files:'
       echo
-      echo "$prev_imgs"
+      echo "$baseline_imgs"
       echo
 
-      test -z "$prev_imgs" || curl $prev_imgs
+      test -z "$baseline_imgs" || curl $baseline_imgs
 
     # Generate image diffs.
     - |-
       cd $CIRCLE_ARTIFACTS/imgs/
-      for file in $(ls *.png | grep -v '^PREV_'); do
+      mkdir raw_diffs/
+      for file in $(ls *.png); do
         # if evergreen browser, browser version of previous screenshot may not match,
         # so replace previous browser version with glob
-        prev=PREV_"$(sh -c "ls $(echo $file | sed 's/[^_]*_(evergreen)/*/')")"
-        metric_diff=$(compare -metric AE -compose src $prev $file RAW_DIFF_$file)
+        baseline=baseline/"$(sh -c "ls $(echo $file | sed 's/[^_]*_(evergreen)/*/')")"
+        metric_diff=$(compare -metric AE -compose src $baseline $file raw_diffs/$file)
         echo "Metric diff for $file: $metric_diff"
-        composite -alpha on RAW_DIFF_$file $prev DIFF_$file
+        composite -alpha on raw_diffs/$file $prev ${file/%.png/_DIFF.png}
       done
   post:
     - killall --wait sc; true  # wait for Sauce Connect to close the tunnel; ignore errors since it's just cleanup

--- a/circle.yml
+++ b/circle.yml
@@ -213,7 +213,7 @@ test:
       for file in $(ls *.png); do
         # if evergreen browser, browser version of previous screenshot may not match,
         # so replace previous browser version with glob
-        baseline="$(echo baseline/$(echo $file | sed 's/[^_]*_(evergreen)/*/'))"
+        baseline="$(echo baseline/$(echo $file | sed 's/[^_]*_(evergreen)/*/; s/OS_X_[^.]*/OS_X_*/' | tee /dev/stderr) | tee /dev/stderr)"
         echo "Number of different pixels from baseline in $file:"
         compare -metric AE $baseline $file ${file/%.png/_DIFF.png}
       done

--- a/circle.yml
+++ b/circle.yml
@@ -128,7 +128,7 @@ test:
                  "framework": "mocha",
                  "url": "http://localhost:8000/test/unit.html?post_xunit_to=http://localhost:9000",
                  "platforms": [["", "Chrome", ""]]
-      }' | tee js-tests
+      }' | tee /dev/stderr | tail -1 > js-tests.json
 
     # Wait for tests to finish:
     #
@@ -144,17 +144,16 @@ test:
              -X POST \
              -u $SAUCE_USERNAME:$SAUCE_ACCESS_KEY \
              -H 'Content-Type: application/json' \
-             -d "$(tail -1 js-tests)" \
-        | tee status
-        tail -1 status > status.json
+             -d @js-tests.json \
+        | tee /dev/stderr | tail -1 > status.json
+
         # deliberately do `... != false` rather than `... == true`
         # because unexpected values should break rather than infinite loop
-        [ "$(node -p 'require("./status.json").completed')" != false ] && break
+        [ "$($json completed <status.json)" != false ] && break
       done
 
     # Complain to Circle CI if any unit tests failed
-    - |-
-      [ "$(node -p 'require("./status.json")["js tests"][0].result.failures')" == 0 ]
+    - test "$($json 'js tests'.0.result.failures <status.json)" = 0
 
     # Wait for screenshots to be ready
     - while [ ! -e ~/screenshots_are_ready ]; do sleep 1; done; test -z "$(<~/screenshots_are_ready)":

--- a/circle.yml
+++ b/circle.yml
@@ -185,13 +185,23 @@ test:
 
     # Download the latest mathquill artifacts.
     - |-
-      prev_imgs="$(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts \
-                    | tee /dev/stderr \
+      artifacts_json="$(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts)"
+      echo
+      echo '/latest/artifacts:'
+      echo
+      echo "$artifacts_json"
+      echo
+
+      prev_imgs="$(echo "$artifacts_json" \
                     | $json -a url pretty_path -d '\n\t' \
                     | grep '\.png$' \
                     | grep -v 'PREV_' \
-                    | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/PREV_:" \
-                    | tee /dev/stderr)"
+                    | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/PREV_:")"
+      echo 'Previous image URLs and files:'
+      echo
+      echo "$prev_imgs"
+      echo
+
       test -z "$prev_imgs" || curl $prev_imgs
 
     # Generate image diffs.

--- a/circle.yml
+++ b/circle.yml
@@ -181,7 +181,7 @@ test:
         convert $(ls -1 $CIRCLE_ARTIFACTS/imgs/pieces/$img/*.png | sort -n) -append $CIRCLE_ARTIFACTS/imgs/$img.png
       done
 
-    # Download the latest mathquill artifacts from master.
+    # Download the latest screenshots from master.
     - |-
       artifacts_json="$(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts?branch=master)"
       echo
@@ -197,7 +197,7 @@ test:
                     | grep -v '/DIFF_' \
                     | grep -v '/pieces/' \
                     | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/PREV_:")"
-      echo 'Previous image URLs and files:'
+      echo 'Baseline image URLs and files:'
       echo
       echo "$prev_imgs"
       echo

--- a/circle.yml
+++ b/circle.yml
@@ -195,8 +195,9 @@ test:
       baseline_imgs="$(echo "$artifacts_json" \
                     | $json -a url pretty_path -d '\n\t' \
                     | grep '\.png$' \
-                    | grep -v '/pieces/' \
-                    | grep -v '/baseline/' \
+                    | grep -v '_DIFF\.png$' \
+                    | grep -vF '/pieces/' \
+                    | grep -vF '/baseline/' \
                     | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/baseline/:")"
       echo 'Baseline image URLs and files:'
       echo

--- a/circle.yml
+++ b/circle.yml
@@ -181,12 +181,10 @@ test:
       # Stitch together screenshots and diff against master
 
       echo '0. Wait for screenshots to be ready'
-      echo
       while [ ! -e ~/screenshots_are_ready ]; do sleep 1; done
       test -z "$(<~/screenshots_are_ready)" || exit 1
 
       echo '1. Stitch together pieces'
-      echo
       for img in $(ls $CIRCLE_ARTIFACTS/imgs/pieces/); do
         convert $(ls -1 $CIRCLE_ARTIFACTS/imgs/pieces/$img/*.png | sort -n) -append $CIRCLE_ARTIFACTS/imgs/$img.png
       done
@@ -217,6 +215,7 @@ test:
 
       test -z "$baseline_imgs" && { echo 'No baseline images to download'; exit; }
       curl $baseline_imgs
+      echo
 
       echo '3.  Generate image diffs'
       echo
@@ -227,6 +226,7 @@ test:
         baseline="$(echo baseline/$(echo $file | sed 's/[^_]*_(evergreen)/*/; s/OS_X_.*/OS_X_*.png/' | tee /dev/stderr) | tee /dev/stderr)"
         echo "Number of different pixels from baseline in $file:"
         compare -metric AE $baseline $file ${file/%.png/_DIFF.png}
+        echo
       done
       true  # ignore errors like "image widths or heights differ"
 

--- a/circle.yml
+++ b/circle.yml
@@ -212,7 +212,7 @@ test:
       for file in $(ls *.png); do
         # if evergreen browser, browser version of previous screenshot may not match,
         # so replace previous browser version with glob
-        baseline="$(sh -c "ls \"baseline/$(echo $file | sed 's/[^_]*_(evergreen)/*/')\"")"
+        baseline="$(echo baseline/$(echo $file | sed 's/[^_]*_(evergreen)/*/')"
         echo "Number of different pixels from baseline in $file:"
         compare -metric AE $baseline $file ${file/%.png/_DIFF.png}
       done

--- a/circle.yml
+++ b/circle.yml
@@ -119,6 +119,7 @@ test:
       fi
       build_name="$build_name @ ${CIRCLE_SHA1:0:7}"
 
+      set -o pipefail
       curl -i -X POST https://saucelabs.com/rest/v1/$SAUCE_USERNAME/js-tests \
            -u $SAUCE_USERNAME:$SAUCE_ACCESS_KEY \
            -H 'Content-Type: application/json' \

--- a/circle.yml
+++ b/circle.yml
@@ -102,6 +102,16 @@ test:
     # Start taking screenshots in the background while the unit tests are running
     - ? |-
         {
+          build_name="CircleCI build #$CIRCLE_BUILD_NUM"
+          if [ $CIRCLE_PR_NUMBER ]; then
+            build_name="$build_name: PR #$CIRCLE_PR_NUMBER"
+            [ "$CIRCLE_BRANCH" ] && build_name="$build_name ($CIRCLE_BRANCH)"
+          else
+            build_name="$build_name: $CIRCLE_BRANCH"
+          fi
+          build_name="$build_name @ ${CIRCLE_SHA1:0:7}"
+          export MQ_CI_BUILD_NAME="$build_name"
+
           time { test -d node_modules/wd || npm install wd; }
           time node script/screenshots.js http://localhost:8000/test/visual.html \
             && touch ~/screenshots_are_ready || echo EXIT STATUS $? | tee /dev/stderr > ~/screenshots_are_ready:

--- a/circle.yml
+++ b/circle.yml
@@ -213,7 +213,7 @@ test:
       for file in $(ls *.png); do
         # if evergreen browser, browser version of previous screenshot may not match,
         # so replace previous browser version with glob
-        baseline="$(echo baseline/$(echo $file | sed 's/[^_]*_(evergreen)/*/; s/OS_X_[^.]*/OS_X_*/' | tee /dev/stderr) | tee /dev/stderr)"
+        baseline="$(echo baseline/$(echo $file | sed 's/[^_]*_(evergreen)/*/; s/OS_X_.*/OS_X_*.png/' | tee /dev/stderr) | tee /dev/stderr)"
         echo "Number of different pixels from baseline in $file:"
         compare -metric AE $baseline $file ${file/%.png/_DIFF.png}
       done

--- a/circle.yml
+++ b/circle.yml
@@ -214,8 +214,8 @@ test:
         # if evergreen browser, browser version of previous screenshot may not match,
         # so replace previous browser version with glob
         baseline=baseline/"$(sh -c "ls $(echo $file | sed 's/[^_]*_(evergreen)/*/')")"
-        metric_diff=$(compare -metric AE -compose src $baseline $file raw_diffs/$file)
-        echo "Metric diff for $file: $metric_diff"
+        echo "Metric diff for $file:"
+        compare -metric AE -compose src $baseline $file raw_diffs/$file
         composite -alpha on raw_diffs/$file $prev ${file/%.png/_DIFF.png}
       done
   post:

--- a/circle.yml
+++ b/circle.yml
@@ -177,21 +177,9 @@ test:
 
     # Stitch together images
     - |-
-      for img in $(ls $CIRCLE_ARTIFACTS/imgs/); do
-        convert $CIRCLE_ARTIFACTS/imgs/$img/*.png -append $CIRCLE_ARTIFACTS/imgs/$img.png
+      for img in $(ls $CIRCLE_ARTIFACTS/imgs/pieces/); do
+        convert $CIRCLE_ARTIFACTS/imgs/pieces/$img/*.png -append $CIRCLE_ARTIFACTS/imgs/$img.png
       done
-
-    # Remove all directories in $CIRCLE_ARTIFACTS/img
-    # Currently the pieces aren't kept around. If it's
-    # desirable to keep them around, we should use
-    #    cp -r $dir $CIRCLE_ARTIFACTS/img_pieces
-    # The reason the image pieces aren't currently kept
-    # around is that it was leading to a problem. Specifically,
-    # when we get the previous images, we niavely grab any *.png,
-    # including the pieces images. This compounded so that each
-    # iteration of a test run would have all of the images from
-    # the previous test run plus whichever new images were generated.
-    - rm -R -- $CIRCLE_ARTIFACTS/imgs/*/
 
     # Download the latest mathquill artifacts from master.
     - |-
@@ -205,7 +193,8 @@ test:
       prev_imgs="$(echo "$artifacts_json" \
                     | $json -a url pretty_path -d '\n\t' \
                     | grep '\.png$' \
-                    | grep -v 'PREV_' \
+                    | grep -v '/PREV_' \
+                    | grep -v '/pieces/' \
                     | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/PREV_:")"
       echo 'Previous image URLs and files:'
       echo

--- a/circle.yml
+++ b/circle.yml
@@ -52,11 +52,15 @@ dependencies:
             time tar -xzf sc-latest-linux.tar.gz
           fi
           # Sauce Connect randomly fails so try twice https://git.io/vPN8v
-          time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY --readyfile ~/sauce_is_ready
-          test -e sauce_is_ready \
-            || time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY --readyfile ~/sauce_is_ready
-          test -e sauce_is_ready \
-            || echo 'ERROR: Exited twice without creating readyfile' | tee /dev/stderr > ~/sauce_is_ready
+          time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY \
+            --readyfile ~/sauce_is_ready
+          test -e sauce_is_ready && exit
+          time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY \
+            --readyfile ~/sauce_is_ready
+          test -e sauce_is_ready && exit
+          echo 'ERROR: Exited twice without creating readyfile' \
+            | tee /dev/stderr > ~/sauce_is_ready
+          exit 1
         } >$CIRCLE_ARTIFACTS/sauce-connect.log 2>&1
       :
         background: true

--- a/circle.yml
+++ b/circle.yml
@@ -166,49 +166,47 @@ test:
         timeout: 300
 
     # Stitch together images
-    # TODO: Split this into multiple yaml lines. I (Michael)
-    #       niavely tried to split this into mutiple yaml lines
-    #       but was unsucessful in doing do.
     - |-
-      img_dir=$CIRCLE_ARTIFACTS/imgs/
-      for x in $(ls $img_dir)
-      do
-        convert $img_dir/$x/*.png -append $img_dir/$x.png
+      for img in $(ls $CIRCLE_ARTIFACTS/imgs/); do
+        convert $CIRCLE_ARTIFACTS/imgs/$img/*.png -append $CIRCLE_ARTIFACTS/imgs/$img.png
       done
 
-      # Remove all directories in $CIRCLE_ARTIFACTS/img
-      # Currently the pieces aren't kept around. If it's
-      # desirable to keep them around, we should use
-      #    cp -r $dir $CIRCLE_ARTIFACTS/img_pieces
-      # The reason the image pieces aren't currently kept
-      # around is that it was leading to a problem. Specifically,
-      # when we get the previous images, we niavely grab any *.png,
-      # including the pieces images. This compounded so that each
-      # iteration of a test run would have all of the images from
-      # the previous test run plus whichever new images were generated.
-      rm -R -- $img_dir/*/
+    # Remove all directories in $CIRCLE_ARTIFACTS/img
+    # Currently the pieces aren't kept around. If it's
+    # desirable to keep them around, we should use
+    #    cp -r $dir $CIRCLE_ARTIFACTS/img_pieces
+    # The reason the image pieces aren't currently kept
+    # around is that it was leading to a problem. Specifically,
+    # when we get the previous images, we niavely grab any *.png,
+    # including the pieces images. This compounded so that each
+    # iteration of a test run would have all of the images from
+    # the previous test run plus whichever new images were generated.
+    - rm -R -- $CIRCLE_ARTIFACTS/imgs/*/
 
-      # Download the latest mathquill artifacts.
+    # Download the latest mathquill artifacts.
+    - |-
       curl $(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts \
               | $json -a url pretty_path -d '\n\t' \
               | grep '\.png$' \
               | grep -v 'PREV_' \
-              | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $img_dir/PREV_:")
+              | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/PREV_:")
 
-      # Generate image diffs.
-      cd $img_dir
+    # Generate image diffs.
+    - |-
+      cd $CIRCLE_ARTIFACTS/imgs/
       for file in $(ls PINNED*); do
         prev=PREV_$file
         metric_diff=$(compare -metric AE -compose src $prev $file raw_diff.png)
         composite -alpha on raw_diff.png $prev DIFF_$file
       done
 
+    - |-
       for file in $(ls EVERGREEN*); do
         prev=$(ls PREV_$file*)
         metric_diff=$(compare -metric AE -compose src $prev $file raw_diff.png)
         composite -alpha on raw_diff.png $prev DIFF_$file
       done
 
-      rm raw_diff.png
+    - rm raw_diff.png
   post:
     - killall --wait sc; true  # wait for Sauce Connect to close the tunnel; ignore errors since it's just cleanup

--- a/circle.yml
+++ b/circle.yml
@@ -119,7 +119,7 @@ test:
            -H 'Content-Type: application/json' \
            -d '{
                  "build": "'"$build_name"'",
-                 "customData": {"build_url": "'"$CIRCLE_BUILD_URL"'"}
+                 "customData": {"build_url": "'"$CIRCLE_BUILD_URL"'"},
                  "framework": "mocha",
                  "url": "http://localhost:8000/test/unit.html?post_xunit_to=http://localhost:9000",
                  "platforms": [["", "Chrome", ""]]

--- a/circle.yml
+++ b/circle.yml
@@ -212,7 +212,7 @@ test:
       for file in $(ls *.png); do
         # if evergreen browser, browser version of previous screenshot may not match,
         # so replace previous browser version with glob
-        baseline="$(echo baseline/$(echo $file | sed 's/[^_]*_(evergreen)/*/')"
+        baseline="$(echo baseline/$(echo $file | sed 's/[^_]*_(evergreen)/*/'))"
         echo "Number of different pixels from baseline in $file:"
         compare -metric AE $baseline $file ${file/%.png/_DIFF.png}
       done

--- a/circle.yml
+++ b/circle.yml
@@ -194,6 +194,7 @@ test:
                     | $json -a url pretty_path -d '\n\t' \
                     | grep '\.png$' \
                     | grep -v '/PREV_' \
+                    | grep -v '/DIFF_' \
                     | grep -v '/pieces/' \
                     | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/PREV_:")"
       echo 'Previous image URLs and files:'

--- a/circle.yml
+++ b/circle.yml
@@ -212,8 +212,8 @@ test:
         # if evergreen browser, browser version of previous screenshot may not match,
         # so replace previous browser version with glob
         baseline=baseline/"$(sh -c "ls $(echo $file | sed 's/[^_]*_(evergreen)/*/')")"
-        echo "Diff metrics for $file:"
-        compare -list metric $baseline $file ${file/%.png/_DIFF.png}
+        echo "Number of different pixels from baseline in $file:"
+        compare -metric AE $baseline $file ${file/%.png/_DIFF.png}
       done
   post:
     - killall --wait sc; true  # wait for Sauce Connect to close the tunnel; ignore errors since it's just cleanup

--- a/circle.yml
+++ b/circle.yml
@@ -178,7 +178,7 @@ test:
     # Stitch together images
     - |-
       for img in $(ls $CIRCLE_ARTIFACTS/imgs/pieces/); do
-        convert $CIRCLE_ARTIFACTS/imgs/pieces/$img/*.png -append $CIRCLE_ARTIFACTS/imgs/$img.png
+        convert $(ls -1 $CIRCLE_ARTIFACTS/imgs/pieces/$img/*.png | sort -n) -append $CIRCLE_ARTIFACTS/imgs/$img.png
       done
 
     # Download the latest mathquill artifacts from master.

--- a/circle.yml
+++ b/circle.yml
@@ -33,7 +33,7 @@
 
 machine:
   environment:
-    json: ~/node_modules/.bin/json
+    json: node_modules/.bin/json
 
 dependencies:
   cache_directories:
@@ -60,7 +60,7 @@ dependencies:
         } >$CIRCLE_ARTIFACTS/sauce-connect.log 2>&1
       :
         background: true
-    - test -x $json || { cd; npm install json; }
+    - test -x $json || npm install json
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -60,7 +60,7 @@ dependencies:
         } >$CIRCLE_ARTIFACTS/sauce-connect.log 2>&1
       :
         background: true
-    - test -x $json || npm install json
+    - test -x $json || { cd; npm install json; }
 
 test:
   override:

--- a/circle.yml
+++ b/circle.yml
@@ -31,6 +31,10 @@
 # this file is based on https://github.com/circleci/sauce-connect/blob/a65e41c91e02550ce56c75740a422bebc4acbf6f/circle.yml
 # via https://circleci.com/docs/browser-testing-with-sauce-labs/
 
+machine:
+  environment:
+    json: ~/node_modules/.bin/json
+
 dependencies:
   cache_directories:
     - ~/sauce-connect
@@ -54,6 +58,7 @@ dependencies:
         } >$CIRCLE_ARTIFACTS/sauce-connect.log 2>&1
       :
         background: true
+    - test -x $json || npm install json
 
 test:
   override:
@@ -178,12 +183,9 @@ test:
       # the previous test run plus whichever new images were generated.
       rm -R -- $img_dir/*/
 
-      # Install utility we need
-      npm install -g json
-
       # Download the latest mathquill artifacts.
       curl $(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts \
-              | json -a url pretty_path -d '\n\t' \
+              | $json -a url pretty_path -d '\n\t' \
               | grep '\.png$' \
               | grep -v 'PREV' \
               | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $img_dir/PREV_:")

--- a/circle.yml
+++ b/circle.yml
@@ -186,11 +186,11 @@ test:
     # Download the latest mathquill artifacts.
     - |-
       prev_imgs="$(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts \
-                    | tee /dev/stderr
+                    | tee /dev/stderr \
                     | $json -a url pretty_path -d '\n\t' \
                     | grep '\.png$' \
                     | grep -v 'PREV_' \
-                    | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/PREV_:"
+                    | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/PREV_:" \
                     | tee /dev/stderr)"
       test -z "$prev_imgs" || curl $prev_imgs
 

--- a/circle.yml
+++ b/circle.yml
@@ -140,6 +140,7 @@ test:
            -u $SAUCE_USERNAME:$SAUCE_ACCESS_KEY \
            -H 'Content-Type: application/json' \
            -d '{
+                 "name": "Unit tests, Mocha",
                  "build": "'"$build_name"'",
                  "customData": {"build_url": "'"$CIRCLE_BUILD_URL"'"},
                  "framework": "mocha",

--- a/circle.yml
+++ b/circle.yml
@@ -183,11 +183,11 @@ test:
     # the previous test run plus whichever new images were generated.
     - rm -R -- $CIRCLE_ARTIFACTS/imgs/*/
 
-    # Download the latest mathquill artifacts.
+    # Download the latest mathquill artifacts from master.
     - |-
-      artifacts_json="$(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts)"
+      artifacts_json="$(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts?branch=master)"
       echo
-      echo '/latest/artifacts:'
+      echo '/latest/artifacts?branch=master:'
       echo
       echo "$artifacts_json"
       echo

--- a/circle.yml
+++ b/circle.yml
@@ -216,5 +216,6 @@ test:
         echo "Number of different pixels from baseline in $file:"
         compare -metric AE $baseline $file ${file/%.png/_DIFF.png}
       done
+      true  # ignore errors like "image widths or heights differ"
   post:
     - killall --wait sc; true  # wait for Sauce Connect to close the tunnel; ignore errors since it's just cleanup

--- a/circle.yml
+++ b/circle.yml
@@ -185,11 +185,14 @@ test:
 
     # Download the latest mathquill artifacts.
     - |-
-      curl $(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts \
-              | $json -a url pretty_path -d '\n\t' \
-              | grep '\.png$' \
-              | grep -v 'PREV_' \
-              | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/PREV_:")
+      prev_imgs="$(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts \
+                    | tee /dev/stderr
+                    | $json -a url pretty_path -d '\n\t' \
+                    | grep '\.png$' \
+                    | grep -v 'PREV_' \
+                    | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/PREV_:"
+                    | tee /dev/stderr)"
+      test -z "$prev_imgs" || curl $prev_imgs
 
     # Generate image diffs.
     - |-

--- a/circle.yml
+++ b/circle.yml
@@ -207,20 +207,13 @@ test:
     # Generate image diffs.
     - |-
       cd $CIRCLE_ARTIFACTS/imgs/
-      for file in $(ls PINNED*); do
-        prev=PREV_$file
-        metric_diff=$(compare -metric AE -compose src $prev $file raw_diff.png)
-        composite -alpha on raw_diff.png $prev DIFF_$file
+      for file in $(ls *.png | grep -v '^PREV_'); do
+        # if evergreen browser, browser version of previous screenshot may not match,
+        # so replace previous browser version with glob
+        prev=PREV_"$(sh -c "ls $(echo $file | sed 's/[^_]*_(evergreen)/*/')")"
+        metric_diff=$(compare -metric AE -compose src $prev $file RAW_DIFF_$file)
+        echo "Metric diff for $file: $metric_diff"
+        composite -alpha on RAW_DIFF_$file $prev DIFF_$file
       done
-
-    - |-
-      cd $CIRCLE_ARTIFACTS/imgs/
-      for file in $(ls EVERGREEN*); do
-        prev=$(ls PREV_$file*)
-        metric_diff=$(compare -metric AE -compose src $prev $file raw_diff.png)
-        composite -alpha on raw_diff.png $prev DIFF_$file
-      done
-
-    - rm $CIRCLE_ARTIFACTS/imgs/raw_diff.png
   post:
     - killall --wait sc; true  # wait for Sauce Connect to close the tunnel; ignore errors since it's just cleanup

--- a/circle.yml
+++ b/circle.yml
@@ -212,7 +212,7 @@ test:
       for file in $(ls *.png); do
         # if evergreen browser, browser version of previous screenshot may not match,
         # so replace previous browser version with glob
-        baseline=baseline/"$(sh -c "ls $(echo $file | sed 's/[^_]*_(evergreen)/*/')")"
+        baseline="$(sh -c "ls \"baseline/$(echo $file | sed 's/[^_]*_(evergreen)/*/')\"")"
         echo "Number of different pixels from baseline in $file:"
         compare -metric AE $baseline $file ${file/%.png/_DIFF.png}
       done

--- a/circle.yml
+++ b/circle.yml
@@ -31,10 +31,6 @@
 # this file is based on https://github.com/circleci/sauce-connect/blob/a65e41c91e02550ce56c75740a422bebc4acbf6f/circle.yml
 # via https://circleci.com/docs/browser-testing-with-sauce-labs/
 
-machine:
-  environment:
-    json: node_modules/.bin/json
-
 dependencies:
   cache_directories:
     - ~/sauce-connect
@@ -66,7 +62,6 @@ dependencies:
         exit 1
       :
         background: true
-    - test -x $json || npm install json
 
 test:
   pre:
@@ -171,11 +166,11 @@ test:
 
         # deliberately do `... != false` rather than `... == true`
         # because unexpected values should break rather than infinite loop
-        [ "$($json completed <status.json)" != false ] && break
+        [ "$(jq .completed <status.json)" != false ] && break
       done
 
       echo '3. Exit with non-zero status code if any unit tests failed'
-      exit "$($json 'js tests'.0.result.failures <status.json)"
+      exit "$(jq '.["js tests"][0].result.failures' <status.json)"
 
     - |-
       # Stitch together screenshots and diff against master
@@ -202,12 +197,12 @@ test:
 
       mkdir $CIRCLE_ARTIFACTS/imgs/baseline/
       baseline_imgs="$(echo "$artifacts_json" \
-                    | $json -a url pretty_path -d '\n\t' \
+                    | jq -r '.[] | .url + " -o " + .pretty_path' \
                     | grep '\.png$' \
                     | grep -v '_DIFF\.png$' \
                     | grep -vF '/pieces/' \
                     | grep -vF '/baseline/' \
-                    | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/baseline/:")"
+                    | sed "s:\$CIRCLE_ARTIFACTS/imgs/:$CIRCLE_ARTIFACTS/imgs/baseline/:")"
       echo 'Baseline image URLs and files:'
       echo
       echo "$baseline_imgs"

--- a/circle.yml
+++ b/circle.yml
@@ -118,8 +118,8 @@ test:
            -u $SAUCE_USERNAME:$SAUCE_ACCESS_KEY \
            -H 'Content-Type: application/json' \
            -d '{
-                 "build": "'$build_name'",
-                 "customData": {"build_url": "'$CIRCLE_BUILD_URL'"}
+                 "build": "'"$build_name"'",
+                 "customData": {"build_url": "'"$CIRCLE_BUILD_URL"'"}
                  "framework": "mocha",
                  "url": "http://localhost:8000/test/unit.html?post_xunit_to=http://localhost:9000",
                  "platforms": [["", "Chrome", ""]]

--- a/circle.yml
+++ b/circle.yml
@@ -54,10 +54,10 @@ dependencies:
           # Sauce Connect randomly fails so try twice https://git.io/vPN8v
           time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY \
             --readyfile ~/sauce_is_ready
-          test -e ~/sauce_is_ready && exit
+          test -e ~/sauce_was_ready && exit
           time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY \
             --readyfile ~/sauce_is_ready
-          test -e ~/sauce_is_ready && exit
+          test -e ~/sauce_was_ready && exit
           echo 'ERROR: Exited twice without creating readyfile' \
             | tee /dev/stderr > ~/sauce_is_ready
           exit 1
@@ -97,7 +97,7 @@ test:
 
     # Wait for tunnel to be ready (`make server` and the trivial Node server
     # are much faster, no need to wait for them)
-    - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done; test -z "$(<~/sauce_is_ready)"
+    - while [ ! -e ~/sauce_is_ready ]; do sleep 1; done; touch ~/sauce_was_ready; test -z "$(<~/sauce_is_ready)"
 
     # Start taking screenshots in the background while the unit tests are running
     - ? |-

--- a/circle.yml
+++ b/circle.yml
@@ -197,7 +197,6 @@ test:
                     | grep '\.png$' \
                     | grep -v '/pieces/' \
                     | grep -v '/baseline/' \
-                    | grep -v '/raw_diffs/' \
                     | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $CIRCLE_ARTIFACTS/imgs/baseline/:")"
       echo 'Baseline image URLs and files:'
       echo
@@ -209,14 +208,12 @@ test:
     # Generate image diffs.
     - |-
       cd $CIRCLE_ARTIFACTS/imgs/
-      mkdir raw_diffs/
       for file in $(ls *.png); do
         # if evergreen browser, browser version of previous screenshot may not match,
         # so replace previous browser version with glob
         baseline=baseline/"$(sh -c "ls $(echo $file | sed 's/[^_]*_(evergreen)/*/')")"
-        echo "Metric diff for $file:"
-        compare -metric AE -compose src $baseline $file raw_diffs/$file
-        composite -alpha on raw_diffs/$file $prev ${file/%.png/_DIFF.png}
+        echo "Diff metrics for $file:"
+        compare -list metric $baseline $file ${file/%.png/_DIFF.png}
       done
   post:
     - killall --wait sc; true  # wait for Sauce Connect to close the tunnel; ignore errors since it's just cleanup

--- a/circle.yml
+++ b/circle.yml
@@ -201,12 +201,13 @@ test:
       done
 
     - |-
+      cd $CIRCLE_ARTIFACTS/imgs/
       for file in $(ls EVERGREEN*); do
         prev=$(ls PREV_$file*)
         metric_diff=$(compare -metric AE -compose src $prev $file raw_diff.png)
         composite -alpha on raw_diff.png $prev DIFF_$file
       done
 
-    - rm raw_diff.png
+    - rm $CIRCLE_ARTIFACTS/imgs/raw_diff.png
   post:
     - killall --wait sc; true  # wait for Sauce Connect to close the tunnel; ignore errors since it's just cleanup

--- a/circle.yml
+++ b/circle.yml
@@ -183,7 +183,8 @@ test:
 
     # Download the latest screenshots from master.
     - |-
-      artifacts_json="$(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts?branch=master)"
+      artifacts_json="$(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts?branch=ci.cleanup)"
+      #when done testing, restore: artifacts_json="$(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts?branch=master)"
       echo
       echo '/latest/artifacts?branch=master:'
       echo

--- a/circle.yml
+++ b/circle.yml
@@ -185,7 +185,7 @@ test:
       curl $(curl https://circleci.com/api/v1/project/mathquill/mathquill/latest/artifacts \
               | $json -a url pretty_path -d '\n\t' \
               | grep '\.png$' \
-              | grep -v 'PREV' \
+              | grep -v 'PREV_' \
               | sed "s:\$CIRCLE_ARTIFACTS/imgs/:-o $img_dir/PREV_:")
 
       # Generate image diffs.

--- a/circle.yml
+++ b/circle.yml
@@ -85,11 +85,11 @@ test:
         mkdir -p $CIRCLE_TEST_REPORTS/mocha
 
         # CircleCI expects test results to be reported in an JUnit/xUnit-style XML file:
-        #   https://circleci.com/docs/test-metadata/
+        #   https://circleci.com/docs/test-metadata/#a-namemochajsamocha-for-nodejs
         # Our unit tests are in a browser, so they can't write to a file, and Sauce
         # apparently truncates custom data in their test result reports, so instead we
         # POST to this trivial Node server on localhost:9000 that writes the body of
-        # any POST request to $CIRCLE_TEST_REPORTS/mocha/xunit.xml
+        # any POST request to $CIRCLE_TEST_REPORTS/junit/test-results.xml
         node -e '
           require("http").createServer(function(req, res) {
             res.setHeader("Access-Control-Allow-Origin", "*");
@@ -98,7 +98,7 @@ test:
           })
           .listen(9000);
           console.error("listening on http://0.0.0.0:9000/");
-        ' 2>&1 >$CIRCLE_TEST_REPORTS/mocha/xunit.xml | {
+        ' 2>&1 >$CIRCLE_TEST_REPORTS/junit/test-results.xml | {
           # ^ note: `2>&1` must precede `>$CIRCLE_TEST_REPORTS/...` because
           # shell redirect is like assignment; if it came after, then both
           # stdout and stderr would be written to `xunit.xml` and nothing

--- a/circle.yml
+++ b/circle.yml
@@ -54,10 +54,10 @@ dependencies:
           # Sauce Connect randomly fails so try twice https://git.io/vPN8v
           time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY \
             --readyfile ~/sauce_is_ready
-          test -e sauce_is_ready && exit
+          test -e ~/sauce_is_ready && exit
           time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY \
             --readyfile ~/sauce_is_ready
-          test -e sauce_is_ready && exit
+          test -e ~/sauce_is_ready && exit
           echo 'ERROR: Exited twice without creating readyfile' \
             | tee /dev/stderr > ~/sauce_is_ready
           exit 1

--- a/circle.yml
+++ b/circle.yml
@@ -140,8 +140,7 @@ test:
       while true  # Bash has no do...while >:(
       do
         sleep 5
-        curl -i https://saucelabs.com/rest/v1/$SAUCE_USERNAME/js-tests/status \
-             -X POST \
+        curl -i -X POST https://saucelabs.com/rest/v1/$SAUCE_USERNAME/js-tests/status \
              -u $SAUCE_USERNAME:$SAUCE_ACCESS_KEY \
              -H 'Content-Type: application/json' \
              -d @js-tests.json \

--- a/circle.yml
+++ b/circle.yml
@@ -52,9 +52,11 @@ dependencies:
             time tar -xzf sc-latest-linux.tar.gz
           fi
           # Sauce Connect randomly fails so try twice https://git.io/vPN8v
-          time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY --readyfile ~/sauce_is_ready \
-            || time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY --readyfile ~/sauce_is_ready \
-            || echo EXIT STATUS $? | tee /dev/stderr > ~/sauce_is_ready
+          time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY --readyfile ~/sauce_is_ready
+          test -e sauce_is_ready \
+            || time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY --readyfile ~/sauce_is_ready
+          test -e sauce_is_ready \
+            || echo 'ERROR: Exited twice without creating readyfile' | tee /dev/stderr > ~/sauce_is_ready
         } >$CIRCLE_ARTIFACTS/sauce-connect.log 2>&1
       :
         background: true

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -175,7 +175,7 @@ browsers.forEach(function(browser) {
     });
   })
   .fail(function(err) {
-    console.log('ERROR:', sessionName);
+    console.log('ERROR:', browser.config.browserName, browser.config.platform);
     console.log(JSON.stringify(err, null, 2));
   });
 

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -82,12 +82,13 @@ browsers.forEach(function(browser) {
   return browserDriver.init(browser.config)
   .then(function(args) {
     var cfg = browser.config, capabilities = args[1];
-    var sessionName = [cfg.browserName, capabilities.version, cfg.platform].join(' ');
+    var version = capabilities.version || capabilities.browserVersion;
+    var sessionName = [cfg.browserName, version, cfg.platform].join(' ');
     if (capabilities.platformVersion) sessionName += ' ' + capabilities.platformVersion;
     console.log(sessionName, 'init', args);
 
     var evergreen = browser.pinned ? '' : '_(evergreen)';
-    var fileName = [cfg.browserName, capabilities.version + evergreen, cfg.platform].join('_');
+    var fileName = [cfg.browserName, version + evergreen, cfg.platform].join('_');
     if (capabilities.platformVersion) fileName += ' ' + capabilities.platformVersion;
     fileName = fileName.replace(/ /g, '_');
 

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -149,22 +149,22 @@ browsers.forEach(function(browser) {
         })();
       }
     })
-  })
-  .log('browser')
-  .then(function(logs) {
-    var logfile = baseDir+'/'+browserName+'_'+platform+'.log'
-    return new Promise(function(resolve, reject) {
-      fs.writeFile(logfile,logs.join('\n'), function(err) {
-        if (err) return reject(err);
-        console.log(cfg.browserName,cfg.platform,'writeFile');
+    .log('browser')
+    .then(function(logs) {
+      var logfile = baseDir + '/' + [cfg.browserName, cfg.version, cfg.platform].join('_').replace(/ /g, '_');
+      return new Promise(function(resolve, reject) {
+        fs.writeFile(logfile, logs.join('\n'), function(err) {
+          if (err) return reject(err);
+          console.log(cfg.browserName, cfg.version, cfg.platform, 'writeFile');
 
-        return resolve(browserDriver.quit());
+          return resolve(browserDriver.quit());
+        });
       });
+    }, function(err) {
+      // the Edge/Internet Explorer drivers don't support logs, but the others do
+      console.log(cfg.browserName, cfg.platform, 'Error fetching logs:', JSON.stringify(err, null, 2));
+      return [];
     });
-  }, function(err) {
-    // the Edge/Internet Explorer drivers don't support logs, but the others do
-    console.log(cfg.browserName, cfg.platform, 'Error fetching logs:', JSON.stringify(err, null, 2));
-    return [];
   })
   .fail(function(err) {
     console.log('ERROR:', cfg.browserName, cfg.platform);

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -155,21 +155,23 @@ browsers.forEach(function(browser) {
         })();
       }
     })
-    .log('browser')
-    .then(function(logs) {
-      var logfile = baseDir + '/browser_logs/' + sessionName.replace(/ /g, '_') + '.log';
-      return new Promise(function(resolve, reject) {
-        fs.writeFile(logfile, JSON.stringify(logs, null, 2), function(err) {
-          if (err) return reject(err);
-          console.log(sessionName, 'writeFile');
+    .then(function() {
+      return browserDriver.log('browser')
+      .then(function(logs) {
+        var logfile = baseDir + '/browser_logs/' + sessionName.replace(/ /g, '_') + '.log';
+        return new Promise(function(resolve, reject) {
+          fs.writeFile(logfile, JSON.stringify(logs, null, 2), function(err) {
+            if (err) return reject(err);
+            console.log(sessionName, 'writeFile');
 
-          return resolve(browserDriver.quit());
+            return resolve(browserDriver.quit());
+          });
         });
+      }, function(err) {
+        // the Edge/Internet Explorer drivers don't support logs, but the others do
+        console.log(sessionName, 'Error fetching logs:', JSON.stringify(err, null, 2));
+        return [];
       });
-    }, function(err) {
-      // the Edge/Internet Explorer drivers don't support logs, but the others do
-      console.log(sessionName, 'Error fetching logs:', JSON.stringify(err, null, 2));
-      return [];
     });
   })
   .fail(function(err) {

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -78,6 +78,8 @@ var browsers = [
 
 browsers.forEach(function(browser) {
   browser.config.build = build_name;
+  browser.config.name = 'Visual tests, ' + browser.config.browserName + ' on ' + browser.config.platform;
+  browser.config.customData = {build_url: process.env.CIRCLE_BUILD_URL};
   var browserDriver = wd.promiseChainRemote('ondemand.saucelabs.com', 80, username, accessKey);
   return browserDriver.init(browser.config)
   .then(function(args) {

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -107,12 +107,13 @@ browserVersions.forEach(function(obj) {
             browserDriver.safeExecute('document.documentElement.clientHeight')];
   })
   .spread(function(scrollHeight, viewportHeight) {
-    console.log(cfg.browserName,cfg.platform,'get scrollHeight, clientHeight');
+    console.log(cfg.browserName, cfg.platform, 'get scrollHeight, clientHeight', scrollHeight, viewportHeight);
 
     // Firefox and Internet Explorer will take a screenshot of the entire webpage,
     if (cfg.browserName != 'Safari' && cfg.browserName != 'Chrome' && cfg.browserName != 'MicrosoftEdge') {
       // saves file in the file `piecesDir/browser_version_platform/*.png`
       var filename = piecesDir+'/'+browser+'_'+platform+'.png';
+      console.log(cfg.browserName, cfg.platform, 'about to saveScreenshot');
       return browserDriver.saveScreenshot(filename)
       .then(willLog(cfg.browserName,cfg.platform,'saveScreenshot'))
       .log('browser')

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -115,7 +115,19 @@ browsers.forEach(function(browser) {
 
         var scrollTop = 0;
         var index = 1;
-        return (function loop() {
+
+        // Microsoft Edge starts out with illegally big window: https://git.io/vD63O
+        if (cfg.browserName === 'MicrosoftEdge') {
+          return browserDriver.getWindowSize()
+          .then(function(size) {
+            return browserDriver.setWindowSize(size.width, size.height)
+          })
+          .then(willLog(sessionName, 'reset window size (Edge-only workaround)'))
+          .then(loop);
+        } else {
+          return loop();
+        }
+        function loop() {
           return browserDriver.safeEval('window.scrollTo(0,'+scrollTop+');')
           .then(willLog(sessionName, 'scrollTo()'))
           .saveScreenshot(piecesDir + index + '.png')
@@ -155,7 +167,7 @@ browsers.forEach(function(browser) {
               });
             }
           });
-        })();
+        }
       }
     })
     .then(function() {

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -95,8 +95,10 @@ browsers.forEach(function(browser) {
     return browserDriver.get(url)
     .then(willLog(sessionName, 'get'))
     .safeExecute('document.body.focus()') // blur anything that's auto-focused
+    .then(willLog(sessionName, 'document.body.focus()'))
+    .safeExecute('document.documentElement.style.overflow = "hidden"') // hide scrollbars
+    .then(willLog(sessionName, 'hide scrollbars'))
     .then(function() {
-      console.log(sessionName, 'document.body.focus()');
       return [browserDriver.safeExecute('document.documentElement.scrollHeight'),
               browserDriver.safeExecute('document.documentElement.clientHeight')];
     })

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -192,6 +192,7 @@ browsers.forEach(function(browser) {
   .fail(function(err) {
     console.log('ERROR:', browser.config.browserName, browser.config.platform);
     console.log(JSON.stringify(err, null, 2));
+    return browserDriver.sauceJobStatus(false);
   })
   .quit();
 

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -93,8 +93,10 @@ browsers.forEach(function(browser) {
     fileName = fileName.replace(/ /g, '_');
 
     return browserDriver.get(url)
+    .then(willLog(sessionName, 'get'))
+    .safeExecute('document.body.focus()') // blur anything that's auto-focused
     .then(function() {
-      console.log(sessionName, 'get');
+      console.log(sessionName, 'document.body.focus()');
       return [browserDriver.safeExecute('document.documentElement.scrollHeight'),
               browserDriver.safeExecute('document.documentElement.clientHeight')];
     })
@@ -114,7 +116,9 @@ browsers.forEach(function(browser) {
         var scrollTop = 0;
         var index = 1;
         return (function loop() {
-          return browserDriver.saveScreenshot(piecesDir + index + '.png')
+          return browserDriver.safeEval('window.scrollTo(0,'+scrollTop+');')
+          .then(willLog(sessionName, 'scrollTo()'))
+          .saveScreenshot(piecesDir + index + '.png')
           .then(function() {
             console.log(sessionName, 'saveScreenshot');
 
@@ -128,9 +132,7 @@ browsers.forEach(function(browser) {
               //   https://github.com/jquery/jquery/blob/1.12.3/src/offset.js#L186
               // Use `window.scrollTo` instead of jQuery because jQuery was
               // causing a stackoverflow in Safari.
-              return browserDriver.safeEval('window.scrollTo(0,'+scrollTop+');')
-              .then(willLog(sessionName, 'scrollTo()'))
-              .then(loop);
+              return loop();
             } else { // we are past the bottom edge of the page, reduce window size to
               // fit only the part of the page that hasn't been screenshotted.
 

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -151,7 +151,7 @@ browsers.forEach(function(browser) {
     })
     .log('browser')
     .then(function(logs) {
-      var logfile = baseDir + '/' + [cfg.browserName, cfg.version, cfg.platform].join('_').replace(/ /g, '_');
+      var logfile = baseDir + '/browser_logs/' + [cfg.browserName, cfg.version, cfg.platform].join('_').replace(/ /g, '_') + '.log';
       return new Promise(function(resolve, reject) {
         fs.writeFile(logfile, logs.join('\n'), function(err) {
           if (err) return reject(err);

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -102,12 +102,12 @@ browsers.forEach(function(browser) {
 
       // the easy case: Firefox and IE return a screenshot of the entire webpage
       if (cfg.browserName === 'Firefox' || cfg.browserName === 'Internet Explorer') {
-        return browserDriver.saveScreenshot(baseDir + '/imgs/' + filename + '.png')
+        return browserDriver.saveScreenshot(baseDir + '/imgs/' + fileName + '.png')
         .then(willLog(sessionName, 'saveScreenshot'))
       // the hard case: for Chrome, Safari, and Edge, scroll through the page and
       // take screenshots of each piece; circle.yml will stitch them together
       } else {
-        var piecesDir = baseDir + '/imgs/pieces/' + filename + '/';
+        var piecesDir = baseDir + '/imgs/pieces/' + fileName + '/';
         fs.mkdirSync(piecesDir);
 
         var scrollTop = 0;

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -25,6 +25,7 @@ if (!baseDir) {
 }
 fs.mkdirSync(baseDir+'/imgs');
 fs.mkdirSync(baseDir+'/imgs/pieces');
+fs.mkdirSync(baseDir+'/browser_logs');
 
 var browsers = [
   {

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -155,7 +155,7 @@ browsers.forEach(function(browser) {
     .then(function(logs) {
       var logfile = baseDir + '/browser_logs/' + [cfg.browserName, cfg.version, cfg.platform].join('_').replace(/ /g, '_') + '.log';
       return new Promise(function(resolve, reject) {
-        fs.writeFile(logfile, logs.join('\n'), function(err) {
+        fs.writeFile(logfile, JSON.stringify(logs, null, 2), function(err) {
           if (err) return reject(err);
           console.log(cfg.browserName, cfg.version, cfg.platform, 'writeFile');
 

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -33,15 +33,14 @@ var browsers = [
       browserName: 'Internet Explorer',
       platform: 'Windows XP'
     },
-    pinned: true // should be pinned to IE 8
+    pinned: true // assume pinned to IE 8
   },
   {
     config: {
-      // Expecting IE 11
       browserName: 'Internet Explorer',
       platform: 'Windows 7'
     },
-    pinned: true // should be pinned to IE 11
+    pinned: true // assume pinned to IE 11
   },
   {
     config: {

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -179,19 +179,17 @@ browsers.forEach(function(browser) {
         var logfile = baseDir + '/browser_logs/' + sessionName.replace(/ /g, '_') + '.log';
         return new Promise(function(resolve, reject) {
           fs.writeFile(logfile, JSON.stringify(logs, null, 2), function(err) {
-            if (err) return reject(err);
-            console.log(sessionName, 'writeFile');
-
-            return resolve(browserDriver.quit());
+            err ? reject(err) : resolve();
           });
-        });
+        })
+        .then(willLog(sessionName, 'writeFile'));
       }, function(err) {
-        // the Edge/Internet Explorer drivers don't support logs, but the others do
+        // the Edge, IE, and Firefox-on-macOS drivers don't support logs, but the others do
         console.log(sessionName, 'Error fetching logs:', JSON.stringify(err, null, 2));
-        return [];
       });
     });
   })
+  .quit()
   .fail(function(err) {
     console.log('ERROR:', browser.config.browserName, browser.config.platform);
     console.log(JSON.stringify(err, null, 2));

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -24,6 +24,7 @@ if (!baseDir) {
   process.exit(1);
 }
 fs.mkdirSync(baseDir+'/imgs');
+fs.mkdirSync(baseDir+'/imgs/pieces');
 
 var browsers = [
   {
@@ -101,7 +102,7 @@ browsers.forEach(function(browser) {
       // the hard case: for Chrome, Safari, and Edge, scroll through the page and
       // take screenshots of each piece; circle.yml will stitch them together
       } else {
-        var piecesDir = baseDir + '/imgs/' + filename + '/';
+        var piecesDir = baseDir + '/imgs/pieces/' + filename + '/';
         fs.mkdirSync(piecesDir);
 
         var scrollTop = 0;

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -189,11 +189,12 @@ browsers.forEach(function(browser) {
       });
     });
   })
-  .quit()
+  .sauceJobStatus(true)
   .fail(function(err) {
     console.log('ERROR:', browser.config.browserName, browser.config.platform);
     console.log(JSON.stringify(err, null, 2));
-  });
+  })
+  .quit();
 
   function willLog() {
     var msg = [].join.call(arguments, ' ');

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -19,14 +19,7 @@ var accessKey = process.env['SAUCE_ACCESS_KEY'];
 var baseDir = process.env['CIRCLE_ARTIFACTS'] || '/tmp';
 var url = process.argv[2];
 var allImgsDir = baseDir+'/imgs';
-var build_name = 'CircleCI build #' + process.env.CIRCLE_BUILD_NUM;
-if (process.env.CIRCLE_PR_NUMBER) {
-  build_name += ': PR #' + process.env.CIRCLE_PR_NUMBER;
-  if (process.env.CIRCLE_BRANCH) build_name += ' (' + process.env.CIRCLE_BRANCH + ')';
-} else {
-  build_name += ': ' + process.env.CIRCLE_BRANCH;
-}
-build_name += ' @ ' + process.env.CIRCLE_SHA1.slice(0, 7);
+var build_name = process.env.MQ_CI_BUILD_NAME;
 
 fs.mkdirSync(allImgsDir);
 

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -14,13 +14,16 @@
 
 var wd = require('wd');
 var fs = require('fs');
-var username = process.env['SAUCE_USERNAME'];
-var accessKey = process.env['SAUCE_ACCESS_KEY'];
-var baseDir = process.env['CIRCLE_ARTIFACTS'] || '/tmp';
 var url = process.argv[2];
-var allImgsDir = baseDir+'/imgs';
+var username = process.env.SAUCE_USERNAME;
+var accessKey = process.env.SAUCE_ACCESS_KEY;
 var build_name = process.env.MQ_CI_BUILD_NAME;
-
+var baseDir = process.env.CIRCLE_ARTIFACTS;
+if (!baseDir) {
+  console.error('No $CIRCLE_ARTIFACTS found, for testing do something like `CIRCLE_ARTIFACTS=/tmp script/screenshots.js`');
+  process.exit(1);
+}
+var allImgsDir = baseDir+'/imgs';
 fs.mkdirSync(allImgsDir);
 
 var browserVersions = [

--- a/script/screenshots.js
+++ b/script/screenshots.js
@@ -78,9 +78,9 @@ browsers.forEach(function(browser) {
   browser.config.build = build_name;
   var browserDriver = wd.promiseChainRemote('ondemand.saucelabs.com', 80, username, accessKey);
   return browserDriver.init(browser.config)
-  .then(function(sessionID, capabilities) {
-    var cfg = capabilities || browser.config;
-    console.log(cfg.browserName, cfg.version, cfg.platform, 'init', sessionID);
+  .then(function(args) {
+    var cfg = args[1] || browser.config;
+    console.log(cfg.browserName, cfg.version, cfg.platform, 'init', args);
 
     var pinned = browser.pinned ? 'PINNED' : 'EVERGREEN';
     var filename = [pinned, cfg.platform, cfg.browserName].join('_').replace(/ /g, '_');


### PR DESCRIPTION
Major changes:
- throughout circle.yml, use the `json` cli tool
- fix the Sauce Connect retry-ing to only retry on failure rather than always
- on Sauce, use human-readable build name similar to on Circle; in particular, mention the CircleCI build number
- when applicable keep around pieces of screenshots in `imgs/pieces/`, and file away the baseline imgs (formerly the `PREV_*` imgs) in `imgs/baseline/`
- screenshot filename mentions version of browser used (which changes over time for evergreen browsers)
- `script/screenshots.js` now uses the "promise chain"-style of `wd`, much fewer callbacks

Also lots of minor improvements to comments, screenshots script error logging, test names on Sauce, etc.