### PR TITLE
CI: Add Many-Worlds build link to Commit Status

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -73,7 +73,7 @@ test:
                  "context": "ci/many-worlds",
                  "state": "success",
                  "description": "Try the tests on the Many-Worlds build of this commit:",
-                 "target_url": "http://many-worlds.gomix.me/mathquill/mathquill/commit/'$CIRCLE_SHA1'/test/"
+                 "target_url": "http://many-worlds.glitch.me/mathquill/mathquill/commit/'$CIRCLE_SHA1'/test/"
                }'
 
     # Safari on Sauce can only connect to port 3000, 4000, 7000, or 8000. Edge needs port 7000 or 8000.

--- a/circle.yml
+++ b/circle.yml
@@ -65,6 +65,17 @@ dependencies:
 
 test:
   pre:
+    - |-
+      # Generate link to Many-Worlds build and add to GitHub Commit Status
+      curl -i -X POST https://api.github.com/repos/mathquill/mathquill/statuses/$CIRCLE_SHA1 \
+           -u MathQuillBot:$GITHUB_STATUS_API_KEY \
+           -d '{
+                 "context": "ci/many-worlds",
+                 "state": "success",
+                 "description": "Try the tests on the Many-Worlds build of this commit:",
+                 "target_url": "http://many-worlds.gomix.me/mathquill/mathquill/commit/'$CIRCLE_SHA1'/test/"
+               }'
+
     # Safari on Sauce can only connect to port 3000, 4000, 7000, or 8000. Edge needs port 7000 or 8000.
     # https://david263a.wordpress.com/2015/04/18/fixing-safari-cant-connect-to-localhost-issue-when-using-sauce-labs-connect-tunnel/
     # https://support.saucelabs.com/customer/portal/questions/14368823-requests-to-localhost-on-microsoft-edge-are-failing-over-sauce-connect

--- a/circle.yml
+++ b/circle.yml
@@ -159,7 +159,8 @@ test:
                  "framework": "mocha",
                  "url": "http://localhost:8000/test/unit.html?post_xunit_to=http://localhost:9000",
                  "platforms": [["", "Chrome", ""]]
-      }' | tee /dev/stderr | tail -1 > js-tests.json
+               }' \
+      | tee /dev/stderr | tail -1 > js-tests.json
 
       echo '2. Wait for tests to finish:'
       echo


### PR DESCRIPTION
So [Many-Worlds] is this thing I hacked together on Gomix that can fetch,
build, and serve any branch, PR, or commit of MathQuill, on demand. For
example, if you go to:

  http://many-worlds.gomix.me/mathquill/mathquill/branch/master/test/unit.html

then it will fetch the latest `master` branch, run `make test`, then
delegate to a static file server to serve `test/unit.html` and
`build/mathquill.test.js` and all that good stuff.

[Many-Worlds]: https://gomix.com/#!/project/many-worlds

Currently, though, manually formatting that URL is the only way to use
it. What would be nice is if an auto-generated URL were generated per
branch or PR or commit or something and available on GitHub, so you
could just click a link to try out a PR. We could automatically post a
comment on new PRs, but that would spam PR authors with notifications.

A better, quieter way is to use the GitHub Commit Status API:
https://developer.github.com/v3/repos/statuses/

This lets us quietly attach a link to every commit built by CircleCI
without spamming anyone with notifications, and lets you try out
intermediate commits on a PR; not just the tip, every push.

Authentication
--------------

CircleCI doesn't provide us with the token they use for their status
update, probably for good security reasons, but this is exactly what the
MathQuillBot GitHub bot user is for.

`$GITHUB_STATUS_API_KEY` is a [personal access token] for MathQuillBot
limited to the [`repo:status`] authorization scope (so this token can't
be used to write to anything other than commit statuses) that I've added
to the build environment.

[personal access token]: https://help.github.com/articles/creating-an-access-token-for-command-line-use/
[`repo:status`]: https://developer.github.com/v3/oauth/#scopes