### PR TITLE
Fix.729 text spacing

### DIFF
--- a/src/css/math.less
+++ b/src/css/math.less
@@ -50,7 +50,9 @@
 
   .mq-text-mode {
     display: inline-block;
+    white-space: pre;  
   }
+
   .mq-text-mode.mq-hasCursor {
     box-shadow: inset darkgray 0 .1em .2em;
     padding: 0 .1em;

--- a/test/visual.html
+++ b/test/visual.html
@@ -282,6 +282,12 @@ x+\class{testclass}{y}+z
 
 <p>Should wrap anything you type in '&lt;&gt;': <span id="wrap-typing">1+2+3</span></p>
 
+<h3>Text mode</h3>
+
+<p>Spaces at the beginning and end of text mode blocks should be visible: <span class="mathquill-static-math">1\text{ And }2</span></p>
+
+<p>Mutiple consecutive spaces in the middle of a text mode block should not collapse into one space: <span class="mathquill-static-math">\text{three   spaces}</span></p>
+
 </div>
 <script type="text/javascript">
 window.onerror = function(err) {


### PR DESCRIPTION
Fixes #729, the issue where whitespace at the beginning and end of text mode blocks was disappearing, and another issue where multiple whitespace characters in the middle of a text mode block were collapsing into a single space.