### PR TITLE
Escape latex in staticmath selectable span

### DIFF
--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -48,7 +48,8 @@ Controller.open(function(_) {
     var ctrlr = this, root = ctrlr.root, cursor = ctrlr.cursor,
       textarea = ctrlr.textarea, textareaSpan = ctrlr.textareaSpan;
 
-    this.container.prepend('<span class="mq-selectable">$'+ctrlr.exportLatex()+'$</span>');
+    this.container.prepend(jQuery('<span class="mq-selectable">')
+      .text('$'+ctrlr.exportLatex()+'$'));
     ctrlr.blurred = true;
     textarea.bind('cut paste', false)
     .bind('copy', function() { ctrlr.setTextareaSelection(); })

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -329,4 +329,18 @@ suite('latex', function() {
     testCantParse('langlerfish/ranglerfish (checking for confusion with langle/rangle)',
 		    '\\left\\langlerfish 123\\right\\ranglerfish)');
   });
+
+  suite('selectable span', function() {
+    setup(function() {
+      MQ.StaticMath($('<span>2&lt;x</span>').appendTo('#mock')[0]);
+    });
+
+    function selectableContent() {
+      return document.querySelector('#mock .mq-selectable').textContent;
+    }
+
+    test('escapes < in textContent', function () {
+      assert.equal(selectableContent(), '$2<x$');
+    });
+  });
 });


### PR DESCRIPTION
Hey @laughinghan @stufflebear - here's a fix for a simple escaping issue we noticed.

ctrlr.exportLatex() was being directly parsed as html, causing issues with chars that are acceptable in latex but not in html.