### PR TITLE
On CI, cached Sauce Connect is outdated

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -44,19 +44,27 @@ dependencies:
 
         mkdir -p ~/sauce-connect
         cd ~/sauce-connect
+
         if [ -x sc-*-linux/bin/sc ]; then
           echo Using cached sc-*-linux/bin/sc
         else
           time wget https://saucelabs.com/downloads/sc-latest-linux.tar.gz
           time tar -xzf sc-latest-linux.tar.gz
         fi
-        # Sauce Connect randomly fails so try twice https://git.io/vPN8v
+
         time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY \
           --readyfile ~/sauce_is_ready
         test -e ~/sauce_was_ready && exit
+
+        echo 'Sauce Connect failed, try redownloading (https://git.io/vSxsJ)'
+        rm -rf .
+        time wget https://saucelabs.com/downloads/sc-latest-linux.tar.gz
+        time tar -xzf sc-latest-linux.tar.gz
+
         time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY \
           --readyfile ~/sauce_is_ready
         test -e ~/sauce_was_ready && exit
+
         echo 'ERROR: Exited twice without creating readyfile' \
           | tee /dev/stderr > ~/sauce_is_ready
         exit 1

--- a/circle.yml
+++ b/circle.yml
@@ -57,7 +57,7 @@ dependencies:
         test -e ~/sauce_was_ready && exit
 
         echo 'Sauce Connect failed, try redownloading (https://git.io/vSxsJ)'
-        rm -rf .
+        rm -rf *
         time wget https://saucelabs.com/downloads/sc-latest-linux.tar.gz
         time tar -xzf sc-latest-linux.tar.gz
 


### PR DESCRIPTION
Circle builds 407-410 have all failed with:
```
{"error": "Your Sauce Connect version (4.3) is no longer supported. Please download the
latest version from https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy."}
```

e.g. https://407-598343-gh.circle-artifacts.com/0/tmp/circle-artifacts.TKNsK04/stdout_SauceConnect_12869.txt

(on https://circleci.com/gh/mathquill/mathquill/407#artifacts )