### PR TITLE
Added missing wrapper call!

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -117,3 +117,5 @@ function bind(cons /*, args... */) {
 function pray(message, cond) {
   if (!cond) throw new Error('prayer failed: '+message);
 }
+
+})();


### PR DESCRIPTION
The source code in this file was missing the
```
})();
```
at the end, to have the wrapper-function actually operate. (it seems the `function() {` line is just ignored otherwise)