### PR TITLE
Fix #553: remove .clear(), improve .empty()

### DIFF
--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -160,7 +160,7 @@ function getInterface(v) {
       if (this.__controller.blurred) this.__controller.cursor.hide().parent.blur();
       return this;
     };
-    _.empty = _.clear = function() {
+    _.empty = function() {
       this.select().__controller.backspace();
       return this;
     };

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -160,6 +160,10 @@ function getInterface(v) {
       if (this.__controller.blurred) this.__controller.cursor.hide().parent.blur();
       return this;
     };
+    _.empty = _.clear = function() {
+      this.select().__controller.backspace();
+      return this;
+    };
     _.cmd = function(cmd) {
       var ctrlr = this.__controller.notify(), cursor = ctrlr.cursor;
       if (/^\\[a-z]+$/i.test(cmd)) {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -161,7 +161,12 @@ function getInterface(v) {
       return this;
     };
     _.empty = function() {
-      this.select().__controller.backspace();
+      var root = this.__controller.root, cursor = this.__controller.cursor;
+      root.eachChild('postOrder', 'dispose');
+      root.ends[L] = root.ends[R] = 0;
+      root.jQ.empty();
+      delete cursor.selection;
+      cursor.insAtRightEnd(root);
       return this;
     };
     _.cmd = function(cmd) {

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -158,12 +158,6 @@ suite('Public API', function() {
       assert.equal(mq.__controller.cursor[R], 0);
     });
 
-    test('.clear()', function() {
-      mq.latex('xyz');
-      mq.clear();
-      assert.equal(mq.latex(), '');
-    });
-
     test('.empty()', function() {
       mq.latex('xyz');
       mq.empty();

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -108,7 +108,7 @@ suite('Public API', function() {
       mq.latex('x+y');
       assert.equal(mq.html(), '<var>x</var><span class="mq-binary-operator">+</span><var>y</var>');
     });
-    
+
     test('.text() with incomplete commands', function() {
       assert.equal(mq.text(), '');
       mq.typedText('\\');
@@ -156,6 +156,18 @@ suite('Public API', function() {
       mq.moveToRightEnd();
       assert.equal(mq.__controller.cursor[L].ctrlSeq, '0');
       assert.equal(mq.__controller.cursor[R], 0);
+    });
+
+    test('.clear()', function() {
+      mq.latex('xyz');
+      mq.clear();
+      assert.equal(mq.latex(), '');
+    });
+
+    test('.empty()', function() {
+      mq.latex('xyz');
+      mq.empty();
+      assert.equal(mq.latex(), '');
     });
   });
 


### PR DESCRIPTION
Based on https://github.com/mathquill/mathquill/pull/553

Removes the .clear() alias for .empty(), removes the test for .clear(), makes .empty() work more efficiently