### PR TITLE
Fix #548, add a config option to StaticMath, making it possible to turn off mouse interaction

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -488,5 +488,18 @@ API.InertMath = function(APIClasses) {
       super_.__mathquillify.call(this, 'mq-math-mode');
       return this;
     };
+    _.init = function() {
+      super_.init.apply(this, arguments);
+      this.__controller.root.postOrder(
+        'registerInnerField', this.innerFields = [], APIClasses.MathField);
+    };
+    _.latex = function() {
+      var returned = super_.latex.apply(this, arguments);
+      if (arguments.length > 0) {
+        this.__controller.root.postOrder(
+          'registerInnerField', this.innerFields = [], APIClasses.MathField);
+      }
+      return returned;
+    };
   });
 };

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -432,14 +432,17 @@ var MathBlock = P(MathElement, function(_, super_) {
   };
 });
 
+Options.p.mouseEvents = true;
 API.StaticMath = function(APIClasses) {
   return P(APIClasses.AbstractMathQuill, function(_, super_) {
     this.RootBlock = MathBlock;
     _.__mathquillify = function(opts, interfaceVersion) {
       this.config(opts);
       super_.__mathquillify.call(this, 'mq-math-mode');
-      this.__controller.delegateMouseEvents();
-      this.__controller.staticMathTextareaEvents();
+      if (this.__options.mouseEvents) {
+        this.__controller.delegateMouseEvents();
+        this.__controller.staticMathTextareaEvents();
+      }
       return this;
     };
     _.init = function() {
@@ -468,38 +471,6 @@ API.MathField = function(APIClasses) {
       super_.__mathquillify.call(this, 'mq-editable-field mq-math-mode');
       delete this.__controller.root.reflow;
       return this;
-    };
-  });
-};
-
-/**
- * This is almost the same as StaticMath, except we don't
- * bind any mouse events (which give us selectability and move
- * around an invisible cursor).
- *
- * Otherwise, if you have a button that contains a rendered StaticMath symbol
- * which causes something to be written into an editable mathquill,
- * the mouseup event will hijack focus.
- */
-API.InertMath = function(APIClasses) {
-  return P(APIClasses.AbstractMathQuill, function(_, super_) {
-    this.RootBlock = MathBlock;
-    _.__mathquillify = function() {
-      super_.__mathquillify.call(this, 'mq-math-mode');
-      return this;
-    };
-    _.init = function() {
-      super_.init.apply(this, arguments);
-      this.__controller.root.postOrder(
-        'registerInnerField', this.innerFields = [], APIClasses.MathField);
-    };
-    _.latex = function() {
-      var returned = super_.latex.apply(this, arguments);
-      if (arguments.length > 0) {
-        this.__controller.root.postOrder(
-          'registerInnerField', this.innerFields = [], APIClasses.MathField);
-      }
-      return returned;
     };
   });
 };

--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -471,3 +471,22 @@ API.MathField = function(APIClasses) {
     };
   });
 };
+
+/**
+ * This is almost the same as StaticMath, except we don't
+ * bind any mouse events (which give us selectability and move
+ * around an invisible cursor).
+ *
+ * Otherwise, if you have a button that contains a rendered StaticMath symbol
+ * which causes something to be written into an editable mathquill,
+ * the mouseup event will hijack focus.
+ */
+API.InertMath = function(APIClasses) {
+  return P(APIClasses.AbstractMathQuill, function(_, super_) {
+    this.RootBlock = MathBlock;
+    _.__mathquillify = function() {
+      super_.__mathquillify.call(this, 'mq-math-mode');
+      return this;
+    };
+  });
+};

--- a/test/demo.html
+++ b/test/demo.html
@@ -51,21 +51,17 @@ code span {
 
 <p>You could actually just copy-and-paste this HTML into any element with <code>class="mq-math-mode"</code> on a page that includes the <code>mathquill.css</code> and it would render beautifully, like this: <span class="mq-math-mode" id="html-transplant-example"></span></p>
 
-<p>Any element with <code>class="mathquill-static-math"</code> whose contents are LaTeX source will be rendered as static math: <span class="mathquill-static-math">e^{i\pi}+1=0</span>. Note that if you're only rendering static math, <a href="http://mathjax.org">MathJax</a> supports more of LaTeX and renders better.</p>
+<p>If you simply want to display some non-interactive math, you can use MathQuill's StaticMath API: <span class="mathquill-static-math">e^{i\pi}+1=0</span>. If you select and copy static math, by default it will copy LaTeX source to the clipboard.</p>
+
+<p>You can also make static math non-selectable: <span class="static-math-no-mouse-events">sin^2\theta + cos^2\theta = 1</span>.</p>
+
+<p>Note that if you're only rendering static math, <a href="http://mathjax.org">MathJax</a> supports more of LaTeX and renders better.</p>
 
 <p>In many applications, such as a chat client, you probably type mostly normal text with some math interspersed, so there is also a MathQuill textbox that let's you type math between $'s: <span class="mathquill-text-field">The Quadratic Equation is $x=\frac{-b\pm\sqrt{b^2-4ac}}{2a}$</span></p>
 
 <p>LaTeX math can also have textboxes inside: <span class="mathquill-static-math">\int\MathQuillMathField{}dx</span> or even <span class="mathquill-static-math">\sqrt{\MathQuillMathField{x^2+y^2}}</span></p>
 
 <p>This button runs the JavaScript code written on it to MathQuill-ify the following <code>&lt;span&gt;</code> element into an editable math textbox: <button onclick="$(this).text('MQ(this.nextSibling).revert()'); MQ.MathField(this.nextSibling); var orig = arguments.callee; this.onclick = function(){ $(this).text('MQ.MathField(this.nextSibling)'); MQ(this.nextSibling).revert(); this.onclick = orig; };">MQ.MathField(this.nextSibling)</button><span>\frac{d}{dx}\sqrt{x} = \frac{d}{dx}x^{\frac{1}{2}} = \frac{1}{2}x^{-\frac{1}{2}} = \frac{1}{2\sqrt{x}}</span></p>
-
-<p>
-  Insert using inertMath <button class="insert-trigger" data-latex="\sqrt{4}"><span class="mathquill-inert-math">\sqrt{4}</span></button> inside formulas below:<br>
-  Insert using inertMath with innerFields <button class="insert-trigger" data-latex="\sqrt{4}\frac{1}{\MathQuillMathField{\sqrt{4}}}"><span class="mathquill-inert-math">\sqrt{4}\frac{1}{\MathQuillMathField{\sqrt{4}}}</span></button> inside formulas below:<br>
-  <span class="mathquill-math-field"></span><br>
-  or here: <span class="mathquill-math-field">\frac{2}{3}</span><br>
-  Now insert using staticMath <button class="insert-trigger" data-latex="\sqrt{4}"><span class="mathquill-static-math">\sqrt{4}</span></button> to the same formulas above, and notice that you can select all the text within a button.<br>
-</p>
 
 </div>
 <script type="text/javascript" src="support/jquery-1.5.2.js"></script>
@@ -77,7 +73,7 @@ MQ = MathQuill.getInterface(MathQuill.getInterface.MAX);
 //elements according to their CSS class.
 $(function() {
   $('.mathquill-static-math').each(function() { MQ.StaticMath(this); });
-  $('.mathquill-inert-math').each(function() { MQ.InertMath(this); });
+  $('.static-math-no-mouse-events').each(function() { MQ.StaticMath(this, { mouseEvents:false }); });
   $('.mathquill-math-field').each(function() { MQ.MathField(this); });
   $('.mathquill-text-field').each(function() { MQ.TextField(this); });
 });

--- a/test/demo.html
+++ b/test/demo.html
@@ -61,6 +61,7 @@ code span {
 
 <p>
   Insert using inertMath <button class="insert-trigger" data-latex="\sqrt{4}"><span class="mathquill-inert-math">\sqrt{4}</span></button> inside formulas below:<br>
+  Insert using inertMath with innerFields <button class="insert-trigger" data-latex="\sqrt{4}\frac{1}{\MathQuillMathField{\sqrt{4}}}"><span class="mathquill-inert-math">\sqrt{4}\frac{1}{\MathQuillMathField{\sqrt{4}}}</span></button> inside formulas below:<br>
   <span class="mathquill-math-field"></span><br>
   or here: <span class="mathquill-math-field">\frac{2}{3}</span><br>
   Now insert using staticMath <button class="insert-trigger" data-latex="\sqrt{4}"><span class="mathquill-static-math">\sqrt{4}</span></button> to the same formulas above, and notice that you can select all the text within a button.<br>

--- a/test/demo.html
+++ b/test/demo.html
@@ -59,6 +59,13 @@ code span {
 
 <p>This button runs the JavaScript code written on it to MathQuill-ify the following <code>&lt;span&gt;</code> element into an editable math textbox: <button onclick="$(this).text('MQ(this.nextSibling).revert()'); MQ.MathField(this.nextSibling); var orig = arguments.callee; this.onclick = function(){ $(this).text('MQ.MathField(this.nextSibling)'); MQ(this.nextSibling).revert(); this.onclick = orig; };">MQ.MathField(this.nextSibling)</button><span>\frac{d}{dx}\sqrt{x} = \frac{d}{dx}x^{\frac{1}{2}} = \frac{1}{2}x^{-\frac{1}{2}} = \frac{1}{2\sqrt{x}}</span></p>
 
+<p>
+  Insert using inertMath <button class="insert-trigger" data-latex="\sqrt{4}"><span class="mathquill-inert-math">\sqrt{4}</span></button> inside formulas below:<br>
+  <span class="mathquill-math-field"></span><br>
+  or here: <span class="mathquill-math-field">\frac{2}{3}</span><br>
+  Now insert using staticMath <button class="insert-trigger" data-latex="\sqrt{4}"><span class="mathquill-static-math">\sqrt{4}</span></button> to the same formulas above, and notice that you can select all the text within a button.<br>
+</p>
+
 </div>
 <script type="text/javascript" src="support/jquery-1.5.2.js"></script>
 <script type="text/javascript" src="../build/mathquill.js"></script>
@@ -69,6 +76,7 @@ MQ = MathQuill.getInterface(MathQuill.getInterface.MAX);
 //elements according to their CSS class.
 $(function() {
   $('.mathquill-static-math').each(function() { MQ.StaticMath(this); });
+  $('.mathquill-inert-math').each(function() { MQ.InertMath(this); });
   $('.mathquill-math-field').each(function() { MQ.MathField(this); });
   $('.mathquill-text-field').each(function() { MQ.TextField(this); });
 });
@@ -114,6 +122,14 @@ $(function() {
 
   if(location.hash && location.hash.length > 1)
     latexMath.latex(decodeURIComponent(location.hash.slice(1))).focus();
+});
+
+$(".insert-trigger").click(function () {
+  var latex = $(this).data('latex');
+  $(this).parent().find('.mathquill-math-field').each(function () {
+    var mathquill = MQ(this);
+    mathquill.write(latex);
+  });
 });
 
 //print the HTML source as an indented tree. TODO: syntax highlight

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -49,6 +49,12 @@ suite('Public API', function() {
       assert.ok(rootBlock.hasClass('mq-empty'));
       assert.ok(!rootBlock.hasClass('mq-hasCursor'));
     });
+
+    test('MathQuill.InertMath', function() {
+      var el = $('<span>x</span>');
+      MathQuill.InertMath(el[0]);
+      assert.ok(el.find('var').length);
+    });
   });
 
   suite('mathquill-basic', function() {

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -50,11 +50,6 @@ suite('Public API', function() {
       assert.ok(!rootBlock.hasClass('mq-hasCursor'));
     });
 
-    test('MathQuill.InertMath', function() {
-      var el = $('<span>x</span>');
-      MathQuill.InertMath(el[0]);
-      assert.ok(el.find('var').length);
-    });
   });
 
   suite('mathquill-basic', function() {

--- a/test/visual.html
+++ b/test/visual.html
@@ -163,6 +163,10 @@ $(function() {
 
 <p>Even in IE&lt;9, the background color of the parens and square root radical should be the background color of the selection.
 
+<p>Static math with mouseEvents set to false should not interact with the mouse: <span class="static-math-no-mouse-events">12 + 34</span></p>
+
+<p>Even in the case where it has an empty element: <span class="static-math-no-mouse-events">\sqrt{} </span></p>
+
 <h3>Dynamic mathquill-ification</h3>
 <table id="dynamic-initial">
 <tr><th colspan=3>Initial LaTeX
@@ -307,6 +311,7 @@ $('#show-textareas-button').click(function() {
 //elements according to their CSS class.
 $(function() {
   $('.mathquill-static-math').each(function() { MQ.StaticMath(this); });
+  $('.static-math-no-mouse-events').each(function() { MQ.StaticMath(this, { mouseEvents: false }); });
   $('.mathquill-math-field').each(function() { MQ.MathField(this); });
   $('.mathquill-text-field').each(function() { MQ.TextField(this); });
 });


### PR DESCRIPTION
This PR is an update to #548.

Adds mouseEvents config option to StaticMath, which defaults to true. For a StaticMath element with MouseEvents set to false, no mouse events are bound.

This PR includes a demo example and some visual tests, and also corrects an inaccuracy in the demo copy that we considered too minor to be worth its own separate issue.
