### PR TITLE
 Fix for Superscript of tall expression (issue #763) #1 

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -329,13 +329,13 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
     super_.finalizeTree.call(this);
   };
   _.reflow = function() {
-     var $block = this.ends[R].jQ;//mq-sup
-     $block = $block.parent() ;//mq-supsub
+     var $block = this.jQ;//mq-supsub
 
      var h = $block.prev().innerHeight() ;
      h *= 0.6 ;
 
      $block.css( 'vertical-align',  h + 'px' ) ;
+
   } ;
 });
 

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -328,6 +328,15 @@ LatexCmds['^'] = P(SupSub, function(_, super_) {
     this.sup.downOutOf = insLeftOfMeUnlessAtEnd;
     super_.finalizeTree.call(this);
   };
+  _.reflow = function() {
+     var $block = this.ends[R].jQ;//mq-sup
+     $block = $block.parent() ;//mq-supsub
+
+     var h = $block.prev().innerHeight() ;
+     h *= 0.6 ;
+
+     $block.css( 'vertical-align',  h + 'px' ) ;
+  } ;
 });
 
 var SummationNotation = P(MathCommand, function(_, super_) {


### PR DESCRIPTION
Superscript of very tall expression is rendered kind of wrong, e.g. `(-5^(1/2))^2+3` (here 2 is superscript):
![image](https://user-images.githubusercontent.com/30241513/28280840-c1fe6e4a-6b2d-11e7-828c-6fe14542d249.png)

with fix it will be smth like:
![image](https://user-images.githubusercontent.com/30241513/28282265-8bf1831e-6b32-11e7-8d9b-a655e9925a6a.png)
