### PR TITLE
Fix #709: typing '\text{' barfs

### DIFF
--- a/src/commands/math/LatexCommandInput.js
+++ b/src/commands/math/LatexCommandInput.js
@@ -33,7 +33,7 @@ CharCmds['\\'] = P(MathCommand, function(_, super_) {
       if (ch.match(/[a-z]/i)) VanillaSymbol(ch).createLeftOf(cursor);
       else {
         this.parent.renderCommand(cursor);
-        if (ch !== '\\' || !this.isEmpty()) this.parent.parent.write(cursor, ch);
+        if (ch !== '\\' || !this.isEmpty()) cursor.parent.write(cursor, ch);
       }
     };
     this.ends[L].keystroke = function(key, e, ctrlr) {

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -65,7 +65,7 @@ var TextBlock = P(Node, function(_, super_) {
   _.latex = function() {
     var contents = this.textContents();
     if (contents.length === 0) return '';
-    return '\\text{' + contents + '}';
+    return '\\text{' + contents.replace(/\\/g, '\\backslash ').replace(/[{}]/g, '\\$&') + '}';
   };
   _.html = function() {
     return (

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -515,7 +515,7 @@ suite('Public API', function() {
       });
       test('backslashes', function() {
         assertPaste('something \\pi something \\asdf',
-                    '\\text{something \\pi something \\asdf}');
+                    '\\text{something \\backslash pi something \\backslash asdf}');
       });
       // TODO: braces (currently broken)
       test('actual math LaTeX wrapped in dollar signs', function() {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -57,6 +57,11 @@ suite('typing with auto-replaces', function() {
       mq.typedText('$');
       assertLatex('\\$');
     });
+
+    test('\\text followed by command', function() {
+      mq.typedText('\\text{');
+      assertLatex('\\text{{}');
+    });
   });
 
   suite('auto-expanding parens', function() {

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -60,7 +60,7 @@ suite('typing with auto-replaces', function() {
 
     test('\\text followed by command', function() {
       mq.typedText('\\text{');
-      assertLatex('\\text{{}');
+      assertLatex('\\text{\\{}');
     });
   });
 


### PR DESCRIPTION
Like both literally throws an exception, and also the LaTeX output ends
up with a decompiled function string