### PR TITLE
Update advancedSymbols.js to include integrals

### DIFF
--- a/src/commands/math/advancedSymbols.js
+++ b/src/commands/math/advancedSymbols.js
@@ -201,6 +201,14 @@ LatexCmds.square = bind(VanillaSymbol, '\\square ', '&#11036;');
 
 //variable-sized
 LatexCmds.oint = bind(VanillaSymbol, '\\oint ', '&#8750;');
+LatexCmds.iint = bind(VanillaSymbol, '\\iint ', '&#8748;');
+LatexCmds.iiint = bind(VanillaSymbol, '\\iiint ', '&#8749;');
+LatexCmds.intclockwise = bind(VanillaSymbol, '\\intclockwise ', '&#8753;');
+LatexCmds.intctrclockwise = bind(VanillaSymbol, '\\intctrclockwise ', '&#10769;');
+LatexCmds.varointclockwise = bind(VanillaSymbol, '\\varointclockwise ', '&#8754;');
+LatexCmds.ointctrclockwise = bind(VanillaSymbol, '\\ointctrclockwise ', '&#8755;');
+LatexCmds.oiint = bind(VanillaSymbol, '\\oiint ', '&#8751;');
+LatexCmds.oiiint = bind(VanillaSymbol, '\\oiiint ', '&#8752;');
 LatexCmds.bigcap = bind(VanillaSymbol, '\\bigcap ', '&#8745;');
 LatexCmds.bigcup = bind(VanillaSymbol, '\\bigcup ', '&#8746;');
 LatexCmds.bigsqcup = bind(VanillaSymbol, '\\bigsqcup ', '&#8852;');


### PR DESCRIPTION
This includes integral symbols in addition to the preexisting \int and \oint [symbols](https://en.wikipedia.org/wiki/Integral_symbol#Extensions_of_the_symbol):

- \iint

- \iiint

- \varointclockwise

- \ointctrclockwise

- \oiint

- \oiiint

In addition it includes two symbols not covered by latex but following the same nomenclature:

- \intclockwise

- \intctrclockwise