### PR TITLE
Improve MathElement.text() compute speed

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -285,7 +285,7 @@ var MathCommand = P(MathElement, function(_, super_) {
       if (text && cmd.textTemplate[i] === '('
           && child_text[0] === '(' && child_text.slice(-1) === ')')
         return text + child_text.slice(1, -1) + cmd.textTemplate[i];
-      return text + child.text() + (cmd.textTemplate[i] || '');
+      return text + child_text + (cmd.textTemplate[i] || '');
     });
   };
 });


### PR DESCRIPTION
Not sure how often this is used, but we discovered a subtle issue with .text() which was causing some significant performance problems with deeply nested constructs.