### PR TITLE
Fixing whitespace parsing bug for \langle,\rangle

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -747,14 +747,14 @@ LatexCmds.left = P(MathCommand, function(_) {
     var succeed = Parser.succeed;
     var optWhitespace = Parser.optWhitespace;
 
-    return optWhitespace.then(regex(/^(?:[([|]|\\\{|\\langle\b|\\lVert\b)/))
+    return optWhitespace.then(regex(/^(?:[([|]|\\\{|\\langle(?![a-zA-Z])|\\lVert(?![a-zA-Z]))/))
       .then(function(ctrlSeq) {
         var open = (ctrlSeq.charAt(0) === '\\' ? ctrlSeq.slice(1) : ctrlSeq);
 	if (ctrlSeq=="\\langle") { open = '&lang;'; ctrlSeq = ctrlSeq + ' '; }
 	if (ctrlSeq=="\\lVert") { open = '&#8741;'; ctrlSeq = ctrlSeq + ' '; }
         return latexMathParser.then(function (block) {
           return string('\\right').skip(optWhitespace)
-            .then(regex(/^(?:[\])|]|\\\}|\\rangle\b|\\rVert\b)/)).map(function(end) {
+            .then(regex(/^(?:[\])|]|\\\}|\\rangle(?![a-zA-Z])|\\rVert(?![a-zA-Z]))/)).map(function(end) {
               var close = (end.charAt(0) === '\\' ? end.slice(1) : end);
 	      if (end=="\\rangle") { close = '&rang;'; end = end + ' '; }
 	      if (end=="\\rVert") { close = '&#8741;'; end = end + ' '; }

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -85,7 +85,7 @@ suite('latex', function() {
     assert.equal(tree.join('latex'), '\\left(123\\right)');
   });
 
-  test('langle/rangle (issue #508)', function() {
+  test('\\langle/\\rangle (issue #508)', function() {
     var tree = latexMathParser.parse('\\left\\langle 123\\right\\rangle)');
 
     assert.ok(tree.ends[L] instanceof Bracket);
@@ -94,7 +94,7 @@ suite('latex', function() {
     assert.equal(tree.join('latex'), '\\left\\langle 123\\right\\rangle )');
   });
 
-  test('langle/rangle (without whitespace)', function() {
+  test('\\langle/\\rangle (without whitespace)', function() {
     var tree = latexMathParser.parse('\\left\\langle123\\right\\rangle)');
 
     assert.ok(tree.ends[L] instanceof Bracket);
@@ -103,9 +103,7 @@ suite('latex', function() {
     assert.equal(tree.join('latex'), '\\left\\langle 123\\right\\rangle )');
   });
 
-
-
-  test('lVert/rVert', function() {
+  test('\\lVert/\\rVert', function() {
     var tree = latexMathParser.parse('\\left\\lVert 123\\right\\rVert)');
 
     assert.ok(tree.ends[L] instanceof Bracket);
@@ -114,6 +112,27 @@ suite('latex', function() {
     assert.equal(tree.join('latex'), '\\left\\lVert 123\\right\\rVert )');
   });
 
+  test('\\lVert/\\rVert (without whitespace)', function() {
+    var tree = latexMathParser.parse('\\left\\lVert123\\right\\rVert)');
+
+    assert.ok(tree.ends[L] instanceof Bracket);
+    var contents = tree.ends[L].ends[L].join('latex');
+    assert.equal(contents, '123');
+    assert.equal(tree.join('latex'), '\\left\\lVert 123\\right\\rVert )');
+  });
+
+  test('\\langler should not parse', function() {
+    assert.throws(function () {
+      latexMathParser.parse('\\left\\langler123\\right\\rangler');
+    })
+  });
+
+  test('\\lVerte should not parse', function() {
+    assert.throws(function () {
+      latexMathParser.parse('\\left\\lVerte123\\right\\rVerte');
+    })
+  });
+  
   test('parens with whitespace', function() {
     assertParsesLatex('\\left ( 123 \\right ) ', '\\left(123\\right)');
   });

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -94,6 +94,17 @@ suite('latex', function() {
     assert.equal(tree.join('latex'), '\\left\\langle 123\\right\\rangle )');
   });
 
+  test('langle/rangle (without whitespace)', function() {
+    var tree = latexMathParser.parse('\\left\\langle123\\right\\rangle)');
+
+    assert.ok(tree.ends[L] instanceof Bracket);
+    var contents = tree.ends[L].ends[L].join('latex');
+    assert.equal(contents, '123');
+    assert.equal(tree.join('latex'), '\\left\\langle 123\\right\\rangle )');
+  });
+
+
+
   test('lVert/rVert', function() {
     var tree = latexMathParser.parse('\\left\\lVert 123\\right\\rVert)');
 


### PR DESCRIPTION
`\left\langle1235\right\rangle` is not parsed by MathQuill (observed by https://github.com/mathquill/mathquill/pull/659#issuecomment-348105353), but `\left\langle 1235\right\rangle` is. The reason is that `\b` matches the end of a word only, and according to Javascript's regular expression semantics, `langle12345` is one word. (While for LaTeX, 12345 cannot be part of a word.)

But we cannot just remove `\b` because it was introduced to avoid confusion with, e.g., `\langlerfish` (see above).

To fix this, we replace every `\b` by `(?![a-zA-Z])` (this is a negative lookahead that only matches when no letter follows). Now things seem to work.