### PR TITLE
Support for command \mathcal for entering script letters.

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -76,6 +76,7 @@ LatexCmds.mathit = bind(Style, '\\mathit', 'i', 'class="mq-font"');
 LatexCmds.mathbf = bind(Style, '\\mathbf', 'b', 'class="mq-font"');
 LatexCmds.mathsf = bind(Style, '\\mathsf', 'span', 'class="mq-sans-serif mq-font"');
 LatexCmds.mathtt = bind(Style, '\\mathtt', 'span', 'class="mq-monospace mq-font"');
+LatexCmds.cal = LatexCmds.mathcal = bind(Style, '\\mathcal', 'span', 'class="mq-script mq-font"');
 //text-decoration
 LatexCmds.underline = bind(Style, '\\underline', 'span', 'class="mq-non-leaf mq-underline"');
 LatexCmds.overline = LatexCmds.bar = bind(Style, '\\overline', 'span', 'class="mq-non-leaf mq-overline"');

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -122,6 +122,13 @@
     font-family: sans-serif, Symbola, serif;
   }
 
+  .mq-script {
+    // A selection of script-style fonts, in the hope that the browser has at least one
+    // Better would be to include a script font with MathQuill (e.g., use what MathJax uses)
+    font-family: URW Chancery L, Apple Chancery, Snell Roundhand, Bradley Hand,
+                 Brush Script MT, Brush Script Std, Comic Sans MS, Comic Sans, cursive;
+  }
+
   .mq-monospace {
     font-family: monospace, Symbola, serif;
   }

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -130,6 +130,10 @@ suite('latex', function() {
     assertParsesLatex('\\class{name}{8-4}', '\\class{name}{8-4}');
   });
 
+  test('\\mathcal', function() {
+    assertParsesLatex('\\mathcal{A}');
+  });
+  
   test('not real LaTex commands, but valid symbols', function() {
     assertParsesLatex('\\parallelogram ');
     assertParsesLatex('\\circledot ', '\\odot ');


### PR DESCRIPTION
This allows us to type, e.g., "\mathcal A" to get a script A.