### PR TITLE
Lessc 3.0.1 breaks build

### DIFF
--- a/src/css/font.less
+++ b/src/css/font.less
@@ -1,4 +1,4 @@
-@omit-font-face:;
+@omit-font-face:~"";
 .font-face;
 .font-face() when not (@omit-font-face) {
   @font-face {
@@ -7,7 +7,7 @@
   }
 }
 
-@basic:;
+@basic:~"";
 .font-srcs() when not (@basic) {
   src: url(fonts/Symbola.eot);
   src:


### PR DESCRIPTION
According to https://github.com/less/less.js/issues/2911 `@var:;` is non-standard and `@var:~'';` is the preferred approach.