### PR TITLE
text-mode now triggers edit handler

### DIFF
--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -97,7 +97,6 @@ var TextBlock = P(Node, function(_, super_) {
     cursor.show().deleteSelection();
 
     if (ch !== '$') {
-      this.postOrder('reflow');
       if (!cursor[L]) TextPiece(ch).createLeftOf(cursor);
       else cursor[L].appendText(ch);
       this.bubble('reflow'); 

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -97,8 +97,10 @@ var TextBlock = P(Node, function(_, super_) {
     cursor.show().deleteSelection();
 
     if (ch !== '$') {
+      this.postOrder('reflow');
       if (!cursor[L]) TextPiece(ch).createLeftOf(cursor);
       else cursor[L].appendText(ch);
+      this.bubble('reflow'); 
     }
     else if (this.isEmpty()) {
       cursor.insRightOf(this);

--- a/test/unit/publicapi.test.js
+++ b/test/unit/publicapi.test.js
@@ -327,6 +327,20 @@ suite('Public API', function() {
       mq.typedText(']');
       assert.equal(count, countBeforeClosingBracket + 1);
     });
+    test('fires in text-mode', function() {
+      var count = 0;
+      var mq = MQ.MathField($('<span>').appendTo('#mock')[0], {
+        handlers: {
+          edit: function() {
+            count += 1;
+          }
+        }
+      });
+      mq.typedText('\\text A');
+      var countBeforeTextMode = count;
+      mq.typedText('B');
+      assert.equal(count, countBeforeTextMode + 1);
+    });
   });
 
   suite('.cmd(...)', function() {


### PR DESCRIPTION
This edit resolves issue #705 by calling for a reflow on parents ~and children~ around the insertion of new characters in text-mode. 

Inspiration drawn from the MathElement class method `_.finalizeInsert`

edit: removed postOrder('reflow') because TextBlock doesn't seem to need it - what children would we have? I tried, but couldn't break the edit handler even with the postOrder call removed... 