### PR TITLE
Match example to proposal: use jQuery 1.5.2

### DIFF
--- a/docs/Getting_Started.md
+++ b/docs/Getting_Started.md
@@ -7,7 +7,7 @@ MathQuill depends on [jQuery 1.5.2+](http://jquery.com), we recommend the [Googl
 Load MathQuill with something like (order matters):
 ```html
 <link rel="stylesheet" href="/path/to/mathquill.css"/>
-<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
+<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.5.2/jquery.min.js"></script>
 <script src="/path/to/mathquill.js"></script>
 <script>
 var MQ = MathQuill.getInterface(2);


### PR DESCRIPTION
We say that “[MathQuill depends on jQuery 1.5.2+](https://github.com/mathquill/mathquill/blob/4e2a50f7dd54df06bcc7fc003c6df8cc87491224/docs/Getting_Started.md#download-and-load)” but we link to 1.11.0. I’m proposing our example link to 1.5.2 (which is [what we do in quickstart.html](https://github.com/mathquill/mathquill/blob/7f7f0af6f7f1a4591bce8b257a539bc12a5a1dda/quickstart.html#L14)).