### PR TITLE
#862 enclose html attributes with quotes.

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -271,7 +271,7 @@ var MathCommand = P(MathElement, function(_, super_) {
 
     var cmd = this;
     var blocks = cmd.blocks;
-    var cmdId = ' mathquill-command-id=' + cmd.id;
+    var cmdId = ' mathquill-command-id="' + cmd.id + '"';
     var tokens = cmd.htmlTemplate.match(/<[^<>]+>|[^<>]+/g);
 
     pray('no unmatched angle brackets', tokens.join('') === this.htmlTemplate);
@@ -305,7 +305,7 @@ var MathCommand = P(MathElement, function(_, super_) {
       }
     }
     return tokens.join('').replace(/>&(\d+)/g, function($0, $1) {
-      return ' mathquill-block-id=' + blocks[$1].id + '>' + blocks[$1].join('html');
+      return ' mathquill-block-id="' + blocks[$1].id + '">' + blocks[$1].join('html');
     });
   };
 

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -69,7 +69,7 @@ var TextBlock = P(Node, function(_, super_) {
   };
   _.html = function() {
     return (
-        '<span class="mq-text-mode" mathquill-command-id='+this.id+'>'
+        '<span class="mq-text-mode" mathquill-command-id="'+this.id+'">'
       +   this.textContents()
       + '</span>'
     );

--- a/src/services/textarea.js
+++ b/src/services/textarea.js
@@ -5,8 +5,8 @@
 
 Controller.open(function(_) {
   Options.p.substituteTextarea = function() {
-    return $('<textarea autocapitalize=off autocomplete=off autocorrect=off ' +
-               'spellcheck=false x-palm-disable-ste-all=true />')[0];
+    return $('<textarea autocapitalize="off" autocomplete="off" autocorrect="off" ' +
+               'spellcheck="false" x-palm-disable-ste-all="true" />')[0];
   };
   _.createTextarea = function() {
     var textareaSpan = this.textareaSpan = $('<span class="mq-textarea"></span>'),


### PR DESCRIPTION
This PR makes basic mathquill library compatible with XML standard (enclosing all attributes in double quotes) as described in #862 