### PR TITLE
Fix typing with gboard on android

### DIFF
--- a/src/services/saneKeyboardEvents.util.js
+++ b/src/services/saneKeyboardEvents.util.js
@@ -89,6 +89,8 @@ var saneKeyboardEvents = (function() {
   // create a keyboard events shim that calls callbacks at useful times
   // and exports useful public methods
   return function saneKeyboardEvents(el, handlers) {
+    var isandroid = /.*android.*/i.test(navigator.userAgent);
+    var androidcompose = false;
     var keydown = null;
     var keypress = null;
 
@@ -147,7 +149,12 @@ var saneKeyboardEvents = (function() {
     }
 
     function handleKey() {
-      handlers.keystroke(stringify(keydown), keydown);
+      if (isandroid && keydown.which === 229) {
+        androidcompose = true;
+        textarea.val('\0');
+      } else {
+        handlers.keystroke(stringify(keydown), keydown);
+      }
     }
 
     // -*- event handlers -*- //
@@ -182,32 +189,48 @@ var saneKeyboardEvents = (function() {
       if (!!keydown && !keypress) checkTextareaFor(typedText);
     }
     function typedText() {
-      // If there is a selection, the contents of the textarea couldn't
-      // possibly have just been typed in.
-      // This happens in browsers like Firefox and Opera that fire
-      // keypress for keystrokes that are not text entry and leave the
-      // selection in the textarea alone, such as Ctrl-C.
-      // Note: we assume that browsers that don't support hasSelection()
-      // also never fire keypress on keystrokes that are not text entry.
-      // This seems reasonably safe because:
-      // - all modern browsers including IE 9+ support hasSelection(),
-      //   making it extremely unlikely any browser besides IE < 9 won't
-      // - as far as we know IE < 9 never fires keypress on keystrokes
-      //   that aren't text entry, which is only as reliable as our
-      //   tests are comprehensive, but the IE < 9 way to do
-      //   hasSelection() is poorly documented and is also only as
-      //   reliable as our tests are comprehensive
-      // If anything like #40 or #71 is reported in IE < 9, see
-      // b1318e5349160b665003e36d4eedd64101ceacd8
-      if (hasSelection()) return;
-
-      var text = textarea.val();
-      if (text.length === 1) {
+      if (androidcompose) {
+        var text = textarea.val();
+        androidcompose = false;
         textarea.val('');
-        handlers.typedText(text);
-      } // in Firefox, keys that don't type text, just clear seln, fire keypress
-      // https://github.com/mathquill/mathquill/issues/293#issuecomment-40997668
-      else if (text && textarea[0].select) textarea[0].select(); // re-select if that's why we're here
+        if (text.length == 0) {
+          handlers.keystroke('Backspace', keydown);
+        }
+        else if (text.length >= 2) {
+          text = text.substring(1);
+          handlers.keystroke(text === ' ' ? 'Spacebar' : text, keydown);
+          if (!keydown.isDefaultPrevented()) {
+            for (var i = 0; i < text.length; i += 1) handlers.typedText(text.charAt(i));
+          }
+        }
+      } else {
+        // If there is a selection, the contents of the textarea couldn't
+        // possibly have just been typed in.
+        // This happens in browsers like Firefox and Opera that fire
+        // keypress for keystrokes that are not text entry and leave the
+        // selection in the textarea alone, such as Ctrl-C.
+        // Note: we assume that browsers that don't support hasSelection()
+        // also never fire keypress on keystrokes that are not text entry.
+        // This seems reasonably safe because:
+        // - all modern browsers including IE 9+ support hasSelection(),
+        //   making it extremely unlikely any browser besides IE < 9 won't
+        // - as far as we know IE < 9 never fires keypress on keystrokes
+        //   that aren't text entry, which is only as reliable as our
+        //   tests are comprehensive, but the IE < 9 way to do
+        //   hasSelection() is poorly documented and is also only as
+        //   reliable as our tests are comprehensive
+        // If anything like #40 or #71 is reported in IE < 9, see
+        // b1318e5349160b665003e36d4eedd64101ceacd8
+        if (hasSelection()) return;
+
+        var text = textarea.val();
+        if (text.length >= 1) {
+          textarea.val('');
+          for (var i = 0; i < text.length; i += 1) handlers.typedText(text.charAt(i));
+        } // in Firefox, keys that don't type text, just clear seln, fire keypress
+        // https://github.com/mathquill/mathquill/issues/293#issuecomment-40997668
+        else if (text && textarea[0].select) textarea[0].select(); // re-select if that's why we're here
+      }
     }
 
     function onBlur() { keydown = keypress = null; }


### PR DESCRIPTION
Solves that the backspace Key on Android Chrome with gboard was not working correctly after latest Keyboard Patch, also allows adding emoticon support https://github.com/mathquill/mathquill/issues/850, https://github.com/mathquill/mathquill/issues/825
Partially fixes Android side of https://github.com/mathquill/mathquill/issues/559