### PR TITLE
Implementing a basic CommonJS Build

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "type": "git",
     "url": "https://github.com/mathquill/mathquill.git"
   },
+  "main": "build/mathquill.commonjs.js",
   "files": [
-    "build/mathquill.{css,js,min.js}",
+    "build/mathquill.{,commonjs}{css,js,min.js}",
     "build/fonts/Symbola.*",
     "quickstart.html"
   ],

--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -2,66 +2,76 @@
  * Commands and Operators.
  **************************/
 
-var scale, // = function(jQ, x, y) { ... }
+var forceIERedraw = noop;
+
+// Detect legacy IE versions and redefine `forceIERedraw` if applicable.
+// See https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Legacy_Internet_Explorer_and_attachEvent
+if (globalAvailable('attachEvent') && !globalAvailable('addEventListener')) {
+  forceIERedraw = function(el) { el.className = el.className; };
+}
+
 //will use a CSS 2D transform to scale the jQuery-wrapped HTML elements,
 //or the filter matrix transform fallback for IE 5.5-8, or gracefully degrade to
 //increasing the fontSize to match the vertical Y scaling factor.
 
 //ideas from http://github.com/louisremi/jquery.transform.js
 //see also http://msdn.microsoft.com/en-us/library/ms533014(v=vs.85).aspx
+var scale = function(jQ, x, y) {
+  var div = document.createElement('div'),
+    div_style = div.style,
+    transformPropNames = {
+      transform:1,
+      WebkitTransform:1,
+      MozTransform:1,
+      OTransform:1,
+      msTransform:1
+    },
+    transformPropName;
 
-  forceIERedraw = noop,
-  div = document.createElement('div'),
-  div_style = div.style,
-  transformPropNames = {
-    transform:1,
-    WebkitTransform:1,
-    MozTransform:1,
-    OTransform:1,
-    msTransform:1
-  },
-  transformPropName;
-
-for (var prop in transformPropNames) {
-  if (prop in div_style) {
-    transformPropName = prop;
-    break;
+  for (var prop in transformPropNames) {
+    if (prop in div_style) {
+      transformPropName = prop;
+      break;
+    }
   }
-}
 
-if (transformPropName) {
-  scale = function(jQ, x, y) {
-    jQ.css(transformPropName, 'scale('+x+','+y+')');
-  };
-}
-else if ('filter' in div_style) { //IE 6, 7, & 8 fallback, see https://github.com/laughinghan/mathquill/wiki/Transforms
-  forceIERedraw = function(el){ el.className = el.className; };
-  scale = function(jQ, x, y) { //NOTE: assumes y > x
-    x /= (1+(y-1)/2);
-    jQ.css('fontSize', y + 'em');
-    if (!jQ.hasClass('mq-matrixed-container')) {
-      jQ.addClass('mq-matrixed-container')
-      .wrapInner('<span class="mq-matrixed"></span>');
-    }
-    var innerjQ = jQ.children()
-    .css('filter', 'progid:DXImageTransform.Microsoft'
-        + '.Matrix(M11=' + x + ",SizingMethod='auto expand')"
-    );
-    function calculateMarginRight() {
-      jQ.css('marginRight', (innerjQ.width()-1)*(x-1)/x + 'px');
-    }
-    calculateMarginRight();
-    var intervalId = setInterval(calculateMarginRight);
-    $(window).load(function() {
-      clearTimeout(intervalId);
+  // Redefine `scale` based on available DOM methods.
+  if (transformPropName) {
+    scale = function(jQ, x, y) {
+      jQ.css(transformPropName, 'scale('+x+','+y+')');
+    };
+  }
+  else if ('filter' in div_style) { //IE 6, 7, & 8 fallback, see https://github.com/laughinghan/mathquill/wiki/Transforms
+    scale = function(jQ, x, y) { //NOTE: assumes y > x
+      x /= (1+(y-1)/2);
+      jQ.css('fontSize', y + 'em');
+      if (!jQ.hasClass('mq-matrixed-container')) {
+        jQ.addClass('mq-matrixed-container')
+        .wrapInner('<span class="mq-matrixed"></span>');
+      }
+      var innerjQ = jQ.children()
+      .css('filter', 'progid:DXImageTransform.Microsoft'
+          + '.Matrix(M11=' + x + ",SizingMethod='auto expand')"
+      );
+      function calculateMarginRight() {
+        jQ.css('marginRight', (innerjQ.width()-1)*(x-1)/x + 'px');
+      }
       calculateMarginRight();
-    });
-  };
-}
-else {
-  scale = function(jQ, x, y) {
-    jQ.css('fontSize', y + 'em');
-  };
+      var intervalId = setInterval(calculateMarginRight);
+      $(window).load(function() {
+        clearTimeout(intervalId);
+        calculateMarginRight();
+      });
+    };
+  }
+  else {
+    scale = function(jQ, x, y) {
+      jQ.css('fontSize', y + 'em');
+    };
+  }
+
+  // Call our redefined `scale` function.
+  scale(jQ, x, y);
 }
 
 var Style = P(MathCommand, function(_, super_) {

--- a/src/entry/browser.js
+++ b/src/entry/browser.js
@@ -1,0 +1,13 @@
+(function() {
+  var jQuery = window.jQuery;
+  if (!jQuery) throw 'MathQuill requires jQuery 1.5.2+ to be loaded first';
+
+  {SOURCE}
+
+  MathQuill.noConflict = function() {
+    window.MathQuill = origMathQuill;
+    return MathQuill;
+  };
+  var origMathQuill = window.MathQuill;
+  window.MathQuill = MathQuill;
+})();

--- a/src/entry/commonjs.js
+++ b/src/entry/commonjs.js
@@ -1,0 +1,7 @@
+module.exports = function(jQuery) {
+  if (!jQuery) throw 'MathQuill requires jQuery 1.5.2+ to be loaded first';
+
+  {SOURCE}
+
+  return MathQuill;
+};

--- a/src/intro.js
+++ b/src/intro.js
@@ -8,16 +8,11 @@
  * one at http://mozilla.org/MPL/2.0/.
  */
 
-(function() {
-
-var jQuery = window.jQuery,
-  undefined,
+var undefined,
   mqCmdId = 'mathquill-command-id',
   mqBlockId = 'mathquill-block-id',
   min = Math.min,
   max = Math.max;
-
-if (!jQuery) throw 'MathQuill requires jQuery 1.5.2+ to be loaded first';
 
 function noop() {}
 

--- a/src/outro.js
+++ b/src/outro.js
@@ -9,5 +9,3 @@ for (var key in MQ1) (function(key, val) {
   }
   else MathQuill[key] = val;
 }(key, MQ1[key]));
-
-}());

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -261,13 +261,6 @@ function getInterface(v) {
   return MQ;
 }
 
-MathQuill.noConflict = function() {
-  window.MathQuill = origMathQuill;
-  return MathQuill;
-};
-var origMathQuill = window.MathQuill;
-window.MathQuill = MathQuill;
-
 function RootBlockMixin(_) {
   var names = 'moveOutOf deleteOutOf selectOutOf upOutOf downOutOf'.split(' ');
   for (var i = 0; i < names.length; i += 1) (function(name) {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -4,6 +4,8 @@
 
 var API = {}, Options = P(), optionProcessors = {}, Progenote = P(), EMBEDS = {};
 
+function globalAvailable(name) { !!this[name] }
+
 /**
  * Interface Versioning (#459, #495) to allow us to virtually guarantee
  * backcompat. v0.10.x introduces it, so for now, don't completely break the
@@ -13,7 +15,7 @@ var API = {}, Options = P(), optionProcessors = {}, Progenote = P(), EMBEDS = {}
  * be accessed.
  */
 function insistOnInterVer() {
-  if (window.console) console.warn(
+  if (globalAvailable('console')) console.warn(
     'You are using the MathQuill API without specifying an interface version, ' +
     'which will fail in v1.0.0. Easiest fix is to do the following before ' +
     'doing anything else:\n' +
@@ -36,7 +38,7 @@ MathQuill.interfaceVersion = function(v) {
   // shim for #459-era interface versioning (ended with #495)
   if (v !== 1) throw 'Only interface version 1 supported. You specified: ' + v;
   insistOnInterVer = function() {
-    if (window.console) console.warn(
+    if (globalAvailable('console')) console.warn(
       'You called MathQuill.interfaceVersion(1); to specify the interface ' +
       'version, which will fail in v1.0.0. You can fix this easily by doing ' +
       'this before doing anything else:\n' +


### PR DESCRIPTION
While alternative build processes like Rollbar [have been discussed before](https://github.com/mathquill/mathquill/issues/658#issuecomment-229399604), there doesn't seem to be a lot of public work being done toward that end, and (as issue #658 attests) the NPM package has been broken for years.

This PR represents a first attempt at a fairly small change to the build process that adds a CommonJS build, and makes the minimal changes required to allow the project to be loaded _outside_ a browser environment.  (While it may seem strange to support loading a _visual editor_ in a _non-visual environment_, this is expected to be a stepping stone towards Node-based testing and server-side LaTeX rendering.)