### PR TITLE
Unwrap the parens around the numerator when forming a fraction

### DIFF
--- a/src/commands/math/commands.js
+++ b/src/commands/math/commands.js
@@ -485,6 +485,16 @@ CharCmds['/'] = P(Fraction, function(_, super_) {
         cursor[L] = leftward;
       }
     }
+    if (this.replacedFragment) {
+      if (this.replacedFragment.ends[L] instanceof Bracket &&
+        this.replacedFragment.ends[L].sides[L].ctrlSeq == '(' &&
+        this.replacedFragment.ends[L].sides[R].ctrlSeq == ')'
+      ) {
+        var tmp = this.replacedFragment.ends[L].children().ends[L].children().disown();
+        this.replacedFragment.remove();
+        this.replacedFragment = tmp;
+      }
+    }
     super_.createLeftOf.call(this, cursor);
   };
 });


### PR DESCRIPTION
So typing (2+3)/4 would display without the parens around the numerator

This is a possible solution to #401 and #460.

I intentionally limited it to blocks wrapped in round paren brackets to avoid breaking potentially legitimate cases of a bracketed quantity in a fraction.

I'm not sure whether this should be hidden under a config flag.