### PR TITLE
Fix #794: TextBlocks dispatch reflow at the wrong time

### DIFF
--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -27,15 +27,15 @@ var TextBlock = P(Node, function(_, super_) {
     var textBlock = this;
     super_.createLeftOf.call(this, cursor);
 
-    if (textBlock[R].siblingCreated) textBlock[R].siblingCreated(cursor.options, L);
-    if (textBlock[L].siblingCreated) textBlock[L].siblingCreated(cursor.options, R);
-    textBlock.bubble('reflow');
-
     cursor.insAtRightEnd(textBlock);
 
     if (textBlock.replacedText)
       for (var i = 0; i < textBlock.replacedText.length; i += 1)
         textBlock.write(cursor, textBlock.replacedText.charAt(i));
+
+    if (textBlock[R].siblingCreated) textBlock[R].siblingCreated(cursor.options, L);
+    if (textBlock[L].siblingCreated) textBlock[L].siblingCreated(cursor.options, R);
+    textBlock.bubble('reflow');
   };
 
   _.parser = function() {
@@ -113,8 +113,9 @@ var TextBlock = P(Node, function(_, super_) {
       leftPc.adopt(leftBlock, 0, 0);
 
       cursor.insLeftOf(this);
-      super_.createLeftOf.call(leftBlock, cursor);
+      super_.createLeftOf.call(leftBlock, cursor); // micro-optimization, not for correctness
     }
+    this.bubble('reflow');
   };
 
   _.seek = function(pageX, cursor) {

--- a/test/demo.html
+++ b/test/demo.html
@@ -94,17 +94,20 @@ $('#codecogs').click(function() {
 
 $(function() {
   var latexMath = MQ($('#editable-math')[0]);
-  $(latexMath.el()).bind('keydown keypress', function() {
-    setTimeout(function() {
-      var latex = latexMath.latex();
-      latexSource.val(latex);
-//      location.hash = '#'+latex; //extremely performance-crippling in Chrome for some reason
-      htmlSource.text(printTree(latexMath.html()));
-      htmlTransplantExample.html(latexMath.html());
-    });
-  }).keydown();
+  latexMath.config({
+    handlers: {
+      edit: function() {
+        var latex = latexMath.latex();
+        latexSource.val(latex);
+//        location.hash = '#'+latex; //extremely performance-crippling in Chrome for some reason
+        htmlSource.text(printTree(latexMath.html()));
+        htmlTransplantExample.html(latexMath.html());
+      }
+    }
+  });
   latexMath.focus();
 
+  latexSource.val(latexMath.latex());
   latexSource.bind('keydown keypress', function() {
     var oldtext = latexSource.val();
     setTimeout(function() {
@@ -116,6 +119,9 @@ $(function() {
       }
     });
   });
+
+  htmlSource.text(printTree(latexMath.html()));
+  htmlTransplantExample.html(latexMath.html());
 
   if(location.hash && location.hash.length > 1)
     latexMath.latex(decodeURIComponent(location.hash.slice(1))).focus();

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1,12 +1,20 @@
 suite('typing with auto-replaces', function() {
-  var mq;
+  var mq, mostRecentlyReportedLatex;
   setup(function() {
-    mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
+    mostRecentlyReportedLatex = NaN; // != to everything
+    mq = MQ.MathField($('<span></span>').appendTo('#mock')[0], {
+      handlers: {
+        edit: function() {
+          mostRecentlyReportedLatex = mq.latex();
+        }
+      }
+    });
   });
 
   function prayWellFormedPoint(pt) { prayWellFormed(pt.parent, pt[L], pt[R]); }
   function assertLatex(latex) {
     prayWellFormedPoint(mq.__controller.cursor);
+    assert.equal(mostRecentlyReportedLatex, latex);
     assert.equal(mq.latex(), latex);
   }
 
@@ -49,6 +57,11 @@ suite('typing with auto-replaces', function() {
     });
 
     test('nonexistent LaTeX command', function() {
+      mq.typedText('\\asdf').keystroke('Enter');
+      assertLatex('\\text{asdf}');
+    });
+
+    test('nonexistent LaTeX command, then symbol', function() {
       mq.typedText('\\asdf+');
       assertLatex('\\text{asdf}+');
     });


### PR DESCRIPTION
Also fix #705, supersede and close #847

Reflow should obviously dispatch after the contents of the TextBlock is
populated, commit log doesn't show any reason it was placed before, it's
been that way since text was refactored into TextBlock:
https://github.com/mathquill/mathquill/commit/c4ba68398fc3e9e5cbb4b00c63430ea12efa6727#diff-d7064a7fc8599c06242c4c9ba3264fdbR28

Similarly after writing a character in TextBlock, should clearly
dispatch a reflow, but it hasn't from the beginning:
https://github.com/mathquill/mathquill/commit/c4ba68398fc3e9e5cbb4b00c63430ea12efa6727#diff-d7064a7fc8599c06242c4c9ba3264fdbR98

Also:
- update demo.html to use edit handlers, since we tell API clients to
- update typing and text test suites to check LaTeX-during-edit-event,
  piggybacking on current LaTeX checks

Recommend -w to view diff.