### PR TITLE
Fix pasting into text blocks

### DIFF
--- a/src/commands/math.js
+++ b/src/commands/math.js
@@ -458,6 +458,25 @@ var MathBlock = P(MathElement, function(_, super_) {
     }
   };
 
+  _.writeLatex = function(cursor, latex) {
+
+    var all = Parser.all;
+    var eof = Parser.eof;
+
+    var block = latexMathParser.skip(eof).or(all.result(false)).parse(latex);
+
+    if (block && !block.isEmpty() && block.prepareInsertionAt(cursor)) {
+      block.children().adopt(cursor.parent, cursor[L], cursor[R]);
+      var jQ = block.jQize();
+      jQ.insertBefore(cursor.jQ);
+      cursor[L] = block.ends[R];
+      block.finalizeInsert(cursor.options, cursor);
+      if (block.ends[R][R].siblingCreated) block.ends[R][R].siblingCreated(cursor.options, L);
+      if (block.ends[L][L].siblingCreated) block.ends[L][L].siblingCreated(cursor.options, R);
+      cursor.parent.bubble('reflow');
+    }
+  };
+
   _.focus = function() {
     this.jQ.addClass('mq-hasCursor');
     this.jQ.removeClass('mq-empty');

--- a/src/commands/text.js
+++ b/src/commands/text.js
@@ -117,6 +117,11 @@ var TextBlock = P(Node, function(_, super_) {
     }
     this.bubble('reflow');
   };
+  _.writeLatex = function(cursor, latex) {
+    if (!cursor[L]) TextPiece(latex).createLeftOf(cursor);
+    else cursor[L].appendText(latex);
+    this.bubble('reflow');
+  };
 
   _.seek = function(pageX, cursor) {
     cursor.hide();

--- a/src/services/latex.js
+++ b/src/services/latex.js
@@ -83,22 +83,7 @@ Controller.open(function(_, super_) {
   };
   _.writeLatex = function(latex) {
     var cursor = this.notify('edit').cursor;
-
-    var all = Parser.all;
-    var eof = Parser.eof;
-
-    var block = latexMathParser.skip(eof).or(all.result(false)).parse(latex);
-
-    if (block && !block.isEmpty() && block.prepareInsertionAt(cursor)) {
-      block.children().adopt(cursor.parent, cursor[L], cursor[R]);
-      var jQ = block.jQize();
-      jQ.insertBefore(cursor.jQ);
-      cursor[L] = block.ends[R];
-      block.finalizeInsert(cursor.options, cursor);
-      if (block.ends[R][R].siblingCreated) block.ends[R][R].siblingCreated(cursor.options, L);
-      if (block.ends[L][L].siblingCreated) block.ends[L][L].siblingCreated(cursor.options, R);
-      cursor.parent.bubble('reflow');
-    }
+    cursor.parent.writeLatex(cursor, latex);
 
     return this;
   };

--- a/test/support/assert.js
+++ b/test/support/assert.js
@@ -3,8 +3,7 @@ window.assert = (function() {
     if (!opts) opts = {};
 
     $.extend(this, opts);
-
-    if (!this.message) this.message = this.explanation;
+    this.message = this.explanation + ' ' + this.message;
 
     Error.call(this, this.message);
   }


### PR DESCRIPTION
- previously it would insert a math node into a text block, if you
  happened to paste in latex
- if you pasted in somthing that wasn't latex you would get mathquill
  source in the latex output
- Update test framework to print both the generic message like a failure
  when comparing two values as well as the cutom message priovided if
  there is one