### PR TITLE
Fix unit test page to work on CI

### DIFF
--- a/test/unit.html
+++ b/test/unit.html
@@ -24,7 +24,7 @@
 
     <!-- configure mocha and chai -->
     <script type="text/javascript">
-      var post_xunit_to = Mocha.utils.parseQuery(location.search).post_xunit_to;
+      var post_xunit_to = new URLSearchParams(location.search).get('post_xunit_to');
 
       mocha.setup({
         ui: 'tdd',


### PR DESCRIPTION
Latest Mocha on CI (v8.1.3), Mocha.utils.parseQuery() has apparently
been removed.

@jaltekruse recommends convenient new URLSearchParams:
https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/get

Unit tests are just JS, should always be run in a recent browser (on CI
we use latest Chrome), so it's fine to use a modern API.