### PR TITLE
Fix redundant focus event on paste

### DIFF
--- a/src/services/saneKeyboardEvents.util.js
+++ b/src/services/saneKeyboardEvents.util.js
@@ -233,7 +233,9 @@ var saneKeyboardEvents = (function() {
       // on keydown too, FWIW).
       //
       // And by nifty, we mean dumb (but useful sometimes).
-      textarea.focus();
+      if (document.activeElement !== textarea[0]) {
+        textarea.focus();
+      }
 
       checkTextareaFor(pastedText);
     }

--- a/test/unit/saneKeyboardEvents.test.js
+++ b/test/unit/saneKeyboardEvents.test.js
@@ -426,6 +426,27 @@ suite('saneKeyboardEvents', function() {
       // before the paste timeout happens.
       el.trigger('input');
     });
+
+    test('pasting into a focused textarea should not fire a redundant focus event', function(done) {
+      el.focus();
+
+      var focusCalled = false;
+      el.focus(function () {
+        focusCalled = true;
+      });
+
+      saneKeyboardEvents(el, {
+        paste: function () {
+          assert.ok(!focusCalled, 'Pasting into a focused mathquill should not fire a focus event');
+          done();
+        }
+      });
+
+      // Simulate a paste
+      el.trigger('paste');
+      el.val('2');
+      el.trigger('input');
+    });
   });
 
   suite('copy', function() {


### PR DESCRIPTION
Mathquill has a workaround for Linux that makes sure the appropriate element is focused on a paste event. This focus event bubbles in the usual way, so it may be observed outside mathquill.

This extra focus event started tickling a bug in the Desmos graphing calculator after upgrading from jQuery 2.x to 3.x. I suspect there may be a difference between these versions (possibly only in some browsers) in handling the case that the appropriate element already had focus.

Switch to only triggering this event if the appropriate element is not already focused to reduce the chance of triggering focus related application bugs.