### PR TITLE
Upgrade SauceConnect from 4.5.4 to 4.7.1

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -90,8 +90,8 @@ jobs:
           if [ -x sc-*-linux/bin/sc ]; then
             echo Using cached sc-*-linux/bin/sc
           else
-            time wget https://saucelabs.com/downloads/sc-4.5.4-linux.tar.gz
-            time tar -xzf sc-4.5.4-linux.tar.gz
+            time wget https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz
+            time tar -xzf sc-4.7.1-linux.tar.gz
           fi
 
           time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY \
@@ -100,8 +100,8 @@ jobs:
 
           echo 'Sauce Connect failed, try redownloading (https://git.io/vSxsJ)'
           rm -rf *
-          time wget https://saucelabs.com/downloads/sc-4.5.4-linux.tar.gz
-          time tar -xzf sc-4.5.4-linux.tar.gz
+          time wget https://saucelabs.com/downloads/sc-4.7.1-linux.tar.gz
+          time tar -xzf sc-4.7.1-linux.tar.gz
 
           time sc-*-linux/bin/sc --user $SAUCE_USERNAME --api-key $SAUCE_ACCESS_KEY \
             --readyfile ~/sauce_is_ready


### PR DESCRIPTION
Intended to fix CI failures like the one in https://github.com/mathquill/mathquill/pull/948

Error msg:
> error querying from https://saucelabs.com/rest/v1/*********/tunnels, error was: 400: Your Sauce Connect version (4.5.4) is no longer supported (must be newer than 4.5.4). Please download the latest version from https://docs.saucelabs.com/secure-connections/sauce-connect/installation (ref: 84650008). HTTP status: 400 Bad Request