### PR TITLE
Bump browser-tools version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@
 version: 2.1
 # browser-tools orb that provides installers for various browsers: https://circleci.com/developer/orbs/orb/circleci/browser-tools
 orbs:
-  browser-tools: circleci/browser-tools@1.4.0
+  browser-tools: circleci/browser-tools@1.4.6
 jobs:
   build:
     working_directory: ~/mathquill/mathquill


### PR DESCRIPTION
Current ci script is failing to download chrome driver.

browser-tools docs: https://circleci.com/developer/orbs/orb/circleci/browser-tools