### PR TITLE
Fix npm install race in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ jobs:
     # https://david263a.wordpress.com/2015/04/18/fixing-safari-cant-connect-to-localhost-issue-when-using-sauce-labs-connect-tunnel/
     # https://support.saucelabs.com/customer/portal/questions/14368823-requests-to-localhost-on-microsoft-edge-are-failing-over-sauce-connect
     - run:
-        command: PORT=8000 make server
+        command: PORT=8000 NO_INSTALL=1 make server
         background: true
     # Wait for tunnel to be ready (`make server` is much faster, no need to wait for it)
     - run: |-

--- a/Makefile
+++ b/Makefile
@@ -142,9 +142,13 @@ $(BASIC_CSS): $(CSS_SOURCES) $(NODE_MODULES_INSTALLED) $(BUILD_DIR_EXISTS)
 	perl -pi -e s/{VERSION}/v$(VERSION)/ $@
 
 $(NODE_MODULES_INSTALLED): package.json
+ifdef NO_INSTALL
+	@echo "Skipping npm install because NO_INSTALL environment variable is set."
+else
 	test -e $(NODE_MODULES_INSTALLED) || rm -rf ./node_modules/ # robust against previous botched npm install
 	NODE_ENV=development npm install
 	touch $(NODE_MODULES_INSTALLED)
+endif
 
 $(BUILD_DIR_EXISTS):
 	mkdir -p $(BUILD_DIR)


### PR DESCRIPTION
MathQuill's CI system starts a server in the background by running `make server`. Previously, this would run `npm install`, which could race later ci steps that were attempting to use node modules.

Fix this by adding a NO_INSTALL environment variable that tells the server not to automatically install npm dependencies.