### PR TITLE
Re-add basic matrix support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /build
+.DS_Store

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -96,7 +96,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
 
     var latex = (this.ends[L] as MQNode).latex();
     if (!latex) latex = ' ';
-    var cmd = LatexCmds[latex];
+    var cmd = LatexCmds[latex] || Environments[latex];
 
     if (cmd) {
       let node: MQNode;

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1540,3 +1540,361 @@ class EmbedNode extends MQSymbol {
   }
 }
 LatexCmds.embed = EmbedNode;
+
+LatexCmds.begin = class extends MathCommand {
+  parser() {
+    var string = Parser.string;
+    var regex = Parser.regex;
+    return string('{')
+      .then(regex(/^[a-z]+/i))
+      .skip(string('}'))
+      .then(function (env) {
+          return (Environments[env] ?
+            Environments[env]().parser() :
+            Parser.fail('unknown environment type: '+env)
+          ).skip(string('\\end{'+env+'}'));
+      })
+  }
+}
+
+class Environment extends MathCommand {
+  template = [['\\begin{', '}'], ['\\end{', '}']];
+  wrappers() {
+    return [
+      this.template[0].join(this.environment),
+      this.template[1].join(this.environment)
+    ];
+  }
+}
+
+class Matrix extends Environment {
+  constructor(leftParentheses,rightParentheses, environment) {
+    super();
+    this.delimiters = {
+      column: '&',
+      row: '\\\\'
+    }
+    this.parentheses = {
+      left: leftParentheses,
+      right: rightParentheses
+    }
+    this.environment = environment
+  }
+
+  latex() {
+    var self = this;
+    var latex = '';
+    var row;
+
+    self.eachChild(function (cell) {
+      if (typeof row !== 'undefined') {
+        latex += (row !== cell.row) ?
+          self.delimiters.row :
+          self.delimiters.column;
+      }
+      row = cell.row;
+      latex += cell.latex();
+    });
+
+    return this.wrappers().join(latex);
+  };
+  html() {
+    var cells = [], trs = '', i=0, row;
+
+    function parenHtml(paren, isRight) {
+      if(paren) {
+        var parenSymbol = SVG_SYMBOLS[paren];
+        return '<span style="width:' +
+                parenSymbol.width +
+                '" class="mq-paren mq-bracket-' + (isRight ? 'r' : 'l') + ' mq-scaled">' +
+                parenSymbol.html +
+                '</span>';
+      }
+      return ''
+    }
+
+    // Build <tr><td>.. structure from cells
+    this.eachChild(function (cell) {
+      if (row !== cell.row) {
+        row = cell.row;
+        trs += '<tr>$tds</tr>';
+        cells[row] = [];
+      }
+      cells[row].push('<td>&'+(i++)+'</td>');
+    });
+    const = matrixCellMargin = SVG_SYMBOLS[this.parentheses.left].width;
+    this.htmlTemplate =
+        '<span class="mq-matrix mq-non-leaf mq-bracket-container">'
+      +   parenHtml(this.parentheses.left, false)
+      +   '<table class="mq-non-leaf" style="margin-left:' + matrixCellMargin + ';margin-right:' + matrixCellMargin + '">'
+      +     trs.replace(/\$tds/g, function () {
+              return cells.shift().join('');
+            })
+      +   '</table>'
+      +   parenHtml(this.parentheses.right, true)
+      + '</span>'
+    ;
+
+    return super.html();
+  };
+  createBlocks() {
+    this.blocks = [
+      new MatrixCell(0, this),
+      new MatrixCell(0, this),
+      new MatrixCell(1, this),
+      new MatrixCell(1, this)
+    ];
+  };
+  parser() {
+    var self = this;
+    var optWhitespace = Parser.optWhitespace;
+    var string = Parser.string;
+
+    return optWhitespace
+    .then(string(self.delimiters.column)
+      .or(string(self.delimiters.row))
+      .or(latexMathParser.block))
+    .many()
+    .skip(optWhitespace)
+    .then(function(items) {
+      var blocks = [];
+      var row = 0;
+      self.blocks = [];
+
+      function addCell() {
+        self.blocks.push(new MatrixCell(row, self, blocks));
+        blocks = [];
+      }
+
+      for (var i=0; i<items.length; i+=1) {
+        if (items[i] instanceof MathBlock) {
+          blocks.push(items[i]);
+        } else {
+          addCell();
+          if (items[i] === self.delimiters.row) row+=1;
+        }
+      }
+      addCell();
+      self.autocorrect();
+      return Parser.succeed(self);
+    });
+  };
+  finalizeTree() {
+    var table = this.jQ.find('table');
+    table.toggleClass('mq-rows-1', table.find('tr').length === 1);
+    this.relink();
+  };
+  // Enter the matrix at the top or bottom row if updown is configured.
+  getEntryPoint(dir, cursor, updown) {
+    if (updown === 'up') {
+      if (dir === L) {
+        return this.blocks[this.rowSize - 1];
+      } else {
+        return this.blocks[0];
+      }
+    } else { // updown === 'down'
+      if (dir === L) {
+        return this.blocks[this.blocks.length - 1];
+      } else {
+        return this.blocks[this.blocks.length - this.rowSize];
+      }
+    }
+  };
+  // Exit the matrix at the first and last columns if updown is configured.
+  atExitPoint(dir, cursor) {
+      // Which block are we in?
+      var i = this.blocks.indexOf(cursor.parent);
+      if (dir === L) {
+        // If we're on the left edge and moving left, we should exit.
+        return i % this.rowSize === 0;
+      } else {
+        // If we're on the right edge and moving right, we should exit.
+        return (i + 1) % this.rowSize === 0;
+      }
+  };
+  moveTowards(dir, cursor, updown) {
+    var entryPoint = updown && this.getEntryPoint(dir, cursor, updown);
+    cursor.insAtDirEnd(-dir, entryPoint || this.ends[-dir]);
+  };
+
+  // Set up directional pointers between cells
+  relink() {
+    var blocks = this.blocks;
+    var rows = [];
+    var row, column, cell;
+
+    // The row size will be used by other functions down the track.
+    // Begin by assuming we're a one-row matrix, and we'll overwrite this if we find another row.
+    this.rowSize = blocks.length;
+
+    // Use a for loop rather than eachChild
+    // as we're still making sure children()
+    // is set up properly
+    for (var i=0; i<blocks.length; i+=1) {
+      cell = blocks[i];
+      if (row !== cell.row) {
+        if (cell.row === 1) {
+          // We've just finished iterating the first row.
+          this.rowSize = column;
+        }
+        row = cell.row;
+        rows[row] = [];
+        column = 0;
+      }
+      rows[row][column] = cell;
+
+      // Set up horizontal linkage
+      cell[R] = blocks[i+1];
+      cell[L] = blocks[i-1];
+
+      // Set up vertical linkage
+      if (rows[row-1] && rows[row-1][column]) {
+        cell.upOutOf = rows[row-1][column];
+        rows[row-1][column].downOutOf = cell;
+      }
+
+      column+=1;
+    }
+
+    // set start and end blocks of matrix
+    this.ends[L] = blocks[0];
+    this.ends[R] = blocks[blocks.length-1];
+  };
+  // Ensure consistent row lengths
+  autocorrect = function(rows) {
+    var lengths = [], rows = [];
+    var blocks = this.blocks;
+    var maxLength, shortfall, position, row, i;
+
+    for (i=0; i<blocks.length; i+=1) {
+      row = blocks[i].row;
+      rows[row] = rows[row] || [];
+      rows[row].push(blocks[i]);
+      lengths[row] = rows[row].length;
+    }
+
+    maxLength = Math.max.apply(null, lengths);
+    if (maxLength !== Math.min.apply(null, lengths)) {
+      // Pad shorter rows to correct length
+      for (i=0; i<rows.length; i+=1) {
+        shortfall = maxLength - rows[i].length;
+        while (shortfall) {
+          position = maxLength*i + rows[i].length;
+          blocks.splice(position, 0, new MatrixCell(i, this));
+          shortfall-=1;
+        }
+      }
+      this.relink();
+    }
+  };
+  deleteCell(currentCell) {
+    var rows = [], columns = [], myRow = [], myColumn = [];
+    var blocks = this.blocks, row, column;
+
+    // Create arrays for cells in the current row / column
+    this.eachChild(function (cell) {
+      if (row !== cell.row) {
+        row = cell.row;
+        rows[row] = [];
+        column = 0;
+      }
+      columns[column] = columns[column] || [];
+      columns[column].push(cell);
+      rows[row].push(cell);
+
+      if (cell === currentCell) {
+        myRow = rows[row];
+        myColumn = columns[column];
+      }
+
+      column+=1;
+    });
+
+    function isEmpty(cells) {
+      var empties = [];
+      for (var i=0; i<cells.length; i+=1) {
+        if (cells[i].isEmpty()) empties.push(cells[i]);
+      }
+      return empties.length === cells.length;
+    }
+
+    function remove(cells) {
+      for (var i=0; i<cells.length; i+=1) {
+        if (blocks.indexOf(cells[i]) > -1) {
+          cells[i].remove();
+          blocks.splice(blocks.indexOf(cells[i]), 1);
+        }
+      }
+    }
+
+    if (isEmpty(myRow) && myColumn.length > 1) {
+      row = rows.indexOf(myRow);
+      // Decrease all following row numbers
+      this.eachChild(function (cell) {
+        if (cell.row > row) cell.row-=1;
+      });
+      // Dispose of cells and remove <tr>
+      remove(myRow);
+      this.jQ.find('tr').eq(row).remove();
+    }
+    if (isEmpty(myColumn) && myRow.length > 1) {
+      remove(myColumn);
+    }
+    this.finalizeTree();
+  };
+  backspace(cell, dir, cursor, finalDeleteCallback) {
+    var dirwards = cell[dir];
+    if (cell.isEmpty()) {
+      this.deleteCell(cell);
+      while (dirwards &&
+        dirwards[dir] &&
+        this.blocks.indexOf(dirwards) === -1) {
+          dirwards = dirwards[dir];
+      }
+      if (dirwards) {
+        cursor.insAtDirEnd(-dir, dirwards);
+      }
+      if (this.blocks.length === 1 && this.blocks[0].isEmpty()) {
+        finalDeleteCallback();
+        this.finalizeTree();
+      }
+      this.bubble(function (node) {
+        node.reflow();
+        return undefined;
+      });
+    }
+  };
+}
+
+Environments.matrix = () => new Matrix("", "", "matrix");
+Environments.pmatrix = () => new Matrix("(", ")", "pmatrix");
+Environments.bmatrix = () => new Matrix("[", "]", "bmatrix");
+Environments.Bmatrix = () => new Matrix("{", "}", "Bmatrix");
+Environments.vmatrix = () => new Matrix("|", "|", "vmatrix");
+Environments.Vmatrix = () => new Matrix("&#8741;", "&#8741;", "Vmatrix");
+
+class MatrixCell extends MathBlock {
+  constructor(row, parent, replaces) {
+    super(row, parent, replaces);
+    this.row = row;
+    if (parent) {
+      this.adopt(parent, parent.ends[R], 0);
+    }
+    if (replaces) {
+      for (var i=0; i<replaces.length; i++) {
+        replaces[i].children().adopt(this, this.ends[R], 0);
+      }
+    }
+  }
+  deleteOutOf(dir, cursor) {
+    this.parent.backspace(this, dir, cursor, () => {
+      return super.deleteOutOf(dir, cursor);
+    });
+  };
+  moveOutOf(dir, cursor, updown) {
+    var atExitPoint = updown && this.parent.atExitPoint(dir, cursor);
+    // Step out of the matrix if we've moved past an edge column
+    if (!atExitPoint && this[dir]) cursor.insAtDirEnd(-dir, this[dir]);
+    else cursor.insDirOf(dir, this.parent);
+  };
+}

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1557,6 +1557,8 @@ LatexCmds.begin = class extends MathCommand {
   }
 }
 
+var Environments = {};
+
 class Environment extends MathCommand {
   template = [['\\begin{', '}'], ['\\end{', '}']];
   wrappers() {

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1622,7 +1622,7 @@ class Matrix extends Environment {
       }
       cells[row].push('<td>&'+(i++)+'</td>');
     });
-    const = matrixCellMargin = SVG_SYMBOLS[this.parentheses.left].width;
+    const = matrixCellMargin = (this.parentheses.left == "") ? 0 : SVG_SYMBOLS[this.parentheses.left].width;
     this.htmlTemplate =
         '<span class="mq-matrix mq-non-leaf mq-bracket-container">'
       +   parenHtml(this.parentheses.left, false)

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -458,4 +458,27 @@
       -ms-filter: "FlipH";
     }
   }
+  .mq-matrix {
+    vertical-align: middle;
+    margin-left: 0.1em;
+    margin-right: 0.1em;
+
+    table {
+      width: auto;
+      border-bottom: none;
+      border-spacing: 3px;
+      border-collapse: separate;
+      &.mq-rows-1 { /* better alignment when there's just one row */
+        vertical-align: middle;
+        margin-bottom: 1px;
+      }
+    }
+
+    td {
+      border: none;
+      width: auto; /* defensive resets */
+      padding: 0.1em 0.3em;
+      vertical-align: baseline;
+    }
+  }
 }

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -286,7 +286,7 @@ function getInterface(v: number) {
         cursor = ctrlr.cursor;
       if (/^\\[a-z]+$/i.test(cmd) && !cursor.isTooDeep()) {
         cmd = cmd.slice(1);
-        var klass = (LatexCmds as LatexCmdsAny)[cmd];
+        var klass = (LatexCmds as LatexCmdsAny)[cmd] || Environments[cmd];
         var node;
         if (klass) {
           if (klass.constructor) {

--- a/test/matrix.html
+++ b/test/matrix.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+
+<title>MathQuill Matrix Test</title>
+
+<link rel="stylesheet" type="text/css" href="../build/mathquill.css">
+<script type="text/javascript" src="support/jquery-1.7.2.js"></script>
+<script type="text/javascript" src="../build/mathquill.js"></script>
+</head>
+<body>
+
+<h3>MathQuill Matrix Test</h3>
+<span id="example">
+\begin{Bmatrix}1&amp;2\\x&amp;y\end{Bmatrix}
+</span>
+
+<script>
+MathQuill = MathQuill.getInterface(1);
+instance = MathQuill.MathField(document.getElementById('example'));
+console.log(instance.latex());
+</script>
+
+</body>
+</html>

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -196,7 +196,17 @@ suite('latex', function () {
     assertParsesLatex('\\degree ');
     assertParsesLatex('\\square ');
   });
+ test('matrices', function() {
+    assertParsesLatex('\\begin{matrix}x\\end{matrix}');
+    assertParsesLatex('\\begin{pmatrix}x\\end{pmatrix}');
+    assertParsesLatex('\\begin{Bmatrix}x\\end{Bmatrix}');
+    assertParsesLatex('\\begin{vmatrix}x&y\\\\1&2\\end{vmatrix}');
+    assertParsesLatex('\\begin{bmatrix}x&y&z&123&x^2\\\\23&s&\\sin \\theta &1&x\\\\e&h&a&1&y\\end{bmatrix}');
 
+    // Adds missing cells
+    assertParsesLatex('\\begin{Vmatrix}x&y\\\\1\\end{Vmatrix}', '\\begin{Vmatrix}x&y\\\\1&\\end{Vmatrix}');
+    assertParsesLatex('\\begin{Vmatrix}x\\\\x&y\\\\x\\end{Vmatrix}', '\\begin{Vmatrix}x&\\\\x&y\\\\x&\\end{Vmatrix}');
+  });
   suite('public API', function () {
     var mq;
     setup(function () {

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -196,16 +196,24 @@ suite('latex', function () {
     assertParsesLatex('\\degree ');
     assertParsesLatex('\\square ');
   });
- test('matrices', function() {
+  test('matrices', function () {
     assertParsesLatex('\\begin{matrix}x\\end{matrix}');
     assertParsesLatex('\\begin{pmatrix}x\\end{pmatrix}');
     assertParsesLatex('\\begin{Bmatrix}x\\end{Bmatrix}');
     assertParsesLatex('\\begin{vmatrix}x&y\\\\1&2\\end{vmatrix}');
-    assertParsesLatex('\\begin{bmatrix}x&y&z&123&x^2\\\\23&s&\\sin \\theta &1&x\\\\e&h&a&1&y\\end{bmatrix}');
+    assertParsesLatex(
+      '\\begin{bmatrix}x&y&z&123&x^{2}\\\\23&s&\\theta &1&x\\\\e&h&a&1&y\\end{bmatrix}'
+    );
 
     // Adds missing cells
-    assertParsesLatex('\\begin{Vmatrix}x&y\\\\1\\end{Vmatrix}', '\\begin{Vmatrix}x&y\\\\1&\\end{Vmatrix}');
-    assertParsesLatex('\\begin{Vmatrix}x\\\\x&y\\\\x\\end{Vmatrix}', '\\begin{Vmatrix}x&\\\\x&y\\\\x&\\end{Vmatrix}');
+    assertParsesLatex(
+      '\\begin{Vmatrix}x&y\\\\1\\end{Vmatrix}',
+      '\\begin{Vmatrix}x&y\\\\1&\\end{Vmatrix}'
+    );
+    assertParsesLatex(
+      '\\begin{Vmatrix}x\\\\x&y\\\\x\\end{Vmatrix}',
+      '\\begin{Vmatrix}x&\\\\x&y\\\\x&\\end{Vmatrix}'
+    );
   });
   suite('public API', function () {
     var mq;

--- a/test/unit/typing.test.js
+++ b/test/unit/typing.test.js
@@ -1651,4 +1651,115 @@ suite('typing with auto-replaces', function () {
       assertMathspeak('0 .3 StartOverline 5 EndOverline');
     });
   });
+  suite('Matrices', function() {
+    test('add matrix via mq.write', function() {
+      mq.write('\\begin{matrix}x&y\\\\1&2\\end{matrix}');
+      assertLatex('\\begin{matrix}x&y\\\\1&2\\end{matrix}');
+    });
+
+    test('key sequence populates matrix', function() {
+      mq.write('\\begin{matrix}x&\\\\&\\end{matrix}')
+        .keystroke('Left Left').typedText('a')
+        .keystroke('Right').typedText('b')
+        .keystroke('Up').typedText('y');
+
+      assertLatex('\\begin{matrix}x&y\\\\a&b\\end{matrix}');
+    });
+
+    test('cursor keys navigate around matrix', function() {
+      mq.write('\\begin{matrix}&&\\\\&&\\\\&&\\end{matrix}');
+
+      mq.keystroke('Left Left Left').typedText('a')
+        .keystroke('Up').typedText('b')
+        .keystroke('Right').typedText('c')
+        .keystroke('Down').typedText('d');
+
+      assertLatex('\\begin{matrix}&&\\\\b&c&\\\\a&d&\\end{matrix}');
+    });
+
+    test('passes over matrices when leftRightIntoCmdGoes is set to up', function() {
+      mq.config({ leftRightIntoCmdGoes: 'up' });
+
+      // 1 2 3
+      // 4 5 6
+      // 7 8 9
+      mq.write('\\begin{matrix}1&2&3\\\\4&5&6\\\\7&8&9\\end{matrix}');
+
+      mq.keystroke('Left Left Left Left Left Left Left').typedText('a')
+        .keystroke('Right Right Right Right Right Right Right').typedText('b')
+        .keystroke('Left Left Left Left').typedText('c');
+
+      // It should've entered the top of the matrix and exited at either end, leading to
+      //   1  2c 3
+      // a 4  5  6 b
+      //   7  8  9
+      assertLatex('a\\begin{matrix}1&2c&3\\\\4&5&6\\\\7&8&9\\end{matrix}b');
+    });
+
+    test('passes under matrices when leftRightIntoCmdGoes is set to down', function() {
+      mq.config({ leftRightIntoCmdGoes: 'down' });
+
+      // 1 2 3
+      // 4 5 6
+      // 7 8 9
+      mq.write('\\begin{matrix}1&2&3\\\\4&5&6\\\\7&8&9\\end{matrix}');
+
+      mq.keystroke('Left Left Left Left Left Left Left').typedText('a')
+        .keystroke('Right Right Right Right Right Right Right').typedText('b')
+        .keystroke('Left Left Left Left').typedText('c');
+
+      // It should've entered the bottom of the matrix and exited at either end, leading to
+      //   1  2  3
+      // a 4  5  6 b
+      //   7  8c 9
+      assertLatex('a\\begin{matrix}1&2&3\\\\4&5&6\\\\7&8c&9\\end{matrix}b');
+    });
+
+    test('exits out of matrices on their edges when leftRightIntoCmdGoes is set', function() {
+      mq.config({ leftRightIntoCmdGoes: 'up' });
+
+      // 1 2 3
+      // 4 5 6
+      // 7 8 9
+      mq.write('\\begin{matrix}1&2&3\\\\4&5&6\\\\7&8&9\\end{matrix}');
+
+      mq.keystroke('Left Left Left Down').typedText('a')
+        .keystroke('Right Right Right').typedText('b')
+
+      // It should've entered the top of the matrix and exited out the side, leading to
+      // 1  2  3
+      // 4  5a 6 b
+      // 7  8  9
+      assertLatex('\\begin{matrix}1&2&3\\\\4&5a&6\\\\7&8&9\\end{matrix}b');
+    });
+
+    test('delete key removes empty matrix row/column', function() {
+      mq.write('\\begin{matrix}a&&b\\\\&c&d\\\\&e&f\\end{matrix}');
+
+      // Row is not yet deleted as there was content
+      mq.keystroke('Left Backspace Left');
+      assertLatex('\\begin{matrix}a&&b\\\\&c&d\\\\&e&\\end{matrix}');
+
+      // Row is now deleted (delete e, then row)
+      mq.keystroke('Backspace Backspace');
+      assertLatex('\\begin{matrix}a&&b\\\\&c&d\\end{matrix}');
+
+      // Column is now deleted (delete c, then column)
+      mq.keystroke('Left Left Backspace Backspace');
+      assertLatex('\\begin{matrix}a&b\\\\&d\\end{matrix}');
+    });
+
+    test('brackets are scaled immediately when height is changed', function() {
+      mq.write('\\begin{bmatrix}x\\end{bmatrix}');
+      function bracketHeight() {
+        return $(mq.el()).find('.mq-matrix .mq-paren.mq-scaled')[0].getBoundingClientRect().height;
+      }
+      var height = bracketHeight();
+      // Add a fraction to make the matrix higher
+      mq.keystroke('Left').write('\\frac{1}{2}');
+
+      assert.ok(bracketHeight() > height,
+        'matrix bracket height should be increased when height is changed');
+    });
+  });
 });

--- a/test/visual.html
+++ b/test/visual.html
@@ -291,6 +291,12 @@
                       \text{NaN}</span
                     >
                   </td>
+                  <td>
+                    <span>\sqrt{ \left ( \frac{x^2 + y^2}{2} \right ) } + \binom{n}{k} + \begin{bmatrix}x&amp;y\\1&amp;2\end{bmatrix}</span>
+                  <td>
+                    <span>\sqrt{ \left ( \frac{x^2 + y^2}{2} \right ) } + \binom{n}{k} + \begin{bmatrix}x&amp;y\\1&amp;2\end{bmatrix}</span>
+                  <td>
+                    <span>\sqrt{ \left ( \frac{x^2 + y^2}{2} \right ) } + \binom{n}{k} + \begin{bmatrix}x&amp;y\\1&amp;2\end{bmatrix}</span>
                 </tr>
               </td>
             </tr>
@@ -770,6 +776,9 @@
                                                                                                                                         <span
                                                                                                                                           >\overarc{abc}</span
                                                                                                                                         >
+                                                                                                                                        <tr>
+                                                                                                                                          <td>
+                                                                                                                                            <span class="mathquill-static-math">\begin{Vmatrix}x&amp;y\\1&amp;2\end{Vmatrix}</span><td><span>\begin{Vmatrix}x&amp;y\\1&amp;2\end{Vmatrix}</span>
                                                                                                                                         <tr>
                                                                                                                                           <td
                                                                                                                                             colspan="2"


### PR DESCRIPTION
This is a rewrite of #762, which was made obsolete by #1025.

Includes support for parsing latex environments (used by matrix).


Supported matrix environments:

- matrix
- pmatrix
- bmatrix
- Bmatrix
- vmatrix
- Vmatrix

Example latex:
```
\begin{bmatrix}x&y\1&2\end{bmatrix}
``` 