### PR TITLE
Fix typedText not terminating a latex command with space and tab characters.

### DIFF
--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -48,7 +48,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
         var cmd = (this.parent as LatexCommandInput).renderCommand(cursor);
         // TODO needs tests
         cursor.controller.aria.queue(cmd.mathspeak({ createdLeftOf: cursor }));
-        if (ch !== '\\' || !this.isEmpty()) cursor.parent.write(cursor, ch);
+        if ((ch !== '\\' || !this.isEmpty()) && ch !== ' ' && ch !== '\n' && ch !== '\t') cursor.parent.write(cursor, ch);
         else cursor.controller.aria.alert();
       }
     };


### PR DESCRIPTION
I noticed that when using typedText, it didn't perform how the [documentation](https://docs.mathquill.com/en/latest/Api_Methods/#typedtexttext) described, instead of space characters finalizing the command and placing the cursor inside the child node, it instead was finalizing the command and inserting an escaped space character.
```ts
typedText('\\sqrt ') // Fixed
typedText('\\sqrt\t') // Fixed
typedText('\\sqrt\n') // Added conditional check, but due to an earlier if statement this remains unfixed.
```

I also think that a newline character should also terminate the command input, but some earlier code explicitly catches newline characters and calls ``Controller.handle('enter')``.

Related issue: #1058 