### PR TITLE
Add matrix support

### DIFF
--- a/docs/Api_Methods.md
+++ b/docs/Api_Methods.md
@@ -200,11 +200,11 @@ mathField.matrixCmd('new','bmatrix',3,2); // inserts a 3x2 bracketed matrix at t
 ```
 
 Altering shape:
-- `.matrixCmd('insertRow')` inserts a row after the row that holds the cursor
-- `.matrixCmd('insertRow', -1)` inserts a row before the row that holds the cursor
+- `.matrixCmd('addRow')` inserts a row after the row that holds the cursor
+- `.matrixCmd('addRow', -1)` inserts a row before the row that holds the cursor
 - `.matrixCmd('deleteRow')` deletes the row that holds the cursor
-- `.matrixCmd('insertColumn')` inserts a column after the column that holds the cursor
-- `.matrixCmd('insertColumn', -1)` inserts a column before the column that holds the cursor
+- `.matrixCmd('addColumn')` inserts a column after the column that holds the cursor
+- `.matrixCmd('addColumn', -1)` inserts a column before the column that holds the cursor
 - `.matrixCmd('deleteColumn')` deletes the row that holds the cursor
 
 ## .select()

--- a/docs/Api_Methods.md
+++ b/docs/Api_Methods.md
@@ -189,6 +189,24 @@ Enter a LaTeX command at the current cursor position or with the current selecti
 mathField.cmd('\\sqrt'); // writes a square root command at the cursor position
 ```
 
+## .matrixCmd(command, ...arguments)
+
+Commands for interacting with a matrix.
+
+Add an empty matrix: `.matrixCmd('new', envtype, rows, colums)`
+
+```javascript
+mathField.matrixCmd('new','bmatrix',3,2); // inserts a 3x2 bracketed matrix at the cursor position
+```
+
+Altering shape:
+- `.matrixCmd('insertRow')` inserts a row after the row that holds the cursor
+- `.matrixCmd('insertRow', -1)` inserts a row before the row that holds the cursor
+- `.matrixCmd('deleteRow')` deletes the row that holds the cursor
+- `.matrixCmd('insertColumn')` inserts a column after the column that holds the cursor
+- `.matrixCmd('insertColumn', -1)` inserts a column before the column that holds the cursor
+- `.matrixCmd('deleteColumn')` deletes the row that holds the cursor
+
 ## .select()
 
 Selects the contents (just like [on `textarea`s](http://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-48880622) and [on `input`s](http://www.w3.org/TR/DOM-Level-2-HTML/html.html#ID-34677168)).

--- a/src/commands/math/LatexCommandInput.ts
+++ b/src/commands/math/LatexCommandInput.ts
@@ -106,7 +106,7 @@ CharCmds['\\'] = class LatexCommandInput extends MathCommand {
 
     var latex = this.getEnd(L).latex();
     if (!latex) latex = ' ';
-    var cmd = LatexCmds[latex];
+    var cmd = LatexCmds[latex] || EnvironmentCmds[latex];
 
     if (cmd) {
       let node: MQNode;

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1908,28 +1908,36 @@ class Matrix extends Environment {
             blocks.push(itemi);
           } else {
             addCell();
+            // if we're on a delimiter and (it's the first item or previous item was a column or row delimiter)
+            // then we have an empty cell
             if (
-              (itemi === self.delimiters.column &&
-                (i == 0 ||
-                  items[i - 1] === self.delimiters.column ||
-                  items[i - 1] === self.delimiters.row)) ||
-              (itemi === self.delimiters.row &&
-                i > 0 &&
-                items[i - 1] === self.delimiters.column)
+              (itemi === self.delimiters.column ||
+                itemi === self.delimiters.row) &&
+              (i == 0 ||
+                items[i - 1] === self.delimiters.column ||
+                items[i - 1] === self.delimiters.row)
             ) {
               // two in a row; empty cell
               self.blocks.push(new MatrixCell(row, self));
               cellcnt++;
             }
-            if (itemi === self.delimiters.column && i === items.length - 1) {
-              self.blocks.push(new MatrixCell(row, self));
-              cellcnt++;
-            }
+
             if (itemi === self.delimiters.row) {
               if (row == 0) {
                 self.rowSize = cellcnt;
               }
               row += 1;
+            }
+
+            // if we're on a delimiter and it's the last item
+            // then we have an empty cell.  This would happen after the new row increment above
+            if (
+              (itemi === self.delimiters.column ||
+                itemi === self.delimiters.row) &&
+              i === items.length - 1
+            ) {
+              self.blocks.push(new MatrixCell(row, self));
+              cellcnt++;
             }
           }
         }

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -21,8 +21,14 @@ var SVG_SYMBOLS = {
   '[': {
     width: '.55em',
     html: () =>
-      h('svg', { preserveAspectRatio: 'none', viewBox: '0 0 11 24' }, [
-        h('path', { d: 'M8 0 L3 0 L3 24 L8 24 L8 23 L4 23 L4 1 L8 1' }),
+      h('svg', { preserveAspectRatio: 'none', viewBox: '0 0 100 100' }, [
+        h('path', {
+          'vector-effect': 'non-scaling-stroke',
+          'stroke-width': 1.4,
+          stroke: 'black',
+          fill: 'none',
+          d: 'M70 1.5 L30 1.5 L30 98.5 L70 98.5',
+        }),
       ]),
   },
   ']': {
@@ -35,9 +41,13 @@ var SVG_SYMBOLS = {
   '(': {
     width: '.55em',
     html: () =>
-      h('svg', { preserveAspectRatio: 'none', viewBox: '3 0 106 186' }, [
+      h('svg', { preserveAspectRatio: 'none', viewBox: '0 0 100 100' }, [
         h('path', {
-          d: 'M85 0 A61 101 0 0 0 85 186 L75 186 A75 101 0 0 1 75 0',
+          'vector-effect': 'non-scaling-stroke',
+          'stroke-width': 1.4,
+          stroke: 'black',
+          fill: 'none',
+          d: 'M30 1.5 L70 1.5 L70 98.5 L30 98.5',
         }),
       ]),
   },
@@ -1695,3 +1705,624 @@ class EmbedNode extends MQSymbol {
   }
 }
 LatexCmds.embed = EmbedNode;
+
+var EnvironmentCmds: EnvironmentCmds = {};
+
+LatexCmds.begin = class extends MathCommand {
+  parser() {
+    var string = Parser.string;
+    var regex = Parser.regex;
+    return string('{')
+      .then(regex(/^[a-z]+/i))
+      .skip(string('}'))
+      .then(function (env) {
+        return (
+          EnvironmentCmds[env]
+            ? EnvironmentCmds[env]().parser()
+            : Parser.fail('unknown environment type: ' + env)
+        ).skip(string('\\end{' + env + '}'));
+      });
+  }
+};
+
+class Environment extends MathCommand {
+  environment = '';
+  template = [
+    ['\\begin{', '}'],
+    ['\\end{', '}'],
+  ];
+  wrappers() {
+    return [
+      this.template[0].join(this.environment),
+      this.template[1].join(this.environment),
+    ];
+  }
+}
+
+class Matrix extends Environment {
+  delimiters = {
+    column: '&',
+    row: '\\\\',
+  };
+  parentheses = { left: '[', right: ']' };
+  blocks: MatrixCell[] = [];
+  rowSize: number = 0;
+
+  constructor(
+    leftParentheses: string,
+    rightParentheses: string,
+    environment: string
+  ) {
+    super();
+    this.parentheses = {
+      left: leftParentheses,
+      right: rightParentheses,
+    };
+    this.environment = environment;
+  }
+
+  latex() {
+    var self = this;
+    var latex = '';
+
+    var row = -1;
+    var wrappers = this.wrappers();
+
+    latex += wrappers[0];
+
+    this.blocks.forEach(function (cell) {
+      if (row > -1) {
+        latex +=
+          row !== cell.row ? self.delimiters.row : self.delimiters.column;
+      }
+      row = cell.row;
+      if (cell.isEmpty()) {
+        // ctx.uncleanedLatex += '{}';
+      } else {
+        latex += cell.latex();
+      }
+    });
+
+    latex += wrappers[1];
+    return latex;
+  }
+  html() {
+    var cells: MatrixCell[] = [],
+      row: number = -1;
+
+    var leftch = this.parentheses.left as keyof typeof SVG_SYMBOLS;
+    var leftBracketSymbol = SVG_SYMBOLS[leftch] || { width: '0' };
+    var rightch = this.parentheses.right as keyof typeof SVG_SYMBOLS;
+    var rightBracketSymbol = SVG_SYMBOLS[rightch] || { width: '0' };
+    this.domView = new DOMView(cells.length, (blocks) => {
+      var rows: HTMLElement[] = [];
+      var tds: HTMLElement[] = [];
+
+      blocks.forEach(function (cell) {
+        if (cell instanceof MatrixCell) {
+          if (row !== cell.row && tds.length > 0) {
+            rows.push(h('tr', {}, tds));
+            tds.length = 0;
+          }
+          row = cell.row;
+          tds.push(h.block('td', {}, cell));
+        }
+      });
+      if (tds.length > 0) {
+        rows.push(h('tr', {}, tds));
+      }
+
+      var matrixhtml: HTMLElement[] = [];
+      if (leftBracketSymbol.width !== '0') {
+        matrixhtml.push(
+          h(
+            'span',
+            {
+              style: 'width:' + leftBracketSymbol.width,
+              class: 'mq-paren mq-bracket-l mq-scaled',
+            },
+            [leftBracketSymbol.html()]
+          )
+        );
+      }
+      matrixhtml.push(
+        h(
+          'table',
+          {
+            class: 'mq-non-left',
+            style:
+              'margin-left:' +
+              leftBracketSymbol.width +
+              '; margin-right:' +
+              rightBracketSymbol.width,
+          },
+          rows
+        )
+      );
+      if (rightBracketSymbol.width !== '0') {
+        matrixhtml.push(
+          h(
+            'span',
+            {
+              style: 'width:' + rightBracketSymbol.width,
+              class: 'mq-paren mq-bracket-r mq-scaled',
+            },
+            [rightBracketSymbol.html()]
+          )
+        );
+      }
+      return h(
+        'span',
+        { class: 'mq-matrix mq-non-leaf mq-bracket-container' },
+        matrixhtml
+      );
+    });
+
+    return super.html();
+  }
+  createBlocks() {
+    this.blocks = [
+      new MatrixCell(0, this),
+      new MatrixCell(0, this),
+      new MatrixCell(1, this),
+      new MatrixCell(1, this),
+    ];
+  }
+  parser() {
+    var self = this;
+    var optWhitespace = Parser.optWhitespace;
+    var string = Parser.string;
+
+    return optWhitespace
+      .then(
+        string(self.delimiters.column)
+          .or(string(self.delimiters.row))
+          .or(latexMathParser.block)
+      )
+      .many()
+      .skip(optWhitespace)
+      .then(function (items) {
+        var row = 0;
+        var blocks: MathBlock[] = [];
+        var cellcnt = 0;
+
+        self.blocks.forEach(function (cell) {
+          cell.remove();
+        });
+
+        function addCell() {
+          if (blocks.length > 0) {
+            self.blocks.push(new MatrixCell(row, self, blocks));
+            cellcnt++;
+          }
+          blocks = [];
+        }
+
+        for (var i = 0; i < items.length; i += 1) {
+          let itemi = items[i];
+          if (itemi instanceof MathBlock) {
+            blocks.push(itemi);
+          } else {
+            addCell();
+            if (
+              (itemi === self.delimiters.column &&
+                (i == 0 ||
+                  items[i - 1] === self.delimiters.column ||
+                  items[i - 1] === self.delimiters.row)) ||
+              (itemi === self.delimiters.row &&
+                i > 0 &&
+                items[i - 1] === self.delimiters.column)
+            ) {
+              // two in a row; empty cell
+              self.blocks.push(new MatrixCell(row, self));
+              cellcnt++;
+            }
+            if (itemi === self.delimiters.column && i === items.length - 1) {
+              self.blocks.push(new MatrixCell(row, self));
+              cellcnt++;
+            }
+            if (itemi === self.delimiters.row) {
+              if (row == 0) {
+                self.rowSize = cellcnt;
+              }
+              row += 1;
+            }
+          }
+        }
+        addCell();
+        self.autocorrect();
+        self.finalizeTree();
+        return Parser.succeed(self);
+      });
+  }
+  finalizeTree() {
+    /*  removed for now
+    var table = this.jQ.find('table');
+    table.toggleClass('mq-rows-1', table.find('tr').length === 1);
+    */
+    this.relink();
+  }
+  // Enter the matrix at the top or bottom row if updown is configured.
+  getEntryPoint(dir: Direction, updown?: 'up' | 'down') {
+    if (updown === 'up') {
+      if (dir === L) {
+        return this.blocks[this.rowSize - 1];
+      } else {
+        return this.blocks[0];
+      }
+    } else {
+      // updown === 'down'
+      if (dir === L) {
+        return this.blocks[this.blocks.length - 1];
+      } else {
+        return this.blocks[this.blocks.length - this.rowSize];
+      }
+    }
+  }
+  // Exit the matrix at the first and last columns if updown is configured.
+  atExitPoint(dir: Direction, cursor: Cursor) {
+    // Which block are we in?
+    if (cursor.parent instanceof MatrixCell) {
+      var i = this.blocks.indexOf(cursor.parent);
+      if (dir === L) {
+        // If we're on the left edge and moving left, we should exit.
+        return i % this.rowSize === 0;
+      } else {
+        // If we're on the right edge and moving right, we should exit.
+        return (i + 1) % this.rowSize === 0;
+      }
+    } else {
+      return false;
+    }
+  }
+  moveTowards(dir: Direction, cursor: Cursor, updown?: 'up' | 'down') {
+    var entryPoint = updown && this.getEntryPoint(dir, updown);
+    cursor.insAtDirEnd(
+      -dir as Direction,
+      entryPoint || this.getEnd(-dir as Direction)
+    );
+  }
+
+  // Set up directional pointers between cells
+  relink() {
+    var blocks = this.blocks;
+    var rows: MatrixCell[][] = [];
+    var row = -1,
+      column = 0,
+      cell;
+
+    // The row size will be used by other functions down the track.
+    // Begin by assuming we're a one-row matrix, and we'll overwrite this if we find another row.
+    this.rowSize = blocks.length;
+
+    // Use a for loop rather than eachChild
+    // as we're still making sure children()
+    // is set up properly
+    for (var i = 0; i < blocks.length; i += 1) {
+      cell = blocks[i];
+      if (row !== cell.row) {
+        if (cell.row === 1) {
+          // We've just finished iterating the first row.
+          this.rowSize = column;
+        }
+        row = cell.row;
+        rows[row] = [];
+        column = 0;
+      }
+      rows[row][column] = cell;
+
+      // Set up horizontal linkage
+      cell[R] = blocks[i + 1] ?? 0;
+      cell[L] = blocks[i - 1] ?? 0;
+
+      // Set up vertical linkage
+      if (rows[row - 1] && rows[row - 1][column]) {
+        cell.upOutOf = rows[row - 1][column];
+        rows[row - 1][column].downOutOf = cell;
+      }
+
+      column += 1;
+    }
+
+    // set start and end blocks of matrix
+    this.setEnds({ [L]: blocks[0], [R]: blocks[blocks.length - 1] });
+  }
+  // Ensure consistent row lengths
+  autocorrect() {
+    var lengths = [],
+      rows: MatrixCell[][] = [];
+    var blocks: MatrixCell[] = this.blocks;
+    var maxLength, shortfall, position, row, i;
+
+    for (i = 0; i < blocks.length; i += 1) {
+      row = blocks[i].row;
+      rows[row] = rows[row] || [];
+      rows[row].push(blocks[i]);
+      lengths[row] = rows[row].length;
+    }
+
+    maxLength = Math.max.apply(null, lengths);
+    if (maxLength !== Math.min.apply(null, lengths)) {
+      // Pad shorter rows to correct length
+      for (i = 0; i < rows.length; i += 1) {
+        shortfall = maxLength - rows[i].length;
+        while (shortfall) {
+          position = maxLength * i + rows[i].length;
+          blocks.splice(position, 0, new MatrixCell(i, this));
+          shortfall -= 1;
+        }
+      }
+      this.relink();
+    }
+  }
+  deleteCell(currentCell: MatrixCell) {
+    var rows: MatrixCell[][] = [],
+      columns: MatrixCell[][] = [],
+      myRow: MatrixCell[] = [],
+      myColumn: MatrixCell[] = [];
+    var blocks = this.blocks,
+      row = -1,
+      column = 0;
+
+    // Create arrays for cells in the current row / column
+    blocks.forEach(function (cell) {
+      if (row !== cell.row) {
+        row = cell.row;
+        rows[row] = [];
+        column = 0;
+      }
+      columns[column] = columns[column] || [];
+      columns[column].push(cell);
+      rows[row].push(cell);
+
+      if (cell === currentCell) {
+        myRow = rows[row];
+        myColumn = columns[column];
+      }
+
+      column += 1;
+    });
+
+    function isEmpty(cells: MatrixCell[]) {
+      var empties = [];
+      for (var i = 0; i < cells.length; i += 1) {
+        if (cells[i].isEmpty()) empties.push(cells[i]);
+      }
+      return empties.length === cells.length;
+    }
+
+    function remove(cells: MatrixCell[]) {
+      for (var i = 0; i < cells.length; i += 1) {
+        if (blocks.indexOf(cells[i]) > -1) {
+          cells[i].remove();
+          blocks.splice(blocks.indexOf(cells[i]), 1);
+        }
+      }
+    }
+
+    if (isEmpty(myRow) && myColumn.length > 1) {
+      row = rows.indexOf(myRow);
+      // Decrease all following row numbers
+      blocks.forEach(function (cell) {
+        if (cell.row > row) cell.row -= 1;
+      });
+      // Dispose of cells and remove <tr>
+      remove(myRow);
+      /*  removed for now - not sure what we need to do
+        this.jQ.find('tr').eq(row).remove();
+      */
+      /* 
+        hacky fix, since tr's aren't tethered to anything
+      */
+      let tofix = this.domFrag().oneElement().querySelectorAll('tr');
+      tofix.forEach(function (el) {
+        if (!el.querySelector('td')) {
+          el.remove();
+        }
+      });
+    }
+    if (isEmpty(myColumn) && myRow.length > 1) {
+      remove(myColumn);
+    }
+    this.finalizeTree();
+  }
+  deleteColumn(basecellindex: number, cursor: Cursor) {
+    var rowSize = this.rowSize;
+    var colnum = basecellindex % rowSize;
+    var rownum = Math.floor(basecellindex / rowSize);
+
+    if (rowSize == 1) {
+      cursor.insRightOf(this);
+      this.remove();
+      return;
+    }
+
+    let curcol = colnum;
+    while (curcol < this.blocks.length) {
+      this.blocks[curcol].remove();
+      this.blocks.splice(curcol, 1);
+      curcol += rowSize - 1;
+    }
+
+    this.rowSize--;
+
+    if (colnum < this.rowSize) {
+      cursor.insAtRightEnd(this.blocks[rownum * this.rowSize + colnum]);
+    } else {
+      cursor.insAtRightEnd(this.blocks[rownum * this.rowSize + colnum - 1]);
+    }
+
+    this.finalizeTree();
+  }
+  deleteRow(basecellindex: number, cursor: Cursor) {
+    var rowSize = this.rowSize;
+    var rownum = Math.floor(basecellindex / rowSize);
+    var index = rownum * rowSize;
+
+    if (this.blocks.length == rowSize) {
+      cursor.insRightOf(this);
+      this.remove();
+      return;
+    }
+
+    for (let i = 0; i < rowSize; i++) {
+      this.blocks[index + i].remove();
+    }
+    this.blocks.splice(index, rowSize);
+
+    //hacky tr cleanup
+    let tofix = this.domFrag().oneElement().querySelectorAll('tr');
+    tofix.forEach(function (el) {
+      if (!el.querySelector('td')) {
+        el.remove();
+      }
+    });
+
+    for (let i = index; i < this.blocks.length; i++) {
+      this.blocks[i].row--;
+    }
+
+    if (basecellindex < this.blocks.length) {
+      cursor.insAtRightEnd(this.blocks[basecellindex]);
+    } else {
+      cursor.insAtRightEnd(this.blocks[basecellindex - rowSize]);
+    }
+
+    this.finalizeTree();
+  }
+  addColumn(basecellindex: number, dir?: any) {
+    var rowSize = this.rowSize;
+    var colnum = basecellindex % rowSize;
+    var row = 0;
+    var self = this;
+    if (dir !== 1 && dir !== -1) {
+      dir = 1;
+    }
+
+    while (colnum < this.blocks.length) {
+      let newcell = new MatrixCell(row, self);
+      newcell.setDOM(
+        domFrag(h('td', { class: 'mq-empty' }, []))
+          .insDirOf(dir as Direction, this.blocks[colnum].domFrag())
+          .oneElement()
+      );
+      NodeBase.linkElementByBlockNode(newcell.domFrag().oneElement(), newcell);
+      this.blocks.splice(colnum + (dir === 1 ? 1 : 0), 0, newcell);
+      colnum += rowSize + 1;
+      row++;
+    }
+
+    this.rowSize++;
+    this.finalizeTree();
+  }
+  addRow(basecellindex: number, dir?: any) {
+    var rowSize = this.rowSize;
+    var self = this;
+    if (dir !== 1 && dir !== -1) {
+      dir = 1;
+    }
+    var rownum = Math.floor(basecellindex / rowSize) + (dir === 1 ? 1 : 0);
+    var index = rownum * rowSize;
+
+    let newtr = domFrag(h('tr', {}, []));
+    if (dir === 1) {
+      newtr.insertAfter(this.blocks[index - 1].domFrag().parent());
+    } else {
+      newtr.insertBefore(this.blocks[index].domFrag().parent());
+    }
+
+    for (let i = 0; i < rowSize; i++) {
+      let newcell = new MatrixCell(rownum, self);
+      newcell.setDOM(
+        domFrag(h('td', { class: 'mq-empty' }, []))
+          .appendTo(newtr.oneElement())
+          .oneElement()
+      );
+      NodeBase.linkElementByBlockNode(newcell.domFrag().oneElement(), newcell);
+      this.blocks.splice(index, 0, newcell);
+      index++;
+    }
+    for (let i = index; i < this.blocks.length; i++) {
+      this.blocks[i].row++;
+    }
+
+    this.finalizeTree();
+  }
+  backspace(
+    cell: MatrixCell,
+    dir: Direction,
+    cursor: Cursor,
+    finalDeleteCallback: Function
+  ) {
+    var dirwards = cell[dir];
+    if (cell.isEmpty()) {
+      this.deleteCell(cell);
+      while (
+        dirwards &&
+        dirwards[dir] &&
+        this.blocks.indexOf(dirwards as MatrixCell) === -1
+      ) {
+        dirwards = dirwards[dir];
+      }
+      if (dirwards) {
+        cursor.insAtDirEnd(-dir as Direction, dirwards);
+      }
+      if (this.blocks.length === 1 && this.blocks[0].isEmpty()) {
+        finalDeleteCallback();
+        this.finalizeTree();
+      }
+      this.bubble(function (node) {
+        node.reflow();
+        return undefined;
+      });
+    }
+  }
+  remove() {
+    this.blocks.forEach(function (cell) {
+      cell.remove();
+    });
+    this.domFrag().remove();
+    return this.disown();
+  }
+}
+
+EnvironmentCmds.matrix = () => new Matrix('', '', 'matrix');
+EnvironmentCmds.pmatrix = () => new Matrix('(', ')', 'pmatrix');
+EnvironmentCmds.bmatrix = () => new Matrix('[', ']', 'bmatrix');
+EnvironmentCmds.Bmatrix = () => new Matrix('{', '}', 'Bmatrix');
+EnvironmentCmds.vmatrix = () => new Matrix('|', '|', 'vmatrix');
+EnvironmentCmds.Vmatrix = () => new Matrix('&#8741;', '&#8741;', 'Vmatrix');
+
+class MatrixCell extends MathBlock {
+  row;
+
+  constructor(row: number, parent: Matrix, replaces?: MathBlock[]) {
+    super();
+    this.row = row;
+    if (parent instanceof Matrix) {
+      this.adopt(parent, parent.getEnd(R), 0);
+    }
+    if (replaces) {
+      for (var i = 0; i < replaces.length; i++) {
+        replaces[i].children().adopt(this, this.ends[R], 0);
+      }
+    }
+  }
+  deleteOutOf(dir: Direction, cursor: Cursor) {
+    if (this.parent instanceof Matrix) {
+      this.parent.backspace(this, dir, cursor, () => {
+        return super.deleteOutOf(dir, cursor);
+      });
+    }
+  }
+  moveOutOf(dir: Direction, cursor: Cursor, updown?: 'up' | 'down') {
+    var atExitPoint =
+      updown &&
+      this.parent instanceof Matrix &&
+      this.parent.atExitPoint(dir, cursor);
+    // Step out of the matrix if we've moved past an edge column
+    if (!atExitPoint && this[dir] instanceof MQNode)
+      cursor.insAtDirEnd(-dir as Direction, this[dir] as MQNode);
+    else cursor.insDirOf(dir, this.parent);
+  }
+}

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -34,13 +34,6 @@ var SVG_SYMBOLS = {
   ']': {
     width: '.55em',
     html: () =>
-      h('svg', { preserveAspectRatio: 'none', viewBox: '0 0 11 24' }, [
-        h('path', { d: 'M3 0 L8 0 L8 24 L3 24 L3 23 L7 23 L7 1 L3 1' }),
-      ]),
-  },
-  '(': {
-    width: '.55em',
-    html: () =>
       h('svg', { preserveAspectRatio: 'none', viewBox: '0 0 100 100' }, [
         h('path', {
           'vector-effect': 'non-scaling-stroke',
@@ -48,6 +41,15 @@ var SVG_SYMBOLS = {
           stroke: 'black',
           fill: 'none',
           d: 'M30 1.5 L70 1.5 L70 98.5 L30 98.5',
+        }),
+      ]),
+  },
+  '(': {
+    width: '.55em',
+    html: () =>
+      h('svg', { preserveAspectRatio: 'none', viewBox: '3 0 106 186' }, [
+        h('path', {
+          d: 'M85 0 A61 101 0 0 0 85 186 L75 186 A75 101 0 0 1 75 0',
         }),
       ]),
   },

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -1747,6 +1747,8 @@ class Matrix extends Environment {
   parentheses = { left: '[', right: ']' };
   blocks: MatrixCell[] = [];
   rowSize: number = 0;
+  mathspeakTemplate: string[];
+  ariaLabel = 'matrix';
 
   constructor(
     leftParentheses: string,
@@ -1941,6 +1943,7 @@ class Matrix extends Environment {
     table.toggleClass('mq-rows-1', table.find('tr').length === 1);
     */
     this.relink();
+    this.updateMathspeakTemplate();
   }
   // Enter the matrix at the top or bottom row if updown is configured.
   getEntryPoint(dir: Direction, updown?: 'up' | 'down') {
@@ -2026,6 +2029,40 @@ class Matrix extends Environment {
 
     // set start and end blocks of matrix
     this.setEnds({ [L]: blocks[0], [R]: blocks[blocks.length - 1] });
+  }
+  updateMathspeakTemplate() {
+    var rowcnt = Math.floor(this.blocks.length / this.rowSize);
+    var colcnt = this.rowSize;
+
+    var newTemplate: string[] = [];
+
+    function toOrdinal(n: number) {
+      const s = ['th', 'st', 'nd', 'rd'];
+      const v = n % 100;
+      return n + (s[(v - 20) % 10] || s[v] || s[0]);
+    }
+
+    for (let i = 0; i < this.blocks.length; i++) {
+      const currow = Math.floor(i / this.rowSize) + 1;
+      const curcol = (i % this.rowSize) + 1;
+
+      var thistext = '';
+      if (curcol === 1) {
+        thistext += toOrdinal(currow) + ' Row ';
+      }
+      thistext += toOrdinal(curcol) + ' Column';
+
+      if (i == 0) {
+        newTemplate.push(
+          'Start ' + rowcnt + ' By ' + colcnt + ' Matrix ' + thistext
+        );
+      } else {
+        newTemplate.push(thistext);
+      }
+    }
+    newTemplate.push('EndMatrix');
+
+    this.mathspeakTemplate = newTemplate;
   }
   // Ensure consistent row lengths
   autocorrect() {

--- a/src/css/math.less
+++ b/src/css/math.less
@@ -459,3 +459,34 @@
     }
   }
 }
+
+
+.mq-matrix {
+    vertical-align: middle;
+    margin-left: 0.1em;
+    margin-right: 0.1em;
+
+    table {
+      width: auto;
+      border-bottom: none;
+      border-spacing: 3px;
+      border-bottom: 2px;
+      border-collapse: separate;
+      &.mq-rows-1 { /* better alignment when there's just one row */
+        vertical-align: middle;
+        margin-bottom: 1px;
+      }
+    }
+
+    td {
+      border: none;
+      width: auto; /* defensive resets */
+      padding: 0.1em 0.3em;
+      vertical-align: baseline;
+    }
+    /*
+    td.mq-hasCursor {
+       todo focus indicator 
+    }
+    */
+  }

--- a/src/dom.ts
+++ b/src/dom.ts
@@ -8,7 +8,10 @@ type HTMLTagName =
   | 'big'
   | 'sup'
   | 'var'
-  | 'br';
+  | 'br'
+  | 'table'
+  | 'tr'
+  | 'td';
 type SVGTagName = 'svg' | 'path';
 
 interface CreateElementAttributes {

--- a/src/publicapi.ts
+++ b/src/publicapi.ts
@@ -384,7 +384,7 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
         cursor = ctrlr.cursor;
       if (/^\\[a-z]+$/i.test(cmd) && !cursor.isTooDeep()) {
         cmd = cmd.slice(1);
-        var klass = (LatexCmds as LatexCmdsAny)[cmd];
+        var klass = (LatexCmds as LatexCmdsAny)[cmd] || EnvironmentCmds[cmd];
         var node;
         if (klass) {
           if (klass.constructor) {
@@ -396,6 +396,65 @@ function getInterface(v: number): MathQuill.v3.API | MathQuill.v1.API {
           node.createLeftOf(cursor.show());
         } /* TODO: API needs better error reporting */ else;
       } else cursor.parent.write(cursor, cmd);
+
+      ctrlr.scrollHoriz();
+      if (ctrlr.blurred) cursor.hide().parent.blur(cursor);
+      return this;
+    }
+    matrixCmd(cmd: string, ...args: unknown[]) {
+      var ctrlr = this.__controller.notify(undefined),
+        cursor = ctrlr.cursor;
+
+      if (
+        cursor.parent instanceof MatrixCell &&
+        cursor.parent.parent instanceof Matrix
+      ) {
+        var blockindex = cursor.parent.parent.blocks.indexOf(
+          cursor.parent as MatrixCell
+        );
+        if (cmd === 'addColumn') {
+          cursor.parent.parent.addColumn(blockindex, args[0]);
+        } else if (cmd === 'addRow') {
+          cursor.parent.parent.addRow(blockindex, args[0]);
+        } else if (cmd === 'deleteColumn') {
+          cursor.parent.parent.deleteColumn(blockindex, cursor);
+        } else if (cmd === 'deleteRow') {
+          cursor.parent.parent.deleteRow(blockindex, cursor);
+        }
+        this.reflow();
+      } else if (cmd === 'new' && args.length === 3) {
+        let envtype = args[0];
+        let rows = args[1];
+        let cols = args[2];
+        if (
+          EnvironmentCmds.hasOwnProperty(envtype as PropertyKey) &&
+          typeof rows === 'number' &&
+          typeof cols === 'number'
+        ) {
+          let latex = '\\begin{' + envtype + '}';
+          let row = '';
+          for (let i = 0; i < cols - 1; i++) {
+            row += '&';
+          }
+          for (let i = 0; i < rows; i++) {
+            if (i > 0) {
+              latex += '\\\\';
+            }
+            latex += row;
+          }
+          latex += '\\end{' + envtype + '}';
+          ctrlr.writeLatex(latex);
+          this.reflow();
+          // place cursor in first cell
+          if (cursor[L] instanceof Matrix) {
+            let cursorL = cursor[L] as Matrix;
+            if (cursorL.blocks) {
+              let firstcell = cursorL.blocks[0];
+              cursor.insAtLeftEnd(firstcell);
+            }
+          }
+        }
+      }
 
       ctrlr.scrollHoriz();
       if (ctrlr.blurred) cursor.hide().parent.blur(cursor);

--- a/src/shared_types.d.ts
+++ b/src/shared_types.d.ts
@@ -71,6 +71,9 @@ type LatexCmd =
 type LatexCmds = Record<string, LatexCmd>;
 type CharCmds = Record<string, LatexCmd>;
 
+type EnvironmentCmd = MQNodeBuilderNoParam;
+type EnvironmentCmds = Record<string, EnvironmentCmd>;
+
 declare var validateAutoCommandsOption: any;
 
 type JQSelector =

--- a/test/matrix.html
+++ b/test/matrix.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=624" />
+
+    <title>MathQuill Matrix Demo</title>
+
+    <link rel="stylesheet" type="text/css" href="support/home.css" />
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="../build/mathquill-basic.css"
+    />
+  </head>
+  <body>
+    <div id="body">
+      <h1>
+        <a href="http://mathquill.github.com">MathQuill</a> Matrix Demo
+        <small>local test page</small>
+      </h1>
+
+      <p>
+        <span id="basic"
+          >\begin{bmatrix}123&amp;2&amp;3+x\\4&amp;5&amp;6\end{bmatrix}</span
+        >
+      </p>
+
+      <p><textarea id="basic-latex" style="width: 100%" rows="7"></textarea></p>
+
+      <p>
+        <button onclick="mq.matrixCmd('new','bmatrix',3,4)">Add new 3x4</button>
+        <button onclick="mq.matrixCmd('addColumn')">Add column after</button>
+        <button onclick="mq.matrixCmd('addColumn',-1)">
+          Add column before
+        </button>
+        <button onclick="mq.matrixCmd('deleteColumn')">Delete column</button>
+        <button onclick="mq.matrixCmd('addRow')">Add row after</button>
+        <button onclick="mq.matrixCmd('addRow',-1)">Add row before</button>
+        <button onclick="mq.matrixCmd('deleteRow')">Delete row</button>
+      </p>
+    </div>
+
+    <script type="text/javascript" src="support/jquery-1.5.2.js"></script>
+    <script type="text/javascript" src="../build/mathquill.js"></script>
+    <script type="text/javascript">
+      MQ = MathQuill.getInterface(MathQuill.getInterface.MAX);
+
+      var latex = $('#basic-latex').bind('keydown keypress', function () {
+        var prev = latex.val();
+        setTimeout(function () {
+          var now = latex.val();
+          if (now !== prev) mq.latex(now);
+        });
+      });
+      var mq = MQ.MathField($('#basic')[0], {
+        tabindex: -1,
+        charsThatBreakOutOfSupSub: '=<>',
+        restrictMismatchedBrackets: true,
+        autoCommands: 'pi theta sqrt',
+        handlers: {
+          edit: function () {
+            if (!latex.is(':focus')) latex.val(mq.latex());
+          },
+        },
+      });
+      latex.val(mq.latex());
+      mq.config({ tabindex: 0 });
+    </script>
+  </body>
+</html>

--- a/test/unit/latex.test.js
+++ b/test/unit/latex.test.js
@@ -198,6 +198,26 @@ suite('latex', function () {
     assertParsesLatex('\\square ');
   });
 
+  test('matrices', function () {
+    assertParsesLatex('\\begin{matrix}x\\end{matrix}');
+    assertParsesLatex('\\begin{pmatrix}x\\end{pmatrix}');
+    assertParsesLatex('\\begin{Bmatrix}x\\end{Bmatrix}');
+    assertParsesLatex('\\begin{vmatrix}x&y\\\\1&2\\end{vmatrix}');
+    assertParsesLatex(
+      '\\begin{bmatrix}x&y&z&123&x^{2}\\\\23&s&\\theta &1&x\\\\e&h&a&1&y\\end{bmatrix}'
+    );
+
+    // Adds missing cells
+    assertParsesLatex(
+      '\\begin{Vmatrix}x&y\\\\1\\end{Vmatrix}',
+      '\\begin{Vmatrix}x&y\\\\1&\\end{Vmatrix}'
+    );
+    assertParsesLatex(
+      '\\begin{Vmatrix}x\\\\x&y\\\\x\\end{Vmatrix}',
+      '\\begin{Vmatrix}x&\\\\x&y\\\\x&\\end{Vmatrix}'
+    );
+  });
+
   suite('public API', function () {
     var mq;
     setup(function () {

--- a/test/unit/matrix.test.js
+++ b/test/unit/matrix.test.js
@@ -1,0 +1,209 @@
+suite('matrix', function () {
+  const $ = window.test_only_jquery;
+  var mq, mostRecentlyReportedLatex;
+  setup(function () {
+    mostRecentlyReportedLatex = NaN; // != to everything
+    mq = MQ.MathField($('<span></span>').appendTo('#mock')[0], {
+      handlers: {
+        edit: function () {
+          mostRecentlyReportedLatex = mq.latex();
+        },
+      },
+    });
+  });
+
+  function prayWellFormedPoint(pt) {
+    prayWellFormed(pt.parent, pt[L], pt[R]);
+  }
+
+  function assertLatex(latex) {
+    prayWellFormedPoint(mq.__controller.cursor);
+    assert.equal(mq.latex(), latex);
+  }
+
+  suite('Matrices', function () {
+    test('add matrix via mq.write', function () {
+      mq.write('\\begin{matrix}x&y\\\\1&2\\end{matrix}');
+      assertLatex('\\begin{matrix}x&y\\\\1&2\\end{matrix}');
+    });
+
+    test('key sequence populates matrix', function () {
+      mq.write('\\begin{matrix}x&\\\\&\\end{matrix}')
+        .keystroke('Left Left')
+        .typedText('a')
+        .keystroke('Right')
+        .typedText('b')
+        .keystroke('Up')
+        .typedText('y');
+
+      assertLatex('\\begin{matrix}x&y\\\\a&b\\end{matrix}');
+    });
+
+    test('cursor keys navigate around matrix', function () {
+      mq.write('\\begin{matrix}&&\\\\&&\\\\&&\\end{matrix}');
+
+      mq.keystroke('Left Left Left')
+        .typedText('a')
+        .keystroke('Up')
+        .typedText('b')
+        .keystroke('Right')
+        .typedText('c')
+        .keystroke('Down')
+        .typedText('d');
+
+      assertLatex('\\begin{matrix}&&\\\\b&c&\\\\a&d&\\end{matrix}');
+    });
+
+    test('passes over matrices when leftRightIntoCmdGoes is set to up', function () {
+      mq.config({ leftRightIntoCmdGoes: 'up' });
+
+      // 1 2 3
+      // 4 5 6
+      // 7 8 9
+      mq.write('\\begin{matrix}1&2&3\\\\4&5&6\\\\7&8&9\\end{matrix}');
+
+      mq.keystroke('Left Left Left Left Left Left Left')
+        .typedText('a')
+        .keystroke('Right Right Right Right Right Right Right')
+        .typedText('b')
+        .keystroke('Left Left Left Left')
+        .typedText('c');
+
+      // It should've entered the top of the matrix and exited at either end, leading to
+      //   1  2c 3
+      // a 4  5  6 b
+      //   7  8  9
+      assertLatex('a\\begin{matrix}1&2c&3\\\\4&5&6\\\\7&8&9\\end{matrix}b');
+    });
+
+    test('passes under matrices when leftRightIntoCmdGoes is set to down', function () {
+      mq.config({ leftRightIntoCmdGoes: 'down' });
+
+      // 1 2 3
+      // 4 5 6
+      // 7 8 9
+      mq.write('\\begin{matrix}1&2&3\\\\4&5&6\\\\7&8&9\\end{matrix}');
+
+      mq.keystroke('Left Left Left Left Left Left Left')
+        .typedText('a')
+        .keystroke('Right Right Right Right Right Right Right')
+        .typedText('b')
+        .keystroke('Left Left Left Left')
+        .typedText('c');
+
+      // It should've entered the bottom of the matrix and exited at either end, leading to
+      //   1  2  3
+      // a 4  5  6 b
+      //   7  8c 9
+      assertLatex('a\\begin{matrix}1&2&3\\\\4&5&6\\\\7&8c&9\\end{matrix}b');
+    });
+
+    test('exits out of matrices on their edges when leftRightIntoCmdGoes is set', function () {
+      mq.config({ leftRightIntoCmdGoes: 'up' });
+
+      // 1 2 3
+      // 4 5 6
+      // 7 8 9
+      mq.write('\\begin{matrix}1&2&3\\\\4&5&6\\\\7&8&9\\end{matrix}');
+
+      mq.keystroke('Left Left Left Down')
+        .typedText('a')
+        .keystroke('Right Right Right')
+        .typedText('b');
+
+      // It should've entered the top of the matrix and exited out the side, leading to
+      // 1  2  3
+      // 4  5a 6 b
+      // 7  8  9
+      assertLatex('\\begin{matrix}1&2&3\\\\4&5a&6\\\\7&8&9\\end{matrix}b');
+    });
+
+    test('delete key removes empty matrix row/column', function () {
+      mq.write('\\begin{matrix}a&&b\\\\&c&d\\\\&e&f\\end{matrix}');
+
+      // Row is not yet deleted as there was content
+      mq.keystroke('Left Backspace Left');
+      assertLatex('\\begin{matrix}a&&b\\\\&c&d\\\\&e&\\end{matrix}');
+
+      // Row is now deleted (delete e, then row)
+      mq.keystroke('Backspace Backspace');
+      assertLatex('\\begin{matrix}a&&b\\\\&c&d\\end{matrix}');
+
+      // Column is now deleted (delete c, then column)
+      mq.keystroke('Left Left Backspace Backspace');
+      assertLatex('\\begin{matrix}a&b\\\\&d\\end{matrix}');
+    });
+
+    test('brackets are scaled immediately when height is changed', function () {
+      mq.write('\\begin{bmatrix}x\\end{bmatrix}');
+      function bracketHeight() {
+        return $(mq.el())
+          .find('.mq-matrix .mq-paren.mq-scaled')[0]
+          .getBoundingClientRect().height;
+      }
+      var height = bracketHeight();
+      // Add a fraction to make the matrix higher
+      mq.keystroke('Left').write('\\frac{1}{2}');
+
+      assert.ok(
+        bracketHeight() > height,
+        'matrix bracket height should be increased when height is changed'
+      );
+    });
+  });
+});
+
+suite('matrix API methods', function () {
+  const $ = window.test_only_jquery;
+  var mq;
+  setup(function () {
+    mq = MQ.MathField($('<span></span>').appendTo('#mock')[0]);
+  });
+
+  test('new matrix', function () {
+    mq.matrixCmd('new', 'bmatrix', 2, 3);
+    assert.equal(mq.latex(), '\\begin{bmatrix}&&\\\\&&\\end{bmatrix}');
+  });
+  test('new column right', function () {
+    mq.latex('\\begin{bmatrix}1&2&3\\\\4&5&6\\end{bmatrix}');
+    mq.keystroke('Left'); //into righthandcolumn
+    mq.matrixCmd('addColumn');
+    assert.equal(mq.latex(), '\\begin{bmatrix}1&2&3&\\\\4&5&6&\\end{bmatrix}');
+  });
+  test('new column left', function () {
+    mq.latex('\\begin{bmatrix}1&2&3\\\\4&5&6\\end{bmatrix}');
+    mq.keystroke('Left'); //into righthandcolumn
+    mq.matrixCmd('addColumn', -1);
+    assert.equal(mq.latex(), '\\begin{bmatrix}1&2&&3\\\\4&5&&6\\end{bmatrix}');
+  });
+  test('new row after', function () {
+    mq.latex('\\begin{bmatrix}1&2&3\\\\4&5&6\\end{bmatrix}');
+    mq.keystroke('Left'); //into righthandcolumn
+    mq.matrixCmd('addRow');
+    assert.equal(
+      mq.latex(),
+      '\\begin{bmatrix}1&2&3\\\\4&5&6\\\\&&\\end{bmatrix}'
+    );
+  });
+  test('new row before', function () {
+    mq.latex('\\begin{bmatrix}1&2&3\\\\4&5&6\\end{bmatrix}');
+    mq.keystroke('Left'); //into righthandcolumn
+    mq.matrixCmd('addRow', -1);
+    assert.equal(
+      mq.latex(),
+      '\\begin{bmatrix}1&2&3\\\\&&\\\\4&5&6\\end{bmatrix}'
+    );
+  });
+  test('delete column', function () {
+    mq.latex('\\begin{bmatrix}1&2&3\\\\4&5&6\\end{bmatrix}');
+    mq.keystroke('Left'); //into righthandcolumn
+    mq.matrixCmd('deleteColumn');
+    assert.equal(mq.latex(), '\\begin{bmatrix}1&2\\\\4&5\\end{bmatrix}');
+  });
+  test('delete row', function () {
+    mq.latex('\\begin{bmatrix}1&2&3\\\\4&5&6\\end{bmatrix}');
+    mq.keystroke('Left'); //into righthandcolumn
+    mq.matrixCmd('deleteRow');
+    assert.equal(mq.latex(), '\\begin{bmatrix}1&2&3\\end{bmatrix}');
+  });
+});


### PR DESCRIPTION
Adds matrix support.  This is based on #1050 which was a rewrite of #762.

Includes support for parsing latex environments (used by matrix).

Supported matrix environments:
- matrix
- pmatrix
- bmatrix
- Bmatrix
- vmatrix
- Vmatrix

Example latex:
```
\begin{bmatrix}x&y\\1&2\\end{bmatrix}
```

This extends the previous work to also add a `matrixCmd`  API method for interacting with matrices:
- `.matrixCmd('new', 'bmatrix', 3,2)` to add an empty 3x2 matrix
- `.matrixCmd('insertRow')` inserts a row after the row that holds the cursor
- `.matrixCmd('insertRow', -1)` inserts a row before the row that holds the cursor
- `.matrixCmd('deleteRow')` deletes the row that holds the cursor
- `.matrixCmd('insertColumn')` inserts a column after the column that holds the cursor
- `.matrixCmd('insertColumn', -1)` inserts a column before the column that holds the cursor
- `.matrixCmd('deleteColumn')` deletes the row that holds the cursor

The PR also include some changes to how the bracket SVG was done, to prevent the arms of the bracket from looking disproportionately thick when the enclosed expression is very tall.