### PR TITLE
Dynamic layout for supsub, nthroot

### DIFF
--- a/src/commands/math.ts
+++ b/src/commands/math.ts
@@ -75,6 +75,14 @@ class MathElement extends MQNode {
       });
     }
   }
+  reflow() {
+    // if element reflows, and right is supsub, that needs to reflow too
+    // to recalculate layout
+    const right = this[R];
+    if (right instanceof SupSub) {
+      right.reflow();
+    }
+  }
 }
 
 class DOMView {

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -538,6 +538,52 @@ class SupSub extends MathCommand {
         'down up'.split(' ')[i] as 'up' | 'down'
       );
   }
+  reflow() {
+    const left = this[L];
+    if (left && this.blocks) {
+      const base = left.domFrag().oneElement();
+      const supsub = this.domFrag().oneElement();
+      supsub.style.verticalAlign = '0px';
+      const baseRect = base.getBoundingClientRect();
+      const supsubRect = supsub.getBoundingClientRect();
+      // Approximate x_height as 0.5 * font-size
+      const fontSize = parseFloat(getComputedStyle(base).fontSize);
+      const xHeight = fontSize * 0.5;
+      let shiftUp = 0;
+      let targetBottom = 0;
+      let targetTop = 0;
+
+      if (this.sup) {
+        const sup = this.sup.domFrag().oneElement();
+        const supRect = sup.getBoundingClientRect();
+        // Candidates for position
+        const default_bottom = baseRect.top + supRect.height / 2 + xHeight / 4; // align middle of exponent with top of base
+        const clearance_bottom = baseRect.bottom - xHeight / 4; // make sure exp bottom is a little above base bottom
+
+        // Take the min (higher on page) of these
+        targetBottom = Math.min(default_bottom, clearance_bottom);
+        shiftUp = supRect.bottom - targetBottom;
+      }
+      if (this.sub) {
+        const sub = this.sub.domFrag().oneElement();
+        const subRect = sub.getBoundingClientRect();
+        // Candidates for position
+        const default_top = baseRect.bottom - subRect.height / 2 - xHeight / 4; // align middle of sub with bottom of base
+        const clearance_top = baseRect.top + baseRect.height / 3; // make sure sub top is at least 1/3 down base
+
+        // Take the max (lower on page) of these
+        targetTop = Math.max(default_top, clearance_top);
+        if (!this.sup) {
+          shiftUp = supsubRect.top - targetTop;
+        } else {
+          // if both, use margin-top to space
+          console.log(targetBottom + ',' + targetTop);
+          sub.style.marginTop = Math.max(0, targetTop - targetBottom) + 'px';
+        }
+      }
+      supsub.style.verticalAlign = shiftUp + 'px';
+    }
+  }
 }
 
 function insLeftOfMeUnlessAtEnd(this: MQNode, cursor: Cursor) {
@@ -1025,6 +1071,22 @@ class NthRoot extends SquareRoot {
         radicandMathspeak +
         ', End Root'
       );
+    }
+  }
+  reflow() {
+    if (this.blocks) {
+      const index = this.blocks[0].domFrag().oneElement();
+      const radicand = this.blocks[1].domFrag().oneElement();
+      index.style.verticalAlign = '0px';
+      const indexRect = index.getBoundingClientRect();
+      const radicandRect = radicand.getBoundingClientRect();
+
+      // Take the min (higher on page) of these
+      const targetBottom = radicandRect.bottom - radicandRect.height / 2;
+      // Shift up by the difference between where bottom is now and where we want it
+      const shiftUp = indexRect.bottom - targetBottom;
+
+      index.style.verticalAlign = shiftUp + 'px';
     }
   }
 }

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -362,8 +362,11 @@ class SupSub extends MathCommand {
           var src = this[supsub],
             dest = thisDir[supsub];
           if (!src) continue;
-          if (!dest) thisDir.addBlock(src.disown());
-          else if (!src.isEmpty()) {
+          if (!dest) {
+            thisDir.addBlock(src.disown());
+            src.blur(cursor);
+            thisDir.reflow();
+          } else if (!src.isEmpty()) {
             // ins src children at -dir end of dest
             src
               .domFrag()
@@ -530,6 +533,7 @@ class SupSub extends MathCommand {
             cmd.domFrag().addClass('mq-sup-only').children().last().remove();
           }
           this.remove();
+          cmd.reflow();
         };
       })(
         this,

--- a/src/commands/math/commands.ts
+++ b/src/commands/math/commands.ts
@@ -578,10 +578,10 @@ class SupSub extends MathCommand {
         // Take the max (lower on page) of these
         targetTop = Math.max(default_top, clearance_top);
         if (!this.sup) {
+          sub.style.marginTop = '0px';
           shiftUp = supsubRect.top - targetTop;
         } else {
           // if both, use margin-top to space
-          console.log(targetBottom + ',' + targetTop);
           sub.style.marginTop = Math.max(0, targetTop - targetBottom) + 'px';
         }
       }

--- a/test/dynlayout.html
+++ b/test/dynlayout.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=624" />
+
+    <title>MathQuill-basic Demo</title>
+
+    <link rel="stylesheet" type="text/css" href="support/home.css" />
+    <link rel="stylesheet" type="text/css" href="../build/mathquill.css" />
+  </head>
+  <body>
+    <div id="body">
+      <a href="http://github.com/laughinghan/mathquill"
+        ><img
+          style="position: absolute; top: 0; right: 0; border: 0"
+          src="https://s3.amazonaws.com/github/ribbons/forkme_right_white_ffffff.png"
+          alt="Fork me on GitHub!"
+      /></a>
+
+      <h1>
+        <a href="http://mathquill.github.com">MathQuill</a>-basic Demo for
+        Layout
+        <small>local test page</small>
+      </h1>
+
+      <p>Testing supsub and nthroot layouts</p>
+
+      <p>
+        <span id="basic"
+          >\nthroot{3}{x^{2^{3^{2^3}}}} + \nthroot{\frac{\frac{1}{2}}{2}}{5}+
+          \nthroot{\frac{\frac{1}{2}}{2}}{\frac{\frac{1}{2}}{2}}</span
+        >
+      </p>
+      <p>
+        <span id="basic2"
+          >\left(\frac{\frac{1}{2}}{2}\right)^2 + 3^{\frac{\frac{1}{2}}{2}} +
+          \left(\frac{\frac{1}{2}}{2}\right)_2 + 3_{\frac{\frac{1}{2}}{2}} +
+          \left(\frac{\frac{1}{2}}{2}\right)_2^3 +
+          3_{\frac{\frac{5}{6}}{7}}^{\frac{\frac{1}{2}}{2}}</span
+        >
+      </p>
+    </div>
+
+    <script type="text/javascript" src="support/jquery-1.5.2.js"></script>
+    <script type="text/javascript" src="../build/mathquill-basic.js"></script>
+    <script type="text/javascript">
+      MQ = MathQuill.getInterface(MathQuill.getInterface.MAX);
+
+      var latex = $('#basic-latex').bind('keydown keypress', function () {
+        var prev = latex.val();
+        setTimeout(function () {
+          var now = latex.val();
+          if (now !== prev) mq.latex(now);
+        });
+      });
+      var mq = MQ.MathField($('#basic')[0]);
+      var mq2 = MQ.MathField($('#basic2')[0]);
+    </script>
+  </body>
+</html>

--- a/test/tsconfig.public-types-test.json
+++ b/test/tsconfig.public-types-test.json
@@ -12,6 +12,7 @@
       "target": "ES5",
       "lib": ["ES5", "ScriptHost", "DOM", "ES2015.Collection"],
       "module": "ES2015",
+      "moduleResolution": "node",
       "importHelpers": true,
       "noEmit": true,
       "pretty": true


### PR DESCRIPTION
This PR attempts to fix the layout issues raised in #1070.  The rewrite merged 2-3 years ago moved all layout to CSS.  This works great for most elements and certainly simplifies things, but results in some problematic layouts for complex expressions.  Again, see #1070 for examples.

This PR re-adds `reflow` functions for supsub and nthroot, to dynamically calculate the `vertical-align` needed to position the exponent and subscript or root index more reasonably.  I attempted to address the shortcomings of #764 by ensuring that changes to the base would trigger a reflow of the supsub.

Please let me know if any changes or additional items are needed.